### PR TITLE
[5.0] Rename enum groups to be more similar to OpenTK 4

### DIFF
--- a/src/Generator/Parsing/SpecificationData.cs
+++ b/src/Generator/Parsing/SpecificationData.cs
@@ -149,9 +149,10 @@ namespace Generator.Parsing
         GLX,
     }
 
-    /// <param name="Name">The name of the referenced enum group.</param>
+    /// <param name="OriginalName">The name of the referenced enum group (as seen in the xml files).</param>
+    /// <param name="TranslatedName">The name of the referenced enum group (as seen in OpenTK).</param>
     /// <param name="Namespace">The enum namespace that is referenced (gl, wgl, or glx).</param>
-    internal record GroupRef(string Name, GLFile Namespace);
+    internal record GroupRef(string OriginalName, string TranslatedName, GLFile Namespace);
 
     internal abstract record GLType();
 

--- a/src/Generator/Parsing/SpecificationParser.cs
+++ b/src/Generator/Parsing/SpecificationParser.cs
@@ -298,7 +298,7 @@ namespace Generator.Parsing
                 string paramName = element.Element("name")?.Value ?? throw new Exception("Missing parameter name!");
                 string mangledName = NameMangler.MangleParameterName(paramName);
 
-                BaseCSType type = ParsePType(element, currentFile, out GroupRef? groupRef);
+                BaseCSType type = ParsePType(element, currentFile, nameMangler, out GroupRef? groupRef);
                 if (groupRef != null) referencedEnumGroups.Add(groupRef);
 
                 string[] kind = element.Attribute("kind")?.Value?.Split(',') ?? Array.Empty<string>();
@@ -310,7 +310,7 @@ namespace Generator.Parsing
                 paramList.Add(new Parameter(type, kind, mangledName, paramLength));
             }
 
-            BaseCSType returnType = ParsePType(proto, currentFile, out GroupRef? returnGroup);
+            BaseCSType returnType = ParsePType(proto, currentFile, nameMangler, out GroupRef? returnGroup);
             if (returnGroup != null) referencedEnumGroups.Add(returnGroup);
             
             string functionName = nameMangler.MangleFunctionName(entryPoint);
@@ -434,24 +434,13 @@ namespace Generator.Parsing
             else throw new Exception($"Could not parse expression '{expression}'");
         }
 
-        private static BaseCSType ParsePType(XElement t, GLFile currentFile, out GroupRef? groupRef)
+        private static BaseCSType ParsePType(XElement t, GLFile currentFile, NameMangler nameMangler, out GroupRef? groupRef)
         {
             string? group = t.Attribute("group")?.Value;
             if (group != null)
-            {
-                if (group.StartsWith("gl::"))
-                    groupRef = new GroupRef(NameMangler.RemoveStart(group, "gl::"), GLFile.GL);
-                else if (group.StartsWith("wgl::"))
-                    groupRef = new GroupRef(NameMangler.RemoveStart(group, "wgl::"), GLFile.WGL);
-                else if (group.StartsWith("glx::"))
-                    groupRef = new GroupRef(NameMangler.RemoveStart(group, "glx::"), GLFile.GLX);
-                else
-                    groupRef = new GroupRef(group, currentFile);
-            }
+                groupRef = GroupRefFromString(group, currentFile, nameMangler);
             else
-            {
                 groupRef = null;
-            }
 
             string? className = t.Attribute("class")?.Value;
             HandleType? handle = className switch
@@ -479,12 +468,12 @@ namespace Generator.Parsing
 
             string? str = t.GetXmlText(element => element.Name != "name" ? element.Value : string.Empty).Trim();
 
-            BaseCSType type = ParseType(str, handle, groupRef);
+            BaseCSType type = ParseType(str, handle, groupRef, nameMangler);
             
             return type;
         }
 
-        private static BaseCSType ParseType(string type, HandleType? handle, GroupRef? group)
+        private static BaseCSType ParseType(string type, HandleType? handle, GroupRef? group, NameMangler nameMangler)
         {
             type = type.Trim();
 
@@ -502,7 +491,7 @@ namespace Generator.Parsing
                     withoutAsterisk = withoutAsterisk[0..^"const".Length];
                 }
 
-                BaseCSType? baseType = ParseType(withoutAsterisk, handle, group);
+                BaseCSType? baseType = ParseType(withoutAsterisk, handle, group, nameMangler);
 
                 return new CSPointer(baseType, @const);
             }
@@ -547,7 +536,7 @@ namespace Generator.Parsing
                         _ => throw new Exception("This should not happen!"),
                     };
 
-                    return new CSEnum(group.Name, group, baseType, @const);
+                    return new CSEnum(group.TranslatedName, group, baseType, @const);
                 }
 
                 BaseCSType csType;
@@ -555,10 +544,10 @@ namespace Generator.Parsing
                     csType = type switch
                     {
                         "void" => new CSVoid(@const),
-                        "GLenum" => new CSEnum(group?.Name ?? "All", group, CSPrimitive.Uint(@const), @const),
+                        "GLenum" => new CSEnum(group?.TranslatedName ?? "All", group, CSPrimitive.Uint(@const), @const),
                         "GLboolean" => new CSBool8(@const),
                         "GLbitfield" => group != null ?
-                                            new CSEnum(group.Name, group, CSPrimitive.Uint(@const), @const) :
+                                            new CSEnum(group.TranslatedName, group, CSPrimitive.Uint(@const), @const) :
                                             CSPrimitive.Uint(@const),
                         "GLvoid" => new CSVoid(@const),
                         "GLbyte" => CSPrimitive.Sbyte(@const),
@@ -726,7 +715,7 @@ namespace Generator.Parsing
                 // - 2023-03-25 NogginBops
                 if (@namespace == "GLXStrings") continue;
 
-                GroupRef[] parentGroups = ParseGroups(enums.Attribute("group")?.Value, currentFile);
+                GroupRef[] parentGroups = ParseGroups(enums.Attribute("group")?.Value, currentFile, nameMangler);
 
                 string? vendor = enums.Attribute("vendor")?.Value;
 
@@ -749,7 +738,7 @@ namespace Generator.Parsing
 
                     string? alias = @enum.Attribute("alias")?.Value;
 
-                    GroupRef[] groups = ParseGroups(@enum.Attribute("group")?.Value, currentFile);
+                    GroupRef[] groups = ParseGroups(@enum.Attribute("group")?.Value, currentFile, nameMangler);
                     // Mark this with all of the groups from the parent tag.
                     groups = ArrayUtil.MergeDeduplicate(groups, parentGroups);
 
@@ -831,7 +820,7 @@ namespace Generator.Parsing
             };
         }
 
-        internal static GroupRef[] ParseGroups(string? groups, GLFile currentFile)
+        internal static GroupRef[] ParseGroups(string? groups, GLFile currentFile, NameMangler nameMangler)
         {
             if (groups == null) return Array.Empty<GroupRef>();
 
@@ -839,20 +828,41 @@ namespace Generator.Parsing
             GroupRef[] groupRefs = new GroupRef[rawGroups.Length];
             for (int i = 0; i < rawGroups.Length; i++)
             {
-                string group = rawGroups[i];
-                if (group.StartsWith("gl::"))
-                    groupRefs[i] = new GroupRef(NameMangler.RemoveStart(group, "gl::"), GLFile.GL);
-                else if (group.StartsWith("wgl::"))
-                    groupRefs[i] = new GroupRef(NameMangler.RemoveStart(group, "wgl::"), GLFile.WGL);
-                else if (group.StartsWith("glx::"))
-                    groupRefs[i] = new GroupRef(NameMangler.RemoveStart(group, "glx::"), GLFile.GLX);
-                else
-                    groupRefs[i] = new GroupRef(group, currentFile);
+                groupRefs[i] = GroupRefFromString(rawGroups[i], currentFile, nameMangler);
             }
 
             return groupRefs;
         }
 
+        internal static GroupRef GroupRefFromString(string group, GLFile currentFile, NameMangler nameMangler)
+        {
+            string name;
+            GLFile file;
+            if (group.StartsWith("gl::"))
+            {
+                name = NameMangler.RemoveStart(group, "gl::");
+                file = GLFile.GL;
+            }
+            else if (group.StartsWith("wgl::"))
+            {
+                name = NameMangler.RemoveStart(group, "wgl::");
+                file = GLFile.WGL;
+            }
+            else if (group.StartsWith("glx::"))
+            {
+                name = NameMangler.RemoveStart(group, "glx::");
+                file = GLFile.GLX;
+            }
+            else
+            {
+                name = group;
+                file = currentFile;
+            }
+
+            string translatedName = nameMangler.TranslateEnumGroupName(name);
+
+            return new GroupRef(name, translatedName, file);
+        }
 
 
         internal static List<Feature> ParseFeatures(XElement input)

--- a/src/Generator/Process/OutputData.cs
+++ b/src/Generator/Process/OutputData.cs
@@ -176,12 +176,11 @@ namespace Generator.Writing
         }
     }
 
-    // FIXME: Maybe combine TypeName and GroupRef.
-    internal record CSEnum(string TypeName, GroupRef? GroupRef, CSPrimitive PrimitiveType, bool Constant) : BaseCSType, IConstantCSType
+    internal record CSEnum(string TranslatedTypeName, GroupRef? GroupRef, CSPrimitive PrimitiveType, bool Constant) : BaseCSType, IConstantCSType
     {
         internal override string ToCSString()
         {
-            return TypeName;
+            return TranslatedTypeName;
         }
     }
 

--- a/src/Generator/Program.cs
+++ b/src/Generator/Program.cs
@@ -32,6 +32,7 @@ namespace Generator
                         {
                             { "BufferTargetARB", "BufferTarget" },
                             { "BufferAccessARB", "BufferAccess" },
+                            { "BufferUsageARB", "BufferUsage" },
                             { "BufferPNameARB", "BufferPName" },
                             { "ProgramPropertyARB", "ProgramProperty" },
                             { "BlendEquationModeEXT", "BlendEquationMode" },

--- a/src/Generator/Program.cs
+++ b/src/Generator/Program.cs
@@ -28,6 +28,14 @@ namespace Generator
                         FunctionPrefix = "gl",
                         EnumPrefixes = new List<string> { "GL_" },
                         ExtensionPrefix = "GL_",
+                        EnumGroupNameTranslationTable =
+                        {
+                            { "BufferTargetARB", "BufferTarget" },
+                            { "BufferAccessARB", "BufferAccess" },
+                            { "BufferPNameARB", "BufferPName" },
+                            { "ProgramPropertyARB", "ProgramProperty" },
+                            { "BlendEquationModeEXT", "BlendEquationMode" },
+                        }
                     };
 
                     // Reading the gl.xml file and parsing it into data structures.

--- a/src/Generator/Utility/NameMangler.cs
+++ b/src/Generator/Utility/NameMangler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Net.Http.Headers;
 using System.Text;
 
@@ -12,6 +13,8 @@ namespace Generator.Utility
         internal HashSet<string> FunctionsWithoutPrefix { get; init; }
         internal HashSet<string> EnumsWithoutPrefix { get; init; }
 
+        internal Dictionary<string, string> EnumGroupNameTranslationTable { get; init; }
+
         internal NameManglerSettings()
         {
             ExtensionPrefix = "GL_";
@@ -19,6 +22,7 @@ namespace Generator.Utility
             EnumPrefixes = new List<string> { "GL_" };
             FunctionsWithoutPrefix = new HashSet<string>();
             EnumsWithoutPrefix = new HashSet<string>();
+            EnumGroupNameTranslationTable = new Dictionary<string, string>();
         }
     }
 
@@ -159,9 +163,20 @@ namespace Generator.Utility
             return RemoveFunctionPrefix(name);
         }
 
+        internal string TranslateEnumGroupName(string name)
+        {
+            if (Settings.EnumGroupNameTranslationTable.TryGetValue(name, out string? translated))
+            {
+                return translated;
+            }
+
+            return name;
+        }
+
         internal string MangleEnumName(string name)
         {
             // Remove the "GL_" prefix.
+
             var mangledName = RemoveEnumPrefix(name);
             return MangleMemberName(mangledName);
         }

--- a/src/OpenTK.Graphics/GL.Pointers.cs
+++ b/src/OpenTK.Graphics/GL.Pointers.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:43 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/GL.Pointers.cs
+++ b/src/OpenTK.Graphics/GL.Pointers.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:49 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:43 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/GLX.Pointers.cs
+++ b/src/OpenTK.Graphics/GLX.Pointers.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:43 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/GLX.Pointers.cs
+++ b/src/OpenTK.Graphics/GLX.Pointers.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:49 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:43 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/Glx/Enums.cs
+++ b/src/OpenTK.Graphics/Glx/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.Glx

--- a/src/OpenTK.Graphics/Glx/Enums.cs
+++ b/src/OpenTK.Graphics/Glx/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:50 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.Glx

--- a/src/OpenTK.Graphics/Glx/GLX.Native.cs
+++ b/src/OpenTK.Graphics/Glx/GLX.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/Glx/GLX.Native.cs
+++ b/src/OpenTK.Graphics/Glx/GLX.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:50 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/Glx/GLX.Overloads.cs
+++ b/src/OpenTK.Graphics/Glx/GLX.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/OpenTK.Graphics/Glx/GLX.Overloads.cs
+++ b/src/OpenTK.Graphics/Glx/GLX.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:50 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGL.Compatibility
@@ -5435,7 +5435,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         AtomicCounterBuffer = 37568,
     }
     ///<summary>Used in <see cref="GL.BufferData" />, <see cref="GL.ARB.BufferDataARB" /></summary>
-    public enum BufferUsageARB : uint
+    public enum BufferUsage : uint
     {
         StreamDraw = 35040,
         StreamRead = 35041,

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:50 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGL.Compatibility
@@ -5297,7 +5297,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         Double = 5130,
     }
     ///<summary>Used in <see cref="GL.BlendEquation" />, <see cref="GL.BlendEquationi" />, <see cref="GL.BlendEquationSeparate" />, ...</summary>
-    public enum BlendEquationModeEXT : uint
+    public enum BlendEquationMode : uint
     {
         FuncAdd = 32774,
         FuncAddExt = 32774,
@@ -5354,14 +5354,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         Stencil = 6146,
     }
     ///<summary>Used in <see cref="GL.BindImageTexture" />, <see cref="GL.MapBuffer" />, <see cref="GL.MapNamedBuffer" />, ...</summary>
-    public enum BufferAccessARB : uint
+    public enum BufferAccess : uint
     {
         ReadOnly = 35000,
         WriteOnly = 35001,
         ReadWrite = 35002,
     }
     ///<summary>Used in <see cref="GL.GetBufferParameteri64v" />, <see cref="GL.GetBufferParameteriv" />, <see cref="GL.GetNamedBufferParameteri64v" />, ...</summary>
-    public enum BufferPNameARB : uint
+    public enum BufferPName : uint
     {
         BufferImmutableStorage = 33311,
         BufferStorageFlags = 33312,
@@ -5416,7 +5416,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         AtomicCounterBuffer = 37568,
     }
     ///<summary>Used in <see cref="GL.BindBuffer" />, <see cref="GL.BindBufferBase" />, <see cref="GL.BindBufferRange" />, ...</summary>
-    public enum BufferTargetARB : uint
+    public enum BufferTarget : uint
     {
         ParameterBuffer = 33006,
         ArrayBuffer = 34962,
@@ -8956,7 +8956,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         ProgramSeparable = 33368,
     }
     ///<summary>Used in <see cref="GL.GetProgramiv" />, <see cref="GL.EXT.GetNamedProgramivEXT" />, <see cref="GL.ARB.GetProgramivARB" /></summary>
-    public enum ProgramPropertyARB : uint
+    public enum ProgramProperty : uint
     {
         ComputeWorkGroupSize = 33383,
         ProgramBinaryLength = 34625,

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Manual.cs
@@ -47,12 +47,12 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         }
 
         /// <summary>
-        /// This is a convenience function that calls <see cref="GL.GetProgrami(int, ProgramPropertyARB, ref int)"/> followed by <see cref="GL.GetProgramInfoLog(int, int, ref int, out string)"/>.
+        /// This is a convenience function that calls <see cref="GL.GetProgrami(int, ProgramProperty, ref int)"/> followed by <see cref="GL.GetProgramInfoLog(int, int, ref int, out string)"/>.
         /// </summary>
         public static void GetProgramInfoLog(int program, out string info)
         {
             int length = default;
-            GL.GetProgrami(program, ProgramPropertyARB.InfoLogLength, ref length);
+            GL.GetProgrami(program, ProgramProperty.InfoLogLength, ref length);
             if (length == 0)
             {
                 info = string.Empty;

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;
@@ -346,7 +346,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
         /// <param name="usage">Specifies the expected usage pattern of the data store. The symbolic constant must be GL_STREAM_DRAW, GL_STREAM_READ, GL_STREAM_COPY, GL_STATIC_DRAW, GL_STATIC_READ, GL_STATIC_COPY, GL_DYNAMIC_DRAW, GL_DYNAMIC_READ, or GL_DYNAMIC_COPY.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferData.xhtml" /></remarks>
-        public static void BufferData(BufferTarget target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
+        public static void BufferData(BufferTarget target, nint size, void* data, BufferUsage usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_buffer_storage]</b> <b>[entry point: <c>glBufferStorage</c>]</b><br/> Creates and initializes a buffer object&apos;s immutable data    store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glBufferStorage, which must be one of the buffer binding targets in the following table: </param>
@@ -7289,7 +7289,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void BlitNamedFramebuffer(int readFramebuffer, int drawFramebuffer, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter) => GLPointers._glBlitNamedFramebuffer_fnptr(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, (uint)mask, (uint)filter);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glBufferDataARB</c>]</b><br/>  </summary>
-            public static void BufferDataARB(BufferTarget target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferDataARB_fnptr((uint)target, size, data, (uint)usage);
+            public static void BufferDataARB(BufferTarget target, nint size, void* data, BufferUsage usage) => GLPointers._glBufferDataARB_fnptr((uint)target, size, data, (uint)usage);
             
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b> <b>[entry point: <c>glBufferPageCommitmentARB</c>]</b><br/>  </summary>
             public static void BufferPageCommitmentARB(All target, IntPtr offset, nint size, bool commit) => GLPointers._glBufferPageCommitmentARB_fnptr((uint)target, offset, size, (byte)(commit ? 1 : 0));

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:49 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;
@@ -91,14 +91,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="target"> Specifies the target to which the buffer object is bound, which must be one of the buffer binding targets in the following table: </param>
         /// <param name="buffer"> Specifies the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffer.xhtml" /></remarks>
-        public static void BindBuffer(BufferTargetARB target, int buffer) => GLPointers._glBindBuffer_fnptr((uint)target, buffer);
+        public static void BindBuffer(BufferTarget target, int buffer) => GLPointers._glBindBuffer_fnptr((uint)target, buffer);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_uniform_buffer_object]</b> <b>[entry point: <c>glBindBufferBase</c>]</b><br/> Bind a buffer object to an indexed buffer target. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
         /// <param name="index"> Specify the index of the binding point within the array specified by target. </param>
         /// <param name="buffer"> The name of a buffer object to bind to the specified binding point. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferBase.xhtml" /></remarks>
-        public static void BindBufferBase(BufferTargetARB target, uint index, int buffer) => GLPointers._glBindBufferBase_fnptr((uint)target, index, buffer);
+        public static void BindBufferBase(BufferTarget target, uint index, int buffer) => GLPointers._glBindBufferBase_fnptr((uint)target, index, buffer);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_uniform_buffer_object]</b> <b>[entry point: <c>glBindBufferRange</c>]</b><br/> Bind a range within a buffer object to an indexed buffer target. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER, or GL_SHADER_STORAGE_BUFFER. </param>
@@ -107,7 +107,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="offset"> The starting offset in basic machine units into the buffer object buffer. </param>
         /// <param name="size"> The amount of data in machine units that can be read from the buffer object while used as an indexed target. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferRange.xhtml" /></remarks>
-        public static void BindBufferRange(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRange_fnptr((uint)target, index, buffer, offset, size);
+        public static void BindBufferRange(BufferTarget target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRange_fnptr((uint)target, index, buffer, offset, size);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> <b>[entry point: <c>glBindBuffersBase</c>]</b><br/> Bind one or more buffer objects to a sequence of indexed buffer targets. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -115,7 +115,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="count"> Specify the number of contiguous binding points to which to bind buffers. </param>
         /// <param name="buffers"> A pointer to an array of names of buffer objects to bind to the targets on the specified binding point, or NULL. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersBase.xhtml" /></remarks>
-        public static void BindBuffersBase(BufferTargetARB target, uint first, int count, int* buffers) => GLPointers._glBindBuffersBase_fnptr((uint)target, first, count, buffers);
+        public static void BindBuffersBase(BufferTarget target, uint first, int count, int* buffers) => GLPointers._glBindBuffersBase_fnptr((uint)target, first, count, buffers);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> <b>[entry point: <c>glBindBuffersRange</c>]</b><br/> Bind ranges of one or more buffer objects to a sequence of indexed buffer targets. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -125,7 +125,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="offsets"> A pointer to an array of offsets into the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
         /// <param name="sizes"> A pointer to an array of sizes of the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersRange.xhtml" /></remarks>
-        public static void BindBuffersRange(BufferTargetARB target, uint first, int count, int* buffers, IntPtr* offsets, nint* sizes) => GLPointers._glBindBuffersRange_fnptr((uint)target, first, count, buffers, offsets, sizes);
+        public static void BindBuffersRange(BufferTarget target, uint first, int count, int* buffers, IntPtr* offsets, nint* sizes) => GLPointers._glBindBuffersRange_fnptr((uint)target, first, count, buffers, offsets, sizes);
         
         /// <summary> <b>[requires: v3.0]</b> <b>[entry point: <c>glBindFragDataLocation</c>]</b><br/> Bind a user-defined varying out variable to a fragment shader color number. </summary>
         /// <param name="program"> The name of the program containing varying out variable whose binding to modify </param>
@@ -157,7 +157,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
         /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted stores. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTexture.xhtml" /></remarks>
-        public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._glBindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
+        public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccess access, InternalFormat format) => GLPointers._glBindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> <b>[entry point: <c>glBindImageTextures</c>]</b><br/> Bind one or more named texture images to a sequence of consecutive image units. </summary>
         /// <param name="first"> Specifies the first image unit to which a texture is to be bound. </param>
@@ -259,26 +259,26 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <summary> <b>[requires: v1.4 | GL_ARB_imaging]</b> <b>[entry point: <c>glBlendEquation</c>]</b><br/> Specify the equation used for both the RGB blend equation and the Alpha blend equation. </summary>
         /// <param name="mode"> specifies how source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml" /></remarks>
-        public static void BlendEquation(BlendEquationModeEXT mode) => GLPointers._glBlendEquation_fnptr((uint)mode);
+        public static void BlendEquation(BlendEquationMode mode) => GLPointers._glBlendEquation_fnptr((uint)mode);
         
         /// <summary> <b>[requires: v4.0]</b> <b>[entry point: <c>glBlendEquationi</c>]</b><br/> Specify the equation used for both the RGB blend equation and the Alpha blend equation. </summary>
         /// <param name="buf"> for glBlendEquationi, specifies the index of the draw buffer for which to set the blend equation. </param>
         /// <param name="mode"> specifies how source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml" /></remarks>
-        public static void BlendEquationi(uint buf, BlendEquationModeEXT mode) => GLPointers._glBlendEquationi_fnptr(buf, (uint)mode);
+        public static void BlendEquationi(uint buf, BlendEquationMode mode) => GLPointers._glBlendEquationi_fnptr(buf, (uint)mode);
         
         /// <summary> <b>[requires: v2.0]</b> <b>[entry point: <c>glBlendEquationSeparate</c>]</b><br/> Set the RGB blend equation and the alpha blend equation separately. </summary>
         /// <param name="modeRGB"> specifies the RGB blend equation, how the red, green, and blue components of the source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <param name="modeAlpha"> specifies the alpha blend equation, how the alpha component of the source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquationSeparate.xhtml" /></remarks>
-        public static void BlendEquationSeparate(BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparate_fnptr((uint)modeRGB, (uint)modeAlpha);
+        public static void BlendEquationSeparate(BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparate_fnptr((uint)modeRGB, (uint)modeAlpha);
         
         /// <summary> <b>[requires: v4.0]</b> <b>[entry point: <c>glBlendEquationSeparatei</c>]</b><br/> Set the RGB blend equation and the alpha blend equation separately. </summary>
         /// <param name="buf"> for glBlendEquationSeparatei, specifies the index of the draw buffer for which to set the blend equations. </param>
         /// <param name="modeRGB"> specifies the RGB blend equation, how the red, green, and blue components of the source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <param name="modeAlpha"> specifies the alpha blend equation, how the alpha component of the source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquationSeparate.xhtml" /></remarks>
-        public static void BlendEquationSeparatei(uint buf, BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparatei_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
+        public static void BlendEquationSeparatei(uint buf, BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparatei_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glBlendFunc</c>]</b><br/> Specify pixel arithmetic. </summary>
         /// <param name="sfactor"> Specifies how the red, green, blue, and alpha source blending factors are computed. The initial value is GL_ONE. </param>
@@ -346,7 +346,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
         /// <param name="usage">Specifies the expected usage pattern of the data store. The symbolic constant must be GL_STREAM_DRAW, GL_STREAM_READ, GL_STREAM_COPY, GL_STATIC_DRAW, GL_STATIC_READ, GL_STATIC_COPY, GL_DYNAMIC_DRAW, GL_DYNAMIC_READ, or GL_DYNAMIC_COPY.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferData.xhtml" /></remarks>
-        public static void BufferData(BufferTargetARB target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
+        public static void BufferData(BufferTarget target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_buffer_storage]</b> <b>[entry point: <c>glBufferStorage</c>]</b><br/> Creates and initializes a buffer object&apos;s immutable data    store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glBufferStorage, which must be one of the buffer binding targets in the following table: </param>
@@ -362,7 +362,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="size"> Specifies the size in bytes of the data store region being replaced. </param>
         /// <param name="data"> Specifies a pointer to the new data that will be copied into the data store. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferSubData.xhtml" /></remarks>
-        public static void BufferSubData(BufferTargetARB target, IntPtr offset, nint size, void* data) => GLPointers._glBufferSubData_fnptr((uint)target, offset, size, data);
+        public static void BufferSubData(BufferTarget target, IntPtr offset, nint size, void* data) => GLPointers._glBufferSubData_fnptr((uint)target, offset, size, data);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[removed in: v3.2]</b> <b>[entry point: <c>glCallList</c>]</b><br/> Execute a display list. </summary>
         /// <param name="list"> Specifies the integer name of the display list to be executed. </param>
@@ -446,7 +446,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="type"> The type of the data in memory addressed by data. </param>
         /// <param name="data"> The address of a memory location storing the data to be replicated into the buffer&apos;s data store. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBufferSubData.xhtml" /></remarks>
-        public static void ClearBufferSubData(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._glClearBufferSubData_fnptr((uint)target, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
+        public static void ClearBufferSubData(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._glClearBufferSubData_fnptr((uint)target, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
         
         /// <summary> <b>[requires: v3.0]</b> <b>[entry point: <c>glClearBufferuiv</c>]</b><br/> Clear individual buffers of a framebuffer. </summary>
         /// <param name="buffer"> Specify the buffer to clear. </param>
@@ -1620,7 +1620,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="offset"> Specifies the start of the buffer subrange, in basic machine units. </param>
         /// <param name="length"> Specifies the length of the buffer subrange, in basic machine units. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFlushMappedBufferRange.xhtml" /></remarks>
-        public static void FlushMappedBufferRange(BufferTargetARB target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRange_fnptr((uint)target, offset, length);
+        public static void FlushMappedBufferRange(BufferTarget target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRange_fnptr((uint)target, offset, length);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glFlushMappedNamedBufferRange</c>]</b><br/> Indicate modifications to a range of a mapped buffer. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glFlushMappedNamedBufferRange. </param>
@@ -1927,7 +1927,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="index"> Specifies the index of the particular element being queried. </param>
         /// <param name="data"> Returns the value or values of the specified parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGet.xhtml" /></remarks>
-        public static void GetBooleani_v(BufferTargetARB target, uint index, bool* data) => GLPointers._glGetBooleani_v_fnptr((uint)target, index, (byte*)data);
+        public static void GetBooleani_v(BufferTarget target, uint index, bool* data) => GLPointers._glGetBooleani_v_fnptr((uint)target, index, (byte*)data);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glGetBooleanv</c>]</b><br/> Return the value or values of a selected parameter. </summary>
         /// <param name="pname"> Specifies the parameter value to be returned for non-indexed versions of glGet. The symbolic constants in the list below are accepted. </param>
@@ -1940,21 +1940,21 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="value"> Specifies the name of the buffer object parameter to query. </param>
         /// <param name="data"> Returns the requested parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetBufferParameteri64v(BufferTargetARB target, BufferPNameARB pname, long* parameters) => GLPointers._glGetBufferParameteri64v_fnptr((uint)target, (uint)pname, parameters);
+        public static void GetBufferParameteri64v(BufferTarget target, BufferPName pname, long* parameters) => GLPointers._glGetBufferParameteri64v_fnptr((uint)target, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v1.5]</b> <b>[entry point: <c>glGetBufferParameteriv</c>]</b><br/> Return parameters of a buffer object. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glGetBufferParameteriv and glGetBufferParameteri64v. Must be one of the buffer binding targets in the following table: </param>
         /// <param name="value"> Specifies the name of the buffer object parameter to query. </param>
         /// <param name="data"> Returns the requested parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetBufferParameteriv(BufferTargetARB target, BufferPNameARB pname, int* parameters) => GLPointers._glGetBufferParameteriv_fnptr((uint)target, (uint)pname, parameters);
+        public static void GetBufferParameteriv(BufferTarget target, BufferPName pname, int* parameters) => GLPointers._glGetBufferParameteriv_fnptr((uint)target, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v1.5]</b> <b>[entry point: <c>glGetBufferPointerv</c>]</b><br/> Return the pointer to a mapped buffer object&apos;s data store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glGetBufferPointerv, which must be one of the buffer binding targets in the following table: </param>
         /// <param name="pname"> Specifies the name of the pointer to be returned. Must be GL_BUFFER_MAP_POINTER. </param>
         /// <param name="parameters"> Returns the pointer value specified by pname. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferPointerv.xhtml" /></remarks>
-        public static void GetBufferPointerv(BufferTargetARB target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointerv_fnptr((uint)target, (uint)pname, parameters);
+        public static void GetBufferPointerv(BufferTarget target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointerv_fnptr((uint)target, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v1.5]</b> <b>[entry point: <c>glGetBufferSubData</c>]</b><br/> Returns a subset of a buffer object&apos;s data store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glGetBufferSubData, which must be one of the buffer binding targets in the following table: </param>
@@ -1962,7 +1962,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="size"> Specifies the size in bytes of the data store region being returned. </param>
         /// <param name="data"> Specifies a pointer to the location where buffer object data is returned. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferSubData.xhtml" /></remarks>
-        public static void GetBufferSubData(BufferTargetARB target, IntPtr offset, nint size, void* data) => GLPointers._glGetBufferSubData_fnptr((uint)target, offset, size, data);
+        public static void GetBufferSubData(BufferTarget target, IntPtr offset, nint size, void* data) => GLPointers._glGetBufferSubData_fnptr((uint)target, offset, size, data);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[removed in: v3.2]</b> <b>[entry point: <c>glGetClipPlane</c>]</b><br/> Return the coefficients of the specified clipping plane. </summary>
         /// <param name="plane"> Specifies a clipping plane. The number of clipping planes depends on the implementation, but at least six clipping planes are supported. They are identified by symbolic names of the form GL_CLIP_PLANE i where i ranges from 0 to the value of GL_MAX_CLIP_PLANES - 1. </param>
@@ -2177,14 +2177,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname">!!missing documentation!!</param>
         /// <param name="parameters">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetNamedBufferParameteri64v(int buffer, BufferPNameARB pname, long* parameters) => GLPointers._glGetNamedBufferParameteri64v_fnptr(buffer, (uint)pname, parameters);
+        public static void GetNamedBufferParameteri64v(int buffer, BufferPName pname, long* parameters) => GLPointers._glGetNamedBufferParameteri64v_fnptr(buffer, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glGetNamedBufferParameteriv</c>]</b><br/> Return parameters of a buffer object. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferParameteriv and glGetNamedBufferParameteri64v. </param>
         /// <param name="pname">!!missing documentation!!</param>
         /// <param name="parameters">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetNamedBufferParameteriv(int buffer, BufferPNameARB pname, int* parameters) => GLPointers._glGetNamedBufferParameteriv_fnptr(buffer, (uint)pname, parameters);
+        public static void GetNamedBufferParameteriv(int buffer, BufferPName pname, int* parameters) => GLPointers._glGetNamedBufferParameteriv_fnptr(buffer, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glGetNamedBufferPointerv</c>]</b><br/> Return the pointer to a mapped buffer object&apos;s data store. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferPointerv. </param>
@@ -2385,7 +2385,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="pname">Specifies the object parameter. Accepted symbolic names are GL_DELETE_STATUS, GL_LINK_STATUS, GL_VALIDATE_STATUS, GL_INFO_LOG_LENGTH, GL_ATTACHED_SHADERS, GL_ACTIVE_ATOMIC_COUNTER_BUFFERS, GL_ACTIVE_ATTRIBUTES, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, GL_ACTIVE_UNIFORMS, GL_ACTIVE_UNIFORM_BLOCKS, GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH, GL_ACTIVE_UNIFORM_MAX_LENGTH, GL_COMPUTE_WORK_GROUP_SIZE GL_PROGRAM_BINARY_LENGTH, GL_TRANSFORM_FEEDBACK_BUFFER_MODE, GL_TRANSFORM_FEEDBACK_VARYINGS, GL_TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH, GL_GEOMETRY_VERTICES_OUT, GL_GEOMETRY_INPUT_TYPE, and GL_GEOMETRY_OUTPUT_TYPE.</param>
         /// <param name="parameters">Returns the requested object parameter.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgram.xhtml" /></remarks>
-        public static void GetProgramiv(int program, ProgramPropertyARB pname, int* parameters) => GLPointers._glGetProgramiv_fnptr(program, (uint)pname, parameters);
+        public static void GetProgramiv(int program, ProgramProperty pname, int* parameters) => GLPointers._glGetProgramiv_fnptr(program, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> <b>[entry point: <c>glGetProgramPipelineInfoLog</c>]</b><br/> Retrieve the info log string from a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies the name of a program pipeline object from which to retrieve the info log. </param>
@@ -3303,7 +3303,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="target"> Specifies the target to which the buffer object is bound for glMapBuffer, which must be one of the buffer binding targets in the following table: </param>
         /// <param name="access"> Specifies the access policy for glMapBuffer and glMapNamedBuffer, indicating whether it will be possible to read from, write to, or both read from and write to the buffer object&apos;s mapped data store. The symbolic constant must be GL_READ_ONLY, GL_WRITE_ONLY, or GL_READ_WRITE. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBuffer.xhtml" /></remarks>
-        public static void* MapBuffer(BufferTargetARB target, BufferAccessARB access) => GLPointers._glMapBuffer_fnptr((uint)target, (uint)access);
+        public static void* MapBuffer(BufferTarget target, BufferAccess access) => GLPointers._glMapBuffer_fnptr((uint)target, (uint)access);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_map_buffer_range]</b> <b>[entry point: <c>glMapBufferRange</c>]</b><br/> Map all or part of a buffer object&apos;s data store into the client&apos;s address space. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glMapBufferRange, which must be one of the buffer binding targets in the following table: </param>
@@ -3311,7 +3311,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="length"> Specifies the length of the range to be mapped. </param>
         /// <param name="access"> Specifies a combination of access flags indicating the desired access to the mapped range. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBufferRange.xhtml" /></remarks>
-        public static void* MapBufferRange(BufferTargetARB target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRange_fnptr((uint)target, offset, length, (uint)access);
+        public static void* MapBufferRange(BufferTarget target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRange_fnptr((uint)target, offset, length, (uint)access);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[removed in: v3.2]</b> <b>[entry point: <c>glMapGrid1d</c>]</b><br/> Define a one- or two-dimensional mesh. </summary>
         /// <param name="un"> Specifies the number of partitions in the grid range interval [u1, u2]. Must be positive. </param>
@@ -3351,7 +3351,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBuffer. </param>
         /// <param name="access"> Specifies the access policy for glMapBuffer and glMapNamedBuffer, indicating whether it will be possible to read from, write to, or both read from and write to the buffer object&apos;s mapped data store. The symbolic constant must be GL_READ_ONLY, GL_WRITE_ONLY, or GL_READ_WRITE. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBuffer.xhtml" /></remarks>
-        public static void* MapNamedBuffer(int buffer, BufferAccessARB access) => GLPointers._glMapNamedBuffer_fnptr(buffer, (uint)access);
+        public static void* MapNamedBuffer(int buffer, BufferAccess access) => GLPointers._glMapNamedBuffer_fnptr(buffer, (uint)access);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glMapNamedBufferRange</c>]</b><br/> Map all or part of a buffer object&apos;s data store into the client&apos;s address space. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBufferRange. </param>
@@ -5842,7 +5842,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
         /// <summary> <b>[requires: v1.5]</b> <b>[entry point: <c>glUnmapBuffer</c>]</b><br/> Release the mapping of a buffer object&apos;s data store into the client&apos;s address space. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glUnmapBuffer, which must be one of the buffer binding targets in the following table: </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUnmapBuffer.xhtml" /></remarks>
-        public static bool UnmapBuffer(BufferTargetARB target) => GLPointers._glUnmapBuffer_fnptr((uint)target) != 0;
+        public static bool UnmapBuffer(BufferTarget target) => GLPointers._glUnmapBuffer_fnptr((uint)target) != 0;
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glUnmapNamedBuffer</c>]</b><br/> Release the mapping of a buffer object&apos;s data store into the client&apos;s address space. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glUnmapNamedBuffer. </param>
@@ -6749,10 +6749,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void BeginPerfMonitorAMD(uint monitor) => GLPointers._glBeginPerfMonitorAMD_fnptr(monitor);
             
             /// <summary> <b>[requires: GL_AMD_draw_buffers_blend]</b> <b>[entry point: <c>glBlendEquationIndexedAMD</c>]</b><br/>  </summary>
-            public static void BlendEquationIndexedAMD(uint buf, BlendEquationModeEXT mode) => GLPointers._glBlendEquationIndexedAMD_fnptr(buf, (uint)mode);
+            public static void BlendEquationIndexedAMD(uint buf, BlendEquationMode mode) => GLPointers._glBlendEquationIndexedAMD_fnptr(buf, (uint)mode);
             
             /// <summary> <b>[requires: GL_AMD_draw_buffers_blend]</b> <b>[entry point: <c>glBlendEquationSeparateIndexedAMD</c>]</b><br/>  </summary>
-            public static void BlendEquationSeparateIndexedAMD(uint buf, BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparateIndexedAMD_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
+            public static void BlendEquationSeparateIndexedAMD(uint buf, BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparateIndexedAMD_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
             
             /// <summary> <b>[requires: GL_AMD_draw_buffers_blend]</b> <b>[entry point: <c>glBlendFuncIndexedAMD</c>]</b><br/>  </summary>
             public static void BlendFuncIndexedAMD(uint buf, All src, All dst) => GLPointers._glBlendFuncIndexedAMD_fnptr(buf, (uint)src, (uint)dst);
@@ -6999,7 +6999,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void FinishObjectAPPLE(ObjectTypeAPPLE obj, int name) => GLPointers._glFinishObjectAPPLE_fnptr((uint)obj, name);
             
             /// <summary> <b>[requires: GL_APPLE_flush_buffer_range]</b> <b>[entry point: <c>glFlushMappedBufferRangeAPPLE</c>]</b><br/>  </summary>
-            public static void FlushMappedBufferRangeAPPLE(BufferTargetARB target, IntPtr offset, nint size) => GLPointers._glFlushMappedBufferRangeAPPLE_fnptr((uint)target, offset, size);
+            public static void FlushMappedBufferRangeAPPLE(BufferTarget target, IntPtr offset, nint size) => GLPointers._glFlushMappedBufferRangeAPPLE_fnptr((uint)target, offset, size);
             
             /// <summary> <b>[requires: GL_APPLE_vertex_array_range]</b> <b>[entry point: <c>glFlushVertexArrayRangeAPPLE</c>]</b><br/>  </summary>
             public static void FlushVertexArrayRangeAPPLE(int length, void* pointer) => GLPointers._glFlushVertexArrayRangeAPPLE_fnptr(length, pointer);
@@ -7097,14 +7097,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void BindAttribLocationARB(GLHandleARB programObj, uint index, byte* name) => GLPointers._glBindAttribLocationARB_fnptr((IntPtr)programObj, index, name);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glBindBufferARB</c>]</b><br/>  </summary>
-            public static void BindBufferARB(BufferTargetARB target, int buffer) => GLPointers._glBindBufferARB_fnptr((uint)target, buffer);
+            public static void BindBufferARB(BufferTarget target, int buffer) => GLPointers._glBindBufferARB_fnptr((uint)target, buffer);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_uniform_buffer_object]</b> <b>[entry point: <c>glBindBufferBase</c>]</b><br/> Bind a buffer object to an indexed buffer target. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
             /// <param name="index"> Specify the index of the binding point within the array specified by target. </param>
             /// <param name="buffer"> The name of a buffer object to bind to the specified binding point. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferBase.xhtml" /></remarks>
-            public static void BindBufferBase(BufferTargetARB target, uint index, int buffer) => GLPointers._glBindBufferBase_fnptr((uint)target, index, buffer);
+            public static void BindBufferBase(BufferTarget target, uint index, int buffer) => GLPointers._glBindBufferBase_fnptr((uint)target, index, buffer);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_uniform_buffer_object]</b> <b>[entry point: <c>glBindBufferRange</c>]</b><br/> Bind a range within a buffer object to an indexed buffer target. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER, or GL_SHADER_STORAGE_BUFFER. </param>
@@ -7113,7 +7113,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="offset"> The starting offset in basic machine units into the buffer object buffer. </param>
             /// <param name="size"> The amount of data in machine units that can be read from the buffer object while used as an indexed target. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferRange.xhtml" /></remarks>
-            public static void BindBufferRange(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRange_fnptr((uint)target, index, buffer, offset, size);
+            public static void BindBufferRange(BufferTarget target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRange_fnptr((uint)target, index, buffer, offset, size);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> <b>[entry point: <c>glBindBuffersBase</c>]</b><br/> Bind one or more buffer objects to a sequence of indexed buffer targets. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -7121,7 +7121,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="count"> Specify the number of contiguous binding points to which to bind buffers. </param>
             /// <param name="buffers"> A pointer to an array of names of buffer objects to bind to the targets on the specified binding point, or NULL. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersBase.xhtml" /></remarks>
-            public static void BindBuffersBase(BufferTargetARB target, uint first, int count, int* buffers) => GLPointers._glBindBuffersBase_fnptr((uint)target, first, count, buffers);
+            public static void BindBuffersBase(BufferTarget target, uint first, int count, int* buffers) => GLPointers._glBindBuffersBase_fnptr((uint)target, first, count, buffers);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> <b>[entry point: <c>glBindBuffersRange</c>]</b><br/> Bind ranges of one or more buffer objects to a sequence of indexed buffer targets. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -7131,7 +7131,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="offsets"> A pointer to an array of offsets into the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
             /// <param name="sizes"> A pointer to an array of sizes of the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersRange.xhtml" /></remarks>
-            public static void BindBuffersRange(BufferTargetARB target, uint first, int count, int* buffers, IntPtr* offsets, nint* sizes) => GLPointers._glBindBuffersRange_fnptr((uint)target, first, count, buffers, offsets, sizes);
+            public static void BindBuffersRange(BufferTarget target, uint first, int count, int* buffers, IntPtr* offsets, nint* sizes) => GLPointers._glBindBuffersRange_fnptr((uint)target, first, count, buffers, offsets, sizes);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_blend_func_extended]</b> <b>[entry point: <c>glBindFragDataLocationIndexed</c>]</b><br/> Bind a user-defined varying out variable to a fragment shader color number and index. </summary>
             /// <param name="program"> The name of the program containing varying out variable whose binding to modify </param>
@@ -7156,7 +7156,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
             /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted stores. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTexture.xhtml" /></remarks>
-            public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._glBindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
+            public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccess access, InternalFormat format) => GLPointers._glBindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> <b>[entry point: <c>glBindImageTextures</c>]</b><br/> Bind one or more named texture images to a sequence of consecutive image units. </summary>
             /// <param name="first"> Specifies the first image unit to which a texture is to be bound. </param>
@@ -7244,13 +7244,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <summary> <b>[requires: v1.4 | GL_ARB_imaging]</b> <b>[entry point: <c>glBlendEquation</c>]</b><br/> Specify the equation used for both the RGB blend equation and the Alpha blend equation. </summary>
             /// <param name="mode"> specifies how source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml" /></remarks>
-            public static void BlendEquation(BlendEquationModeEXT mode) => GLPointers._glBlendEquation_fnptr((uint)mode);
+            public static void BlendEquation(BlendEquationMode mode) => GLPointers._glBlendEquation_fnptr((uint)mode);
             
             /// <summary> <b>[requires: GL_ARB_draw_buffers_blend]</b> <b>[entry point: <c>glBlendEquationiARB</c>]</b><br/>  </summary>
-            public static void BlendEquationiARB(uint buf, BlendEquationModeEXT mode) => GLPointers._glBlendEquationiARB_fnptr(buf, (uint)mode);
+            public static void BlendEquationiARB(uint buf, BlendEquationMode mode) => GLPointers._glBlendEquationiARB_fnptr(buf, (uint)mode);
             
             /// <summary> <b>[requires: GL_ARB_draw_buffers_blend]</b> <b>[entry point: <c>glBlendEquationSeparateiARB</c>]</b><br/>  </summary>
-            public static void BlendEquationSeparateiARB(uint buf, BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparateiARB_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
+            public static void BlendEquationSeparateiARB(uint buf, BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparateiARB_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
             
             /// <summary> <b>[requires: GL_ARB_draw_buffers_blend]</b> <b>[entry point: <c>glBlendFunciARB</c>]</b><br/>  </summary>
             public static void BlendFunciARB(uint buf, BlendingFactor src, BlendingFactor dst) => GLPointers._glBlendFunciARB_fnptr(buf, (uint)src, (uint)dst);
@@ -7289,7 +7289,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void BlitNamedFramebuffer(int readFramebuffer, int drawFramebuffer, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter) => GLPointers._glBlitNamedFramebuffer_fnptr(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, (uint)mask, (uint)filter);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glBufferDataARB</c>]</b><br/>  </summary>
-            public static void BufferDataARB(BufferTargetARB target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferDataARB_fnptr((uint)target, size, data, (uint)usage);
+            public static void BufferDataARB(BufferTarget target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferDataARB_fnptr((uint)target, size, data, (uint)usage);
             
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b> <b>[entry point: <c>glBufferPageCommitmentARB</c>]</b><br/>  </summary>
             public static void BufferPageCommitmentARB(All target, IntPtr offset, nint size, bool commit) => GLPointers._glBufferPageCommitmentARB_fnptr((uint)target, offset, size, (byte)(commit ? 1 : 0));
@@ -7303,7 +7303,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void BufferStorage(BufferStorageTarget target, nint size, void* data, BufferStorageMask flags) => GLPointers._glBufferStorage_fnptr((uint)target, size, data, (uint)flags);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glBufferSubDataARB</c>]</b><br/>  </summary>
-            public static void BufferSubDataARB(BufferTargetARB target, IntPtr offset, nint size, void* data) => GLPointers._glBufferSubDataARB_fnptr((uint)target, offset, size, data);
+            public static void BufferSubDataARB(BufferTarget target, IntPtr offset, nint size, void* data) => GLPointers._glBufferSubDataARB_fnptr((uint)target, offset, size, data);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> <b>[entry point: <c>glCheckFramebufferStatus</c>]</b><br/> Check the completeness status of a framebuffer. </summary>
             /// <param name="target"> Specify the target to which the framebuffer is bound for glCheckFramebufferStatus, and the target against which framebuffer completeness of framebuffer is checked for glCheckNamedFramebufferStatus. </param>
@@ -7337,7 +7337,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="type"> The type of the data in memory addressed by data. </param>
             /// <param name="data"> The address of a memory location storing the data to be replicated into the buffer&apos;s data store. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBufferSubData.xhtml" /></remarks>
-            public static void ClearBufferSubData(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._glClearBufferSubData_fnptr((uint)target, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
+            public static void ClearBufferSubData(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._glClearBufferSubData_fnptr((uint)target, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_ES2_compatibility]</b> <b>[entry point: <c>glClearDepthf</c>]</b><br/> Specify the clear value for the depth buffer. </summary>
             /// <param name="depth"> Specifies the depth value used when the depth buffer is cleared. The initial value is 1. </param>
@@ -8031,7 +8031,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="offset"> Specifies the start of the buffer subrange, in basic machine units. </param>
             /// <param name="length"> Specifies the length of the buffer subrange, in basic machine units. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFlushMappedBufferRange.xhtml" /></remarks>
-            public static void FlushMappedBufferRange(BufferTargetARB target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRange_fnptr((uint)target, offset, length);
+            public static void FlushMappedBufferRange(BufferTarget target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRange_fnptr((uint)target, offset, length);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glFlushMappedNamedBufferRange</c>]</b><br/> Indicate modifications to a range of a mapped buffer. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glFlushMappedNamedBufferRange. </param>
@@ -8244,13 +8244,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static int GetAttribLocationARB(GLHandleARB programObj, byte* name) => GLPointers._glGetAttribLocationARB_fnptr((IntPtr)programObj, name);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glGetBufferParameterivARB</c>]</b><br/>  </summary>
-            public static void GetBufferParameterivARB(BufferTargetARB target, BufferPNameARB pname, int* parameters) => GLPointers._glGetBufferParameterivARB_fnptr((uint)target, (uint)pname, parameters);
+            public static void GetBufferParameterivARB(BufferTarget target, BufferPName pname, int* parameters) => GLPointers._glGetBufferParameterivARB_fnptr((uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glGetBufferPointervARB</c>]</b><br/>  </summary>
-            public static void GetBufferPointervARB_(BufferTargetARB target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointervARB_fnptr((uint)target, (uint)pname, parameters);
+            public static void GetBufferPointervARB_(BufferTarget target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointervARB_fnptr((uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glGetBufferSubDataARB</c>]</b><br/>  </summary>
-            public static void GetBufferSubDataARB(BufferTargetARB target, IntPtr offset, nint size, void* data) => GLPointers._glGetBufferSubDataARB_fnptr((uint)target, offset, size, data);
+            public static void GetBufferSubDataARB(BufferTarget target, IntPtr offset, nint size, void* data) => GLPointers._glGetBufferSubDataARB_fnptr((uint)target, offset, size, data);
             
             /// <summary> <b>[requires: GL_ARB_imaging]</b> <b>[entry point: <c>glGetColorTable</c>]</b><br/> Retrieve contents of a color lookup table. </summary>
             /// <param name="target"> Must be GL_COLOR_TABLE, GL_POST_CONVOLUTION_COLOR_TABLE, or GL_POST_COLOR_MATRIX_COLOR_TABLE. </param>
@@ -8460,14 +8460,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="pname">!!missing documentation!!</param>
             /// <param name="parameters">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-            public static void GetNamedBufferParameteri64v(int buffer, BufferPNameARB pname, long* parameters) => GLPointers._glGetNamedBufferParameteri64v_fnptr(buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameteri64v(int buffer, BufferPName pname, long* parameters) => GLPointers._glGetNamedBufferParameteri64v_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glGetNamedBufferParameteriv</c>]</b><br/> Return parameters of a buffer object. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferParameteriv and glGetNamedBufferParameteri64v. </param>
             /// <param name="pname">!!missing documentation!!</param>
             /// <param name="parameters">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-            public static void GetNamedBufferParameteriv(int buffer, BufferPNameARB pname, int* parameters) => GLPointers._glGetNamedBufferParameteriv_fnptr(buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameteriv(int buffer, BufferPName pname, int* parameters) => GLPointers._glGetNamedBufferParameteriv_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glGetNamedBufferPointerv</c>]</b><br/> Return the pointer to a mapped buffer object&apos;s data store. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferPointerv. </param>
@@ -8602,7 +8602,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void GetProgramInterfaceiv(int program, ProgramInterface programInterface, ProgramInterfacePName pname, int* parameters) => GLPointers._glGetProgramInterfaceiv_fnptr(program, (uint)programInterface, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b> <b>[entry point: <c>glGetProgramivARB</c>]</b><br/>  </summary>
-            public static void GetProgramivARB(ProgramTarget target, ProgramPropertyARB pname, int* parameters) => GLPointers._glGetProgramivARB_fnptr((uint)target, (uint)pname, parameters);
+            public static void GetProgramivARB(ProgramTarget target, ProgramProperty pname, int* parameters) => GLPointers._glGetProgramivARB_fnptr((uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b> <b>[entry point: <c>glGetProgramLocalParameterdvARB</c>]</b><br/>  </summary>
             public static void GetProgramLocalParameterdvARB(ProgramTarget target, uint index, double* parameters) => GLPointers._glGetProgramLocalParameterdvARB_fnptr((uint)target, index, parameters);
@@ -9157,7 +9157,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void MakeTextureHandleResidentARB(ulong handle) => GLPointers._glMakeTextureHandleResidentARB_fnptr(handle);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glMapBufferARB</c>]</b><br/>  </summary>
-            public static void* MapBufferARB(BufferTargetARB target, BufferAccessARB access) => GLPointers._glMapBufferARB_fnptr((uint)target, (uint)access);
+            public static void* MapBufferARB(BufferTarget target, BufferAccess access) => GLPointers._glMapBufferARB_fnptr((uint)target, (uint)access);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_map_buffer_range]</b> <b>[entry point: <c>glMapBufferRange</c>]</b><br/> Map all or part of a buffer object&apos;s data store into the client&apos;s address space. </summary>
             /// <param name="target"> Specifies the target to which the buffer object is bound for glMapBufferRange, which must be one of the buffer binding targets in the following table: </param>
@@ -9165,13 +9165,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             /// <param name="length"> Specifies the length of the range to be mapped. </param>
             /// <param name="access"> Specifies a combination of access flags indicating the desired access to the mapped range. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBufferRange.xhtml" /></remarks>
-            public static void* MapBufferRange(BufferTargetARB target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRange_fnptr((uint)target, offset, length, (uint)access);
+            public static void* MapBufferRange(BufferTarget target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRange_fnptr((uint)target, offset, length, (uint)access);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glMapNamedBuffer</c>]</b><br/> Map all of a buffer object&apos;s data store into the client&apos;s address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBuffer. </param>
             /// <param name="access"> Specifies the access policy for glMapBuffer and glMapNamedBuffer, indicating whether it will be possible to read from, write to, or both read from and write to the buffer object&apos;s mapped data store. The symbolic constant must be GL_READ_ONLY, GL_WRITE_ONLY, or GL_READ_WRITE. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBuffer.xhtml" /></remarks>
-            public static void* MapNamedBuffer(int buffer, BufferAccessARB access) => GLPointers._glMapNamedBuffer_fnptr(buffer, (uint)access);
+            public static void* MapNamedBuffer(int buffer, BufferAccess access) => GLPointers._glMapNamedBuffer_fnptr(buffer, (uint)access);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glMapNamedBufferRange</c>]</b><br/> Map all or part of a buffer object&apos;s data store into the client&apos;s address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBufferRange. </param>
@@ -10566,7 +10566,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void UniformSubroutinesuiv(ShaderType shadertype, int count, uint* indices) => GLPointers._glUniformSubroutinesuiv_fnptr((uint)shadertype, count, indices);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glUnmapBufferARB</c>]</b><br/>  </summary>
-            public static bool UnmapBufferARB(BufferTargetARB target) => GLPointers._glUnmapBufferARB_fnptr((uint)target) != 0;
+            public static bool UnmapBufferARB(BufferTarget target) => GLPointers._glUnmapBufferARB_fnptr((uint)target) != 0;
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glUnmapNamedBuffer</c>]</b><br/> Release the mapping of a buffer object&apos;s data store into the client&apos;s address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glUnmapNamedBuffer. </param>
@@ -11347,13 +11347,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void BeginVertexShaderEXT() => GLPointers._glBeginVertexShaderEXT_fnptr();
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b> <b>[entry point: <c>glBindBufferBaseEXT</c>]</b><br/>  </summary>
-            public static void BindBufferBaseEXT(BufferTargetARB target, uint index, int buffer) => GLPointers._glBindBufferBaseEXT_fnptr((uint)target, index, buffer);
+            public static void BindBufferBaseEXT(BufferTarget target, uint index, int buffer) => GLPointers._glBindBufferBaseEXT_fnptr((uint)target, index, buffer);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b> <b>[entry point: <c>glBindBufferOffsetEXT</c>]</b><br/>  </summary>
-            public static void BindBufferOffsetEXT(BufferTargetARB target, uint index, int buffer, IntPtr offset) => GLPointers._glBindBufferOffsetEXT_fnptr((uint)target, index, buffer, offset);
+            public static void BindBufferOffsetEXT(BufferTarget target, uint index, int buffer, IntPtr offset) => GLPointers._glBindBufferOffsetEXT_fnptr((uint)target, index, buffer, offset);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b> <b>[entry point: <c>glBindBufferRangeEXT</c>]</b><br/>  </summary>
-            public static void BindBufferRangeEXT(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRangeEXT_fnptr((uint)target, index, buffer, offset, size);
+            public static void BindBufferRangeEXT(BufferTarget target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRangeEXT_fnptr((uint)target, index, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_EXT_gpu_shader4]</b> <b>[entry point: <c>glBindFragDataLocationEXT</c>]</b><br/>  </summary>
             public static void BindFragDataLocationEXT(int program, uint color, byte* name) => GLPointers._glBindFragDataLocationEXT_fnptr(program, color, name);
@@ -11362,7 +11362,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void BindFramebufferEXT(FramebufferTarget target, int framebuffer) => GLPointers._glBindFramebufferEXT_fnptr((uint)target, framebuffer);
             
             /// <summary> <b>[requires: GL_EXT_shader_image_load_store]</b> <b>[entry point: <c>glBindImageTextureEXT</c>]</b><br/>  </summary>
-            public static void BindImageTextureEXT(uint index, int texture, int level, bool layered, int layer, BufferAccessARB access, int format) => GLPointers._glBindImageTextureEXT_fnptr(index, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, format);
+            public static void BindImageTextureEXT(uint index, int texture, int level, bool layered, int layer, BufferAccess access, int format) => GLPointers._glBindImageTextureEXT_fnptr(index, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, format);
             
             /// <summary> <b>[requires: GL_EXT_vertex_shader]</b> <b>[entry point: <c>glBindLightParameterEXT</c>]</b><br/>  </summary>
             public static uint BindLightParameterEXT(LightName light, LightParameter value) => GLPointers._glBindLightParameterEXT_fnptr((uint)light, (uint)value);
@@ -11431,10 +11431,10 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void BlendColorEXT(float red, float green, float blue, float alpha) => GLPointers._glBlendColorEXT_fnptr(red, green, blue, alpha);
             
             /// <summary> <b>[requires: GL_EXT_blend_minmax]</b> <b>[entry point: <c>glBlendEquationEXT</c>]</b><br/>  </summary>
-            public static void BlendEquationEXT(BlendEquationModeEXT mode) => GLPointers._glBlendEquationEXT_fnptr((uint)mode);
+            public static void BlendEquationEXT(BlendEquationMode mode) => GLPointers._glBlendEquationEXT_fnptr((uint)mode);
             
             /// <summary> <b>[requires: GL_EXT_blend_equation_separate]</b> <b>[entry point: <c>glBlendEquationSeparateEXT</c>]</b><br/>  </summary>
-            public static void BlendEquationSeparateEXT(BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparateEXT_fnptr((uint)modeRGB, (uint)modeAlpha);
+            public static void BlendEquationSeparateEXT(BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparateEXT_fnptr((uint)modeRGB, (uint)modeAlpha);
             
             /// <summary> <b>[requires: GL_EXT_blend_func_separate]</b> <b>[entry point: <c>glBlendFuncSeparateEXT</c>]</b><br/>  </summary>
             public static void BlendFuncSeparateEXT(BlendingFactor sfactorRGB, BlendingFactor dfactorRGB, BlendingFactor sfactorAlpha, BlendingFactor dfactorAlpha) => GLPointers._glBlendFuncSeparateEXT_fnptr((uint)sfactorRGB, (uint)dfactorRGB, (uint)sfactorAlpha, (uint)dfactorAlpha);
@@ -11452,7 +11452,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void BufferStorageExternalEXT(All target, IntPtr offset, nint size, void* clientBuffer, BufferStorageMask flags) => GLPointers._glBufferStorageExternalEXT_fnptr((uint)target, offset, size, clientBuffer, (uint)flags);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b> <b>[entry point: <c>glBufferStorageMemEXT</c>]</b><br/>  </summary>
-            public static void BufferStorageMemEXT(BufferTargetARB target, nint size, uint memory, ulong offset) => GLPointers._glBufferStorageMemEXT_fnptr((uint)target, size, memory, offset);
+            public static void BufferStorageMemEXT(BufferTarget target, nint size, uint memory, ulong offset) => GLPointers._glBufferStorageMemEXT_fnptr((uint)target, size, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b> <b>[entry point: <c>glCheckFramebufferStatusEXT</c>]</b><br/>  </summary>
             public static FramebufferStatus CheckFramebufferStatusEXT(FramebufferTarget target) => (FramebufferStatus) GLPointers._glCheckFramebufferStatusEXT_fnptr((uint)target);
@@ -11776,7 +11776,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static uint GenVertexShadersEXT(uint range) => GLPointers._glGenVertexShadersEXT_fnptr(range);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_draw_buffers2]</b> <b>[entry point: <c>glGetBooleanIndexedvEXT</c>]</b><br/>  </summary>
-            public static void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, bool* data) => GLPointers._glGetBooleanIndexedvEXT_fnptr((uint)target, index, (byte*)data);
+            public static void GetBooleanIndexedvEXT(BufferTarget target, uint index, bool* data) => GLPointers._glGetBooleanIndexedvEXT_fnptr((uint)target, index, (byte*)data);
             
             /// <summary> <b>[requires: GL_EXT_paletted_texture]</b> <b>[entry point: <c>glGetColorTableEXT</c>]</b><br/>  </summary>
             public static void GetColorTableEXT(ColorTableTarget target, PixelFormat format, PixelType type, void* data) => GLPointers._glGetColorTableEXT_fnptr((uint)target, (uint)format, (uint)type, data);
@@ -11902,7 +11902,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void GetMultiTexParameterivEXT(TextureUnit texunit, TextureTarget target, GetTextureParameter pname, int* parameters) => GLPointers._glGetMultiTexParameterivEXT_fnptr((uint)texunit, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b> <b>[entry point: <c>glGetNamedBufferParameterivEXT</c>]</b><br/>  </summary>
-            public static void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, int* parameters) => GLPointers._glGetNamedBufferParameterivEXT_fnptr(buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameterivEXT(int buffer, BufferPName pname, int* parameters) => GLPointers._glGetNamedBufferParameterivEXT_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b> <b>[entry point: <c>glGetNamedBufferPointervEXT</c>]</b><br/>  </summary>
             public static void GetNamedBufferPointervEXT_(int buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetNamedBufferPointervEXT_fnptr(buffer, (uint)pname, parameters);
@@ -11917,7 +11917,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void GetNamedFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, int* parameters) => GLPointers._glGetNamedFramebufferParameterivEXT_fnptr(framebuffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b> <b>[entry point: <c>glGetNamedProgramivEXT</c>]</b><br/>  </summary>
-            public static void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, int* parameters) => GLPointers._glGetNamedProgramivEXT_fnptr(program, (uint)target, (uint)pname, parameters);
+            public static void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramProperty pname, int* parameters) => GLPointers._glGetNamedProgramivEXT_fnptr(program, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b> <b>[entry point: <c>glGetNamedProgramLocalParameterdvEXT</c>]</b><br/>  </summary>
             public static void GetNamedProgramLocalParameterdvEXT(int program, ProgramTarget target, uint index, double* parameters) => GLPointers._glGetNamedProgramLocalParameterdvEXT_fnptr(program, (uint)target, index, parameters);
@@ -12124,7 +12124,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void LockArraysEXT(int first, int count) => GLPointers._glLockArraysEXT_fnptr(first, count);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b> <b>[entry point: <c>glMapNamedBufferEXT</c>]</b><br/>  </summary>
-            public static void* MapNamedBufferEXT(int buffer, BufferAccessARB access) => GLPointers._glMapNamedBufferEXT_fnptr(buffer, (uint)access);
+            public static void* MapNamedBufferEXT(int buffer, BufferAccess access) => GLPointers._glMapNamedBufferEXT_fnptr(buffer, (uint)access);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b> <b>[entry point: <c>glMapNamedBufferRangeEXT</c>]</b><br/>  </summary>
             public static void* MapNamedBufferRangeEXT(int buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapNamedBufferRangeEXT_fnptr(buffer, offset, length, (uint)access);
@@ -13508,13 +13508,13 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void BeginVideoCaptureNV(uint video_capture_slot) => GLPointers._glBeginVideoCaptureNV_fnptr(video_capture_slot);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b> <b>[entry point: <c>glBindBufferBaseNV</c>]</b><br/>  </summary>
-            public static void BindBufferBaseNV(BufferTargetARB target, uint index, int buffer) => GLPointers._glBindBufferBaseNV_fnptr((uint)target, index, buffer);
+            public static void BindBufferBaseNV(BufferTarget target, uint index, int buffer) => GLPointers._glBindBufferBaseNV_fnptr((uint)target, index, buffer);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b> <b>[entry point: <c>glBindBufferOffsetNV</c>]</b><br/>  </summary>
-            public static void BindBufferOffsetNV(BufferTargetARB target, uint index, int buffer, IntPtr offset) => GLPointers._glBindBufferOffsetNV_fnptr((uint)target, index, buffer, offset);
+            public static void BindBufferOffsetNV(BufferTarget target, uint index, int buffer, IntPtr offset) => GLPointers._glBindBufferOffsetNV_fnptr((uint)target, index, buffer, offset);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b> <b>[entry point: <c>glBindBufferRangeNV</c>]</b><br/>  </summary>
-            public static void BindBufferRangeNV(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRangeNV_fnptr((uint)target, index, buffer, offset, size);
+            public static void BindBufferRangeNV(BufferTarget target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRangeNV_fnptr((uint)target, index, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b> <b>[entry point: <c>glBindProgramNV</c>]</b><br/>  </summary>
             public static void BindProgramNV(VertexAttribEnumNV target, int id) => GLPointers._glBindProgramNV_fnptr((uint)target, id);
@@ -13523,7 +13523,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void BindShadingRateImageNV(int texture) => GLPointers._glBindShadingRateImageNV_fnptr(texture);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b> <b>[entry point: <c>glBindTransformFeedbackNV</c>]</b><br/>  </summary>
-            public static void BindTransformFeedbackNV(BufferTargetARB target, int id) => GLPointers._glBindTransformFeedbackNV_fnptr((uint)target, id);
+            public static void BindTransformFeedbackNV(BufferTarget target, int id) => GLPointers._glBindTransformFeedbackNV_fnptr((uint)target, id);
             
             /// <summary> <b>[requires: GL_NV_video_capture]</b> <b>[entry point: <c>glBindVideoCaptureStreamBufferNV</c>]</b><br/>  </summary>
             public static void BindVideoCaptureStreamBufferNV(uint video_capture_slot, uint stream, All frame_region, IntPtr offset) => GLPointers._glBindVideoCaptureStreamBufferNV_fnptr(video_capture_slot, stream, (uint)frame_region, offset);
@@ -13541,7 +13541,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void BufferAddressRangeNV(All pname, uint index, ulong address, nint length) => GLPointers._glBufferAddressRangeNV_fnptr((uint)pname, index, address, length);
             
             /// <summary> <b>[requires: GL_NV_memory_attachment]</b> <b>[entry point: <c>glBufferAttachMemoryNV</c>]</b><br/>  </summary>
-            public static void BufferAttachMemoryNV(BufferTargetARB target, uint memory, ulong offset) => GLPointers._glBufferAttachMemoryNV_fnptr((uint)target, memory, offset);
+            public static void BufferAttachMemoryNV(BufferTarget target, uint memory, ulong offset) => GLPointers._glBufferAttachMemoryNV_fnptr((uint)target, memory, offset);
             
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b> <b>[entry point: <c>glBufferPageCommitmentMemNV</c>]</b><br/>  </summary>
             public static void BufferPageCommitmentMemNV(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => GLPointers._glBufferPageCommitmentMemNV_fnptr((uint)target, offset, size, memory, memOffset, (byte)(commit ? 1 : 0));
@@ -13769,7 +13769,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void GetActiveVaryingNV(int program, uint index, int bufSize, int* length, int* size, All* type, byte* name) => GLPointers._glGetActiveVaryingNV_fnptr(program, index, bufSize, length, size, (uint*)type, name);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b> <b>[entry point: <c>glGetBufferParameterui64vNV</c>]</b><br/>  </summary>
-            public static void GetBufferParameterui64vNV(BufferTargetARB target, All pname, ulong* parameters) => GLPointers._glGetBufferParameterui64vNV_fnptr((uint)target, (uint)pname, parameters);
+            public static void GetBufferParameterui64vNV(BufferTarget target, All pname, ulong* parameters) => GLPointers._glGetBufferParameterui64vNV_fnptr((uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_NV_register_combiners]</b> <b>[entry point: <c>glGetCombinerInputParameterfvNV</c>]</b><br/>  </summary>
             public static void GetCombinerInputParameterfvNV(CombinerStageNV stage, CombinerPortionNV portion, CombinerVariableNV variable, CombinerParameterNV pname, float* parameters) => GLPointers._glGetCombinerInputParameterfvNV_fnptr((uint)stage, (uint)portion, (uint)variable, (uint)pname, parameters);
@@ -13835,7 +13835,7 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             public static void GetMultisamplefvNV(GetMultisamplePNameNV pname, uint index, float* val) => GLPointers._glGetMultisamplefvNV_fnptr((uint)pname, index, val);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b> <b>[entry point: <c>glGetNamedBufferParameterui64vNV</c>]</b><br/>  </summary>
-            public static void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, ulong* parameters) => GLPointers._glGetNamedBufferParameterui64vNV_fnptr(buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameterui64vNV(int buffer, BufferPName pname, ulong* parameters) => GLPointers._glGetNamedBufferParameterui64vNV_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_NV_occlusion_query]</b> <b>[entry point: <c>glGetOcclusionQueryivNV</c>]</b><br/>  </summary>
             public static void GetOcclusionQueryivNV(uint id, OcclusionQueryParameterNameNV pname, int* parameters) => GLPointers._glGetOcclusionQueryivNV_fnptr(id, (uint)pname, parameters);

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -274,14 +274,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 Bitmap(width, height, xorig, yorig, xmove, ymove, bitmap_ptr);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData(BufferTarget target, nint size, IntPtr data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData(BufferTarget target, nint size, IntPtr data, BufferUsage usage)
         {
             void* data_vptr = (void*)data;
             BufferData(target, size, data_vptr, usage);
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsage usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -290,8 +290,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTarget target, T1[] data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, T1[] data, BufferUsage usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -300,8 +300,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTarget target, nint size, in T1 data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, nint size, in T1 data, BufferUsage usage)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -18269,14 +18269,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     BindVertexBuffers(first, count, buffers_ptr, offsets_ptr, strides_ptr);
                 }
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB(BufferTarget target, nint size, IntPtr data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsage)"/>
+            public static unsafe void BufferDataARB(BufferTarget target, nint size, IntPtr data, BufferUsage usage)
             {
                 void* data_vptr = (void*)data;
                 BufferDataARB(target, size, data_vptr, usage);
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsage)"/>
+            public static unsafe void BufferDataARB<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsage usage)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -18285,8 +18285,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     BufferDataARB(target, size, data_ptr, usage);
                 }
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB<T1>(BufferTarget target, T1[] data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsage)"/>
+            public static unsafe void BufferDataARB<T1>(BufferTarget target, T1[] data, BufferUsage usage)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -18295,8 +18295,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     BufferDataARB(target, size, data_ptr, usage);
                 }
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB<T1>(BufferTarget target, nint size, in T1 data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsage)"/>
+            public static unsafe void BufferDataARB<T1>(BufferTarget target, nint size, in T1 data, BufferUsage usage)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:49 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -56,8 +56,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             BindAttribLocation(program, index, name_ptr);
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
         }
-        /// <inheritdoc cref="BindBuffersBase(BufferTargetARB, uint, int, int*)"/>
-        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, ReadOnlySpan<int> buffers)
+        /// <inheritdoc cref="BindBuffersBase(BufferTarget, uint, int, int*)"/>
+        public static unsafe void BindBuffersBase(BufferTarget target, uint first, ReadOnlySpan<int> buffers)
         {
             int count = (int)(buffers.Length);
             fixed (int* buffers_ptr = buffers)
@@ -65,8 +65,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 BindBuffersBase(target, first, count, buffers_ptr);
             }
         }
-        /// <inheritdoc cref="BindBuffersBase(BufferTargetARB, uint, int, int*)"/>
-        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int[] buffers)
+        /// <inheritdoc cref="BindBuffersBase(BufferTarget, uint, int, int*)"/>
+        public static unsafe void BindBuffersBase(BufferTarget target, uint first, int[] buffers)
         {
             int count = (int)(buffers.Length);
             fixed (int* buffers_ptr = buffers)
@@ -74,16 +74,16 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 BindBuffersBase(target, first, count, buffers_ptr);
             }
         }
-        /// <inheritdoc cref="BindBuffersBase(BufferTargetARB, uint, int, int*)"/>
-        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int count, in int buffers)
+        /// <inheritdoc cref="BindBuffersBase(BufferTarget, uint, int, int*)"/>
+        public static unsafe void BindBuffersBase(BufferTarget target, uint first, int count, in int buffers)
         {
             fixed (int* buffers_ptr = &buffers)
             {
                 BindBuffersBase(target, first, count, buffers_ptr);
             }
         }
-        /// <inheritdoc cref="BindBuffersRange(BufferTargetARB, uint, int, int*, IntPtr*, nint*)"/>
-        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
+        /// <inheritdoc cref="BindBuffersRange(BufferTarget, uint, int, int*, IntPtr*, nint*)"/>
+        public static unsafe void BindBuffersRange(BufferTarget target, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
         {
             fixed (int* buffers_ptr = buffers)
             {
@@ -96,8 +96,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
         }
-        /// <inheritdoc cref="BindBuffersRange(BufferTargetARB, uint, int, int*, IntPtr*, nint*)"/>
-        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, int[] buffers, IntPtr[] offsets, nint[] sizes)
+        /// <inheritdoc cref="BindBuffersRange(BufferTarget, uint, int, int*, IntPtr*, nint*)"/>
+        public static unsafe void BindBuffersRange(BufferTarget target, uint first, int count, int[] buffers, IntPtr[] offsets, nint[] sizes)
         {
             fixed (int* buffers_ptr = buffers)
             {
@@ -110,8 +110,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 }
             }
         }
-        /// <inheritdoc cref="BindBuffersRange(BufferTargetARB, uint, int, int*, IntPtr*, nint*)"/>
-        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, in int buffers, in IntPtr offsets, in nint sizes)
+        /// <inheritdoc cref="BindBuffersRange(BufferTarget, uint, int, int*, IntPtr*, nint*)"/>
+        public static unsafe void BindBuffersRange(BufferTarget target, uint first, int count, in int buffers, in IntPtr offsets, in nint sizes)
         {
             fixed (int* buffers_ptr = &buffers)
             fixed (IntPtr* offsets_ptr = &offsets)
@@ -274,14 +274,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 Bitmap(width, height, xorig, yorig, xmove, ymove, bitmap_ptr);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData(BufferTargetARB target, nint size, IntPtr data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData(BufferTarget target, nint size, IntPtr data, BufferUsageARB usage)
         {
             void* data_vptr = (void*)data;
             BufferData(target, size, data_vptr, usage);
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTargetARB target, ReadOnlySpan<T1> data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsageARB usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -290,8 +290,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTargetARB target, T1[] data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, T1[] data, BufferUsageARB usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -300,8 +300,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTargetARB target, nint size, in T1 data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, nint size, in T1 data, BufferUsageARB usage)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -344,14 +344,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 BufferStorage(target, size, data_ptr, flags);
             }
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData(BufferTargetARB target, IntPtr offset, nint size, IntPtr data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData(BufferTarget target, IntPtr offset, nint size, IntPtr data)
         {
             void* data_vptr = (void*)data;
             BufferSubData(target, offset, size, data_vptr);
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData<T1>(BufferTargetARB target, IntPtr offset, ReadOnlySpan<T1> data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData<T1>(BufferTarget target, IntPtr offset, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -360,8 +360,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 BufferSubData(target, offset, size, data_ptr);
             }
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData<T1>(BufferTargetARB target, IntPtr offset, T1[] data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData<T1>(BufferTarget target, IntPtr offset, T1[] data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -370,8 +370,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 BufferSubData(target, offset, size, data_ptr);
             }
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData<T1>(BufferTargetARB target, IntPtr offset, nint size, in T1 data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData<T1>(BufferTarget target, IntPtr offset, nint size, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -498,14 +498,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 ClearBufferiv(buffer, drawbuffer, value_ptr);
             }
         }
-        /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-        public static unsafe void ClearBufferSubData(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
+        /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+        public static unsafe void ClearBufferSubData(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
         {
             void* data_vptr = (void*)data;
             ClearBufferSubData(target, internalformat, offset, size, format, type, data_vptr);
         }
-        /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-        public static unsafe void ClearBufferSubData<T1>(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+        /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+        public static unsafe void ClearBufferSubData<T1>(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -513,8 +513,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 ClearBufferSubData(target, internalformat, offset, size, format, type, data_ptr);
             }
         }
-        /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-        public static unsafe void ClearBufferSubData<T1>(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
+        /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+        public static unsafe void ClearBufferSubData<T1>(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -522,8 +522,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 ClearBufferSubData(target, internalformat, offset, size, format, type, data_ptr);
             }
         }
-        /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-        public static unsafe void ClearBufferSubData<T1>(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
+        /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+        public static unsafe void ClearBufferSubData<T1>(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -4133,32 +4133,32 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             return returnValue;
         }
-        /// <inheritdoc cref="GetBooleani_v(BufferTargetARB, uint, bool*)"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, Span<bool> data)
+        /// <inheritdoc cref="GetBooleani_v(BufferTarget, uint, bool*)"/>
+        public static unsafe void GetBoolean(BufferTarget target, uint index, Span<bool> data)
         {
             fixed (bool* data_ptr = data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
-        /// <inheritdoc cref="GetBooleani_v(BufferTargetARB, uint, bool*)"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, bool[] data)
+        /// <inheritdoc cref="GetBooleani_v(BufferTarget, uint, bool*)"/>
+        public static unsafe void GetBoolean(BufferTarget target, uint index, bool[] data)
         {
             fixed (bool* data_ptr = data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
-        /// <inheritdoc cref="GetBooleani_v(BufferTargetARB, uint, bool*)"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, ref bool data)
+        /// <inheritdoc cref="GetBooleani_v(BufferTarget, uint, bool*)"/>
+        public static unsafe void GetBoolean(BufferTarget target, uint index, ref bool data)
         {
             fixed (bool* data_ptr = &data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
-        /// <inheritdoc cref="GetBooleani_v(BufferTargetARB, uint, bool*)"/>
-        public static unsafe bool GetBoolean(BufferTargetARB target, uint index)
+        /// <inheritdoc cref="GetBooleani_v(BufferTarget, uint, bool*)"/>
+        public static unsafe bool GetBoolean(BufferTarget target, uint index)
         {
             bool data_val;
             bool* data = &data_val;
@@ -4197,91 +4197,91 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             GetBooleanv(pname, data);
             return data_val;
         }
-        /// <inheritdoc cref="GetBufferParameteri64v(BufferTargetARB, BufferPNameARB, long*)"/>
-        public static unsafe void GetBufferParameteri64(BufferTargetARB target, BufferPNameARB pname, Span<long> parameters)
+        /// <inheritdoc cref="GetBufferParameteri64v(BufferTarget, BufferPName, long*)"/>
+        public static unsafe void GetBufferParameteri64(BufferTarget target, BufferPName pname, Span<long> parameters)
         {
             fixed (long* parameters_ptr = parameters)
             {
                 GetBufferParameteri64v(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteri64v(BufferTargetARB, BufferPNameARB, long*)"/>
-        public static unsafe void GetBufferParameteri64(BufferTargetARB target, BufferPNameARB pname, long[] parameters)
+        /// <inheritdoc cref="GetBufferParameteri64v(BufferTarget, BufferPName, long*)"/>
+        public static unsafe void GetBufferParameteri64(BufferTarget target, BufferPName pname, long[] parameters)
         {
             fixed (long* parameters_ptr = parameters)
             {
                 GetBufferParameteri64v(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteri64v(BufferTargetARB, BufferPNameARB, long*)"/>
-        public static unsafe void GetBufferParameteri64(BufferTargetARB target, BufferPNameARB pname, ref long parameters)
+        /// <inheritdoc cref="GetBufferParameteri64v(BufferTarget, BufferPName, long*)"/>
+        public static unsafe void GetBufferParameteri64(BufferTarget target, BufferPName pname, ref long parameters)
         {
             fixed (long* parameters_ptr = &parameters)
             {
                 GetBufferParameteri64v(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteri64v(BufferTargetARB, BufferPNameARB, long*)"/>
-        public static unsafe long GetBufferParameteri64(BufferTargetARB target, BufferPNameARB pname)
+        /// <inheritdoc cref="GetBufferParameteri64v(BufferTarget, BufferPName, long*)"/>
+        public static unsafe long GetBufferParameteri64(BufferTarget target, BufferPName pname)
         {
             long parameters_val;
             long* parameters = &parameters_val;
             GetBufferParameteri64v(target, pname, parameters);
             return parameters_val;
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe void GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname, Span<int> parameters)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe void GetBufferParameteri(BufferTarget target, BufferPName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetBufferParameteriv(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe void GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname, int[] parameters)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe void GetBufferParameteri(BufferTarget target, BufferPName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetBufferParameteriv(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe void GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname, ref int parameters)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe void GetBufferParameteri(BufferTarget target, BufferPName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
                 GetBufferParameteriv(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe int GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe int GetBufferParameteri(BufferTarget target, BufferPName pname)
         {
             int parameters_val;
             int* parameters = &parameters_val;
             GetBufferParameteriv(target, pname, parameters);
             return parameters_val;
         }
-        /// <inheritdoc cref="GetBufferPointerv(BufferTargetARB, BufferPointerNameARB, void**)"/>
-        public static unsafe void GetBufferPointer(BufferTargetARB target, BufferPointerNameARB pname, void** parameters)
+        /// <inheritdoc cref="GetBufferPointerv(BufferTarget, BufferPointerNameARB, void**)"/>
+        public static unsafe void GetBufferPointer(BufferTarget target, BufferPointerNameARB pname, void** parameters)
         {
             GetBufferPointerv(target, pname, parameters);
         }
-        /// <inheritdoc cref="GetBufferPointerv(BufferTargetARB, BufferPointerNameARB, void**)"/>
-        public static unsafe void* GetBufferPointer(BufferTargetARB target, BufferPointerNameARB pname)
+        /// <inheritdoc cref="GetBufferPointerv(BufferTarget, BufferPointerNameARB, void**)"/>
+        public static unsafe void* GetBufferPointer(BufferTarget target, BufferPointerNameARB pname)
         {
             void* parameters_val;
             void** parameters = &parameters_val;
             GetBufferPointerv(target, pname, parameters);
             return parameters_val;
         }
-        /// <inheritdoc cref="GetBufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void GetBufferSubData(BufferTargetARB target, IntPtr offset, nint size, IntPtr data)
+        /// <inheritdoc cref="GetBufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void GetBufferSubData(BufferTarget target, IntPtr offset, nint size, IntPtr data)
         {
             void* data_vptr = (void*)data;
             GetBufferSubData(target, offset, size, data_vptr);
         }
-        /// <inheritdoc cref="GetBufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void GetBufferSubData<T1>(BufferTargetARB target, IntPtr offset, Span<T1> data)
+        /// <inheritdoc cref="GetBufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void GetBufferSubData<T1>(BufferTarget target, IntPtr offset, Span<T1> data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -4290,8 +4290,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 GetBufferSubData(target, offset, size, data_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void GetBufferSubData<T1>(BufferTargetARB target, IntPtr offset, T1[] data)
+        /// <inheritdoc cref="GetBufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void GetBufferSubData<T1>(BufferTarget target, IntPtr offset, T1[] data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -4300,8 +4300,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 GetBufferSubData(target, offset, size, data_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void GetBufferSubData<T1>(BufferTargetARB target, IntPtr offset, nint size, ref T1 data)
+        /// <inheritdoc cref="GetBufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void GetBufferSubData<T1>(BufferTarget target, IntPtr offset, nint size, ref T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -5173,32 +5173,32 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             GetMultisamplefv(pname, index, val);
             return val_val;
         }
-        /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPNameARB, long*)"/>
-        public static unsafe void GetNamedBufferParameteri64(int buffer, BufferPNameARB pname, ref long parameters)
+        /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPName, long*)"/>
+        public static unsafe void GetNamedBufferParameteri64(int buffer, BufferPName pname, ref long parameters)
         {
             fixed (long* parameters_ptr = &parameters)
             {
                 GetNamedBufferParameteri64v(buffer, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPNameARB, long*)"/>
-        public static unsafe long GetNamedBufferParameteri64(int buffer, BufferPNameARB pname)
+        /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPName, long*)"/>
+        public static unsafe long GetNamedBufferParameteri64(int buffer, BufferPName pname)
         {
             long parameters_val;
             long* parameters = &parameters_val;
             GetNamedBufferParameteri64v(buffer, pname, parameters);
             return parameters_val;
         }
-        /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPNameARB, int*)"/>
-        public static unsafe void GetNamedBufferParameteri(int buffer, BufferPNameARB pname, ref int parameters)
+        /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPName, int*)"/>
+        public static unsafe void GetNamedBufferParameteri(int buffer, BufferPName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
                 GetNamedBufferParameteriv(buffer, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPNameARB, int*)"/>
-        public static unsafe int GetNamedBufferParameteri(int buffer, BufferPNameARB pname)
+        /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPName, int*)"/>
+        public static unsafe int GetNamedBufferParameteri(int buffer, BufferPName pname)
         {
             int parameters_val;
             int* parameters = &parameters_val;
@@ -6432,32 +6432,32 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
             GetProgramInterfaceiv(program, programInterface, pname, parameters);
             return parameters_val;
         }
-        /// <inheritdoc cref="GetProgramiv(int, ProgramPropertyARB, int*)"/>
-        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, Span<int> parameters)
+        /// <inheritdoc cref="GetProgramiv(int, ProgramProperty, int*)"/>
+        public static unsafe void GetProgrami(int program, ProgramProperty pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetProgramiv(program, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetProgramiv(int, ProgramPropertyARB, int*)"/>
-        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, int[] parameters)
+        /// <inheritdoc cref="GetProgramiv(int, ProgramProperty, int*)"/>
+        public static unsafe void GetProgrami(int program, ProgramProperty pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetProgramiv(program, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetProgramiv(int, ProgramPropertyARB, int*)"/>
-        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, ref int parameters)
+        /// <inheritdoc cref="GetProgramiv(int, ProgramProperty, int*)"/>
+        public static unsafe void GetProgrami(int program, ProgramProperty pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
                 GetProgramiv(program, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetProgramiv(int, ProgramPropertyARB, int*)"/>
-        public static unsafe int GetProgrami(int program, ProgramPropertyARB pname)
+        /// <inheritdoc cref="GetProgramiv(int, ProgramProperty, int*)"/>
+        public static unsafe int GetProgrami(int program, ProgramProperty pname)
         {
             int parameters_val;
             int* parameters = &parameters_val;
@@ -18082,8 +18082,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 BindAttribLocationARB(programObj, index, name_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             }
-            /// <inheritdoc cref="BindBuffersBase(BufferTargetARB, uint, int, int*)"/>
-            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, ReadOnlySpan<int> buffers)
+            /// <inheritdoc cref="BindBuffersBase(BufferTarget, uint, int, int*)"/>
+            public static unsafe void BindBuffersBase(BufferTarget target, uint first, ReadOnlySpan<int> buffers)
             {
                 int count = (int)(buffers.Length);
                 fixed (int* buffers_ptr = buffers)
@@ -18091,8 +18091,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     BindBuffersBase(target, first, count, buffers_ptr);
                 }
             }
-            /// <inheritdoc cref="BindBuffersBase(BufferTargetARB, uint, int, int*)"/>
-            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int[] buffers)
+            /// <inheritdoc cref="BindBuffersBase(BufferTarget, uint, int, int*)"/>
+            public static unsafe void BindBuffersBase(BufferTarget target, uint first, int[] buffers)
             {
                 int count = (int)(buffers.Length);
                 fixed (int* buffers_ptr = buffers)
@@ -18100,16 +18100,16 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     BindBuffersBase(target, first, count, buffers_ptr);
                 }
             }
-            /// <inheritdoc cref="BindBuffersBase(BufferTargetARB, uint, int, int*)"/>
-            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int count, in int buffers)
+            /// <inheritdoc cref="BindBuffersBase(BufferTarget, uint, int, int*)"/>
+            public static unsafe void BindBuffersBase(BufferTarget target, uint first, int count, in int buffers)
             {
                 fixed (int* buffers_ptr = &buffers)
                 {
                     BindBuffersBase(target, first, count, buffers_ptr);
                 }
             }
-            /// <inheritdoc cref="BindBuffersRange(BufferTargetARB, uint, int, int*, IntPtr*, nint*)"/>
-            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
+            /// <inheritdoc cref="BindBuffersRange(BufferTarget, uint, int, int*, IntPtr*, nint*)"/>
+            public static unsafe void BindBuffersRange(BufferTarget target, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
             {
                 fixed (int* buffers_ptr = buffers)
                 {
@@ -18122,8 +18122,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     }
                 }
             }
-            /// <inheritdoc cref="BindBuffersRange(BufferTargetARB, uint, int, int*, IntPtr*, nint*)"/>
-            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, int[] buffers, IntPtr[] offsets, nint[] sizes)
+            /// <inheritdoc cref="BindBuffersRange(BufferTarget, uint, int, int*, IntPtr*, nint*)"/>
+            public static unsafe void BindBuffersRange(BufferTarget target, uint first, int count, int[] buffers, IntPtr[] offsets, nint[] sizes)
             {
                 fixed (int* buffers_ptr = buffers)
                 {
@@ -18136,8 +18136,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     }
                 }
             }
-            /// <inheritdoc cref="BindBuffersRange(BufferTargetARB, uint, int, int*, IntPtr*, nint*)"/>
-            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, in int buffers, in IntPtr offsets, in nint sizes)
+            /// <inheritdoc cref="BindBuffersRange(BufferTarget, uint, int, int*, IntPtr*, nint*)"/>
+            public static unsafe void BindBuffersRange(BufferTarget target, uint first, int count, in int buffers, in IntPtr offsets, in nint sizes)
             {
                 fixed (int* buffers_ptr = &buffers)
                 fixed (IntPtr* offsets_ptr = &offsets)
@@ -18269,14 +18269,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     BindVertexBuffers(first, count, buffers_ptr, offsets_ptr, strides_ptr);
                 }
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB(BufferTargetARB target, nint size, IntPtr data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
+            public static unsafe void BufferDataARB(BufferTarget target, nint size, IntPtr data, BufferUsageARB usage)
             {
                 void* data_vptr = (void*)data;
                 BufferDataARB(target, size, data_vptr, usage);
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB<T1>(BufferTargetARB target, ReadOnlySpan<T1> data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
+            public static unsafe void BufferDataARB<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsageARB usage)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -18285,8 +18285,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     BufferDataARB(target, size, data_ptr, usage);
                 }
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB<T1>(BufferTargetARB target, T1[] data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
+            public static unsafe void BufferDataARB<T1>(BufferTarget target, T1[] data, BufferUsageARB usage)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -18295,8 +18295,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     BufferDataARB(target, size, data_ptr, usage);
                 }
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB<T1>(BufferTargetARB target, nint size, in T1 data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
+            public static unsafe void BufferDataARB<T1>(BufferTarget target, nint size, in T1 data, BufferUsageARB usage)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -18339,14 +18339,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     BufferStorage(target, size, data_ptr, flags);
                 }
             }
-            /// <inheritdoc cref="BufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void BufferSubDataARB(BufferTargetARB target, IntPtr offset, nint size, IntPtr data)
+            /// <inheritdoc cref="BufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void BufferSubDataARB(BufferTarget target, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 BufferSubDataARB(target, offset, size, data_vptr);
             }
-            /// <inheritdoc cref="BufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void BufferSubDataARB<T1>(BufferTargetARB target, IntPtr offset, ReadOnlySpan<T1> data)
+            /// <inheritdoc cref="BufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void BufferSubDataARB<T1>(BufferTarget target, IntPtr offset, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -18355,8 +18355,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     BufferSubDataARB(target, offset, size, data_ptr);
                 }
             }
-            /// <inheritdoc cref="BufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void BufferSubDataARB<T1>(BufferTargetARB target, IntPtr offset, T1[] data)
+            /// <inheritdoc cref="BufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void BufferSubDataARB<T1>(BufferTarget target, IntPtr offset, T1[] data)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -18365,8 +18365,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     BufferSubDataARB(target, offset, size, data_ptr);
                 }
             }
-            /// <inheritdoc cref="BufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void BufferSubDataARB<T1>(BufferTargetARB target, IntPtr offset, nint size, in T1 data)
+            /// <inheritdoc cref="BufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void BufferSubDataARB<T1>(BufferTarget target, IntPtr offset, nint size, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -18407,14 +18407,14 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     ClearBufferData(target, internalformat, format, type, data_ptr);
                 }
             }
-            /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-            public static unsafe void ClearBufferSubData(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
+            /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+            public static unsafe void ClearBufferSubData(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearBufferSubData(target, internalformat, offset, size, format, type, data_vptr);
             }
-            /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-            public static unsafe void ClearBufferSubData<T1>(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+            public static unsafe void ClearBufferSubData<T1>(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -18422,8 +18422,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     ClearBufferSubData(target, internalformat, offset, size, format, type, data_ptr);
                 }
             }
-            /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-            public static unsafe void ClearBufferSubData<T1>(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
+            /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+            public static unsafe void ClearBufferSubData<T1>(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -18431,8 +18431,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     ClearBufferSubData(target, internalformat, offset, size, format, type, data_ptr);
                 }
             }
-            /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-            public static unsafe void ClearBufferSubData<T1>(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
+            /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+            public static unsafe void ClearBufferSubData<T1>(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -21484,59 +21484,59 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
                 return returnValue;
             }
-            /// <inheritdoc cref="GetBufferParameterivARB(BufferTargetARB, BufferPNameARB, int*)"/>
-            public static unsafe void GetBufferParameterivARB(BufferTargetARB target, BufferPNameARB pname, Span<int> parameters)
+            /// <inheritdoc cref="GetBufferParameterivARB(BufferTarget, BufferPName, int*)"/>
+            public static unsafe void GetBufferParameterivARB(BufferTarget target, BufferPName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetBufferParameterivARB(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterivARB(BufferTargetARB, BufferPNameARB, int*)"/>
-            public static unsafe void GetBufferParameterivARB(BufferTargetARB target, BufferPNameARB pname, int[] parameters)
+            /// <inheritdoc cref="GetBufferParameterivARB(BufferTarget, BufferPName, int*)"/>
+            public static unsafe void GetBufferParameterivARB(BufferTarget target, BufferPName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetBufferParameterivARB(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterivARB(BufferTargetARB, BufferPNameARB, int*)"/>
-            public static unsafe void GetBufferParameterivARB(BufferTargetARB target, BufferPNameARB pname, ref int parameters)
+            /// <inheritdoc cref="GetBufferParameterivARB(BufferTarget, BufferPName, int*)"/>
+            public static unsafe void GetBufferParameterivARB(BufferTarget target, BufferPName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
                     GetBufferParameterivARB(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterivARB(BufferTargetARB, BufferPNameARB, int*)"/>
-            public static unsafe int GetBufferParameterivARB(BufferTargetARB target, BufferPNameARB pname)
+            /// <inheritdoc cref="GetBufferParameterivARB(BufferTarget, BufferPName, int*)"/>
+            public static unsafe int GetBufferParameterivARB(BufferTarget target, BufferPName pname)
             {
                 int parameters_val;
                 int* parameters = &parameters_val;
                 GetBufferParameterivARB(target, pname, parameters);
                 return parameters_val;
             }
-            /// <inheritdoc cref="GetBufferPointervARB(BufferTargetARB, BufferPointerNameARB, void**)"/>
-            public static unsafe void GetBufferPointervARB(BufferTargetARB target, BufferPointerNameARB pname, void** parameters)
+            /// <inheritdoc cref="GetBufferPointervARB(BufferTarget, BufferPointerNameARB, void**)"/>
+            public static unsafe void GetBufferPointervARB(BufferTarget target, BufferPointerNameARB pname, void** parameters)
             {
                 GetBufferPointervARB_(target, pname, parameters);
             }
-            /// <inheritdoc cref="GetBufferPointervARB(BufferTargetARB, BufferPointerNameARB, void**)"/>
-            public static unsafe void* GetBufferPointervARB(BufferTargetARB target, BufferPointerNameARB pname)
+            /// <inheritdoc cref="GetBufferPointervARB(BufferTarget, BufferPointerNameARB, void**)"/>
+            public static unsafe void* GetBufferPointervARB(BufferTarget target, BufferPointerNameARB pname)
             {
                 void* parameters_val;
                 void** parameters = &parameters_val;
                 GetBufferPointervARB_(target, pname, parameters);
                 return parameters_val;
             }
-            /// <inheritdoc cref="GetBufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void GetBufferSubDataARB(BufferTargetARB target, IntPtr offset, nint size, IntPtr data)
+            /// <inheritdoc cref="GetBufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void GetBufferSubDataARB(BufferTarget target, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 GetBufferSubDataARB(target, offset, size, data_vptr);
             }
-            /// <inheritdoc cref="GetBufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void GetBufferSubDataARB<T1>(BufferTargetARB target, IntPtr offset, Span<T1> data)
+            /// <inheritdoc cref="GetBufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void GetBufferSubDataARB<T1>(BufferTarget target, IntPtr offset, Span<T1> data)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -21545,8 +21545,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     GetBufferSubDataARB(target, offset, size, data_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void GetBufferSubDataARB<T1>(BufferTargetARB target, IntPtr offset, T1[] data)
+            /// <inheritdoc cref="GetBufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void GetBufferSubDataARB<T1>(BufferTarget target, IntPtr offset, T1[] data)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -21555,8 +21555,8 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     GetBufferSubDataARB(target, offset, size, data_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void GetBufferSubDataARB<T1>(BufferTargetARB target, IntPtr offset, nint size, ref T1 data)
+            /// <inheritdoc cref="GetBufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void GetBufferSubDataARB<T1>(BufferTarget target, IntPtr offset, nint size, ref T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -22495,32 +22495,32 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 GetMultisamplefv(pname, index, val);
                 return val_val;
             }
-            /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPNameARB, long*)"/>
-            public static unsafe void GetNamedBufferParameteri64(int buffer, BufferPNameARB pname, ref long parameters)
+            /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPName, long*)"/>
+            public static unsafe void GetNamedBufferParameteri64(int buffer, BufferPName pname, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
                     GetNamedBufferParameteri64v(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPNameARB, long*)"/>
-            public static unsafe long GetNamedBufferParameteri64(int buffer, BufferPNameARB pname)
+            /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPName, long*)"/>
+            public static unsafe long GetNamedBufferParameteri64(int buffer, BufferPName pname)
             {
                 long parameters_val;
                 long* parameters = &parameters_val;
                 GetNamedBufferParameteri64v(buffer, pname, parameters);
                 return parameters_val;
             }
-            /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPNameARB, int*)"/>
-            public static unsafe void GetNamedBufferParameteri(int buffer, BufferPNameARB pname, ref int parameters)
+            /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPName, int*)"/>
+            public static unsafe void GetNamedBufferParameteri(int buffer, BufferPName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
                     GetNamedBufferParameteriv(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPNameARB, int*)"/>
-            public static unsafe int GetNamedBufferParameteri(int buffer, BufferPNameARB pname)
+            /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPName, int*)"/>
+            public static unsafe int GetNamedBufferParameteri(int buffer, BufferPName pname)
             {
                 int parameters_val;
                 int* parameters = &parameters_val;
@@ -23695,32 +23695,32 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 GetProgramInterfaceiv(program, programInterface, pname, parameters);
                 return parameters_val;
             }
-            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe void GetProgramivARB(ProgramTarget target, ProgramPropertyARB pname, Span<int> parameters)
+            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe void GetProgramivARB(ProgramTarget target, ProgramProperty pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetProgramivARB(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe void GetProgramivARB(ProgramTarget target, ProgramPropertyARB pname, int[] parameters)
+            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe void GetProgramivARB(ProgramTarget target, ProgramProperty pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetProgramivARB(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe void GetProgramivARB(ProgramTarget target, ProgramPropertyARB pname, ref int parameters)
+            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe void GetProgramivARB(ProgramTarget target, ProgramProperty pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
                     GetProgramivARB(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe int GetProgramivARB(ProgramTarget target, ProgramPropertyARB pname)
+            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe int GetProgramivARB(ProgramTarget target, ProgramProperty pname)
             {
                 int parameters_val;
                 int* parameters = &parameters_val;
@@ -33689,32 +33689,32 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     GenTexturesEXT(n, textures_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTargetARB, uint, bool*)"/>
-            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, Span<bool> data)
+            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTarget, uint, bool*)"/>
+            public static unsafe void GetBooleanIndexedvEXT(BufferTarget target, uint index, Span<bool> data)
             {
                 fixed (bool* data_ptr = data)
                 {
                     GetBooleanIndexedvEXT(target, index, data_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTargetARB, uint, bool*)"/>
-            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, bool[] data)
+            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTarget, uint, bool*)"/>
+            public static unsafe void GetBooleanIndexedvEXT(BufferTarget target, uint index, bool[] data)
             {
                 fixed (bool* data_ptr = data)
                 {
                     GetBooleanIndexedvEXT(target, index, data_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTargetARB, uint, bool*)"/>
-            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, ref bool data)
+            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTarget, uint, bool*)"/>
+            public static unsafe void GetBooleanIndexedvEXT(BufferTarget target, uint index, ref bool data)
             {
                 fixed (bool* data_ptr = &data)
                 {
                     GetBooleanIndexedvEXT(target, index, data_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTargetARB, uint, bool*)"/>
-            public static unsafe bool GetBooleanIndexedvEXT(BufferTargetARB target, uint index)
+            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTarget, uint, bool*)"/>
+            public static unsafe bool GetBooleanIndexedvEXT(BufferTarget target, uint index)
             {
                 bool data_val;
                 bool* data = &data_val;
@@ -35001,32 +35001,32 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 GetMultiTexParameterivEXT(texunit, target, pname, parameters);
                 return parameters_val;
             }
-            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPNameARB, int*)"/>
-            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, Span<int> parameters)
+            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPName, int*)"/>
+            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetNamedBufferParameterivEXT(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPNameARB, int*)"/>
-            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, int[] parameters)
+            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPName, int*)"/>
+            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetNamedBufferParameterivEXT(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPNameARB, int*)"/>
-            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, ref int parameters)
+            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPName, int*)"/>
+            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
                     GetNamedBufferParameterivEXT(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPNameARB, int*)"/>
-            public static unsafe int GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname)
+            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPName, int*)"/>
+            public static unsafe int GetNamedBufferParameterivEXT(int buffer, BufferPName pname)
             {
                 int parameters_val;
                 int* parameters = &parameters_val;
@@ -35143,32 +35143,32 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 GetNamedFramebufferParameterivEXT(framebuffer, pname, parameters);
                 return parameters_val;
             }
-            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, Span<int> parameters)
+            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramProperty pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetNamedProgramivEXT(program, target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, int[] parameters)
+            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramProperty pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetNamedProgramivEXT(program, target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, ref int parameters)
+            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramProperty pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
                     GetNamedProgramivEXT(program, target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe int GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname)
+            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe int GetNamedProgramivEXT(int program, ProgramTarget target, ProgramProperty pname)
             {
                 int parameters_val;
                 int* parameters = &parameters_val;
@@ -43512,32 +43512,32 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                     Marshal.FreeCoTaskMem((IntPtr)name_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTargetARB, All, ulong*)"/>
-            public static unsafe void GetBufferParameterui64vNV(BufferTargetARB target, All pname, Span<ulong> parameters)
+            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTarget, All, ulong*)"/>
+            public static unsafe void GetBufferParameterui64vNV(BufferTarget target, All pname, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
                     GetBufferParameterui64vNV(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTargetARB, All, ulong*)"/>
-            public static unsafe void GetBufferParameterui64vNV(BufferTargetARB target, All pname, ulong[] parameters)
+            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTarget, All, ulong*)"/>
+            public static unsafe void GetBufferParameterui64vNV(BufferTarget target, All pname, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
                     GetBufferParameterui64vNV(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTargetARB, All, ulong*)"/>
-            public static unsafe void GetBufferParameterui64vNV(BufferTargetARB target, All pname, ref ulong parameters)
+            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTarget, All, ulong*)"/>
+            public static unsafe void GetBufferParameterui64vNV(BufferTarget target, All pname, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
                     GetBufferParameterui64vNV(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTargetARB, All, ulong*)"/>
-            public static unsafe ulong GetBufferParameterui64vNV(BufferTargetARB target, All pname)
+            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTarget, All, ulong*)"/>
+            public static unsafe ulong GetBufferParameterui64vNV(BufferTarget target, All pname)
             {
                 ulong parameters_val;
                 ulong* parameters = &parameters_val;
@@ -44123,32 +44123,32 @@ namespace OpenTK.Graphics.OpenGL.Compatibility
                 GetMultisamplefvNV(pname, index, val);
                 return val_val;
             }
-            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPNameARB, ulong*)"/>
-            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, Span<ulong> parameters)
+            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPName, ulong*)"/>
+            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPName pname, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
                     GetNamedBufferParameterui64vNV(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPNameARB, ulong*)"/>
-            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, ulong[] parameters)
+            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPName, ulong*)"/>
+            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPName pname, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
                     GetNamedBufferParameterui64vNV(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPNameARB, ulong*)"/>
-            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, ref ulong parameters)
+            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPName, ulong*)"/>
+            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPName pname, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
                     GetNamedBufferParameterui64vNV(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPNameARB, ulong*)"/>
-            public static unsafe ulong GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname)
+            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPName, ulong*)"/>
+            public static unsafe ulong GetNamedBufferParameterui64vNV(int buffer, BufferPName pname)
             {
                 ulong parameters_val;
                 ulong* parameters = &parameters_val;

--- a/src/OpenTK.Graphics/OpenGL/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGL/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGL
@@ -4905,7 +4905,7 @@ namespace OpenTK.Graphics.OpenGL
         AtomicCounterBuffer = 37568,
     }
     ///<summary>Used in <see cref="GL.BufferData" />, <see cref="GL.ARB.BufferDataARB" /></summary>
-    public enum BufferUsageARB : uint
+    public enum BufferUsage : uint
     {
         StreamDraw = 35040,
         StreamRead = 35041,

--- a/src/OpenTK.Graphics/OpenGL/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGL/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:49 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGL
@@ -4767,7 +4767,7 @@ namespace OpenTK.Graphics.OpenGL
         Double = 5130,
     }
     ///<summary>Used in <see cref="GL.BlendEquation" />, <see cref="GL.BlendEquationi" />, <see cref="GL.BlendEquationSeparate" />, ...</summary>
-    public enum BlendEquationModeEXT : uint
+    public enum BlendEquationMode : uint
     {
         FuncAdd = 32774,
         FuncAddExt = 32774,
@@ -4824,14 +4824,14 @@ namespace OpenTK.Graphics.OpenGL
         Stencil = 6146,
     }
     ///<summary>Used in <see cref="GL.BindImageTexture" />, <see cref="GL.MapBuffer" />, <see cref="GL.MapNamedBuffer" />, ...</summary>
-    public enum BufferAccessARB : uint
+    public enum BufferAccess : uint
     {
         ReadOnly = 35000,
         WriteOnly = 35001,
         ReadWrite = 35002,
     }
     ///<summary>Used in <see cref="GL.GetBufferParameteri64v" />, <see cref="GL.GetBufferParameteriv" />, <see cref="GL.GetNamedBufferParameteri64v" />, ...</summary>
-    public enum BufferPNameARB : uint
+    public enum BufferPName : uint
     {
         BufferImmutableStorage = 33311,
         BufferStorageFlags = 33312,
@@ -4886,7 +4886,7 @@ namespace OpenTK.Graphics.OpenGL
         AtomicCounterBuffer = 37568,
     }
     ///<summary>Used in <see cref="GL.BindBuffer" />, <see cref="GL.BindBufferBase" />, <see cref="GL.BindBufferRange" />, ...</summary>
-    public enum BufferTargetARB : uint
+    public enum BufferTarget : uint
     {
         ParameterBuffer = 33006,
         ArrayBuffer = 34962,
@@ -7875,7 +7875,7 @@ namespace OpenTK.Graphics.OpenGL
         ProgramSeparable = 33368,
     }
     ///<summary>Used in <see cref="GL.GetProgramiv" />, <see cref="GL.EXT.GetNamedProgramivEXT" />, <see cref="GL.ARB.GetProgramivARB" /></summary>
-    public enum ProgramPropertyARB : uint
+    public enum ProgramProperty : uint
     {
         ComputeWorkGroupSize = 33383,
         ProgramBinaryLength = 34625,

--- a/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Manual.cs
@@ -47,12 +47,12 @@ namespace OpenTK.Graphics.OpenGL
         }
 
         /// <summary>
-        /// This is a convenience function that calls <see cref="GL.GetProgrami(int, ProgramPropertyARB, ref int)"/> followed by <see cref="GL.GetProgramInfoLog(int, int, ref int, out string)"/>.
+        /// This is a convenience function that calls <see cref="GL.GetProgrami(int, ProgramProperty, ref int)"/> followed by <see cref="GL.GetProgramInfoLog(int, int, ref int, out string)"/>.
         /// </summary>
         public static void GetProgramInfoLog(int program, out string info)
         {
             int length = default;
-            GL.GetProgrami(program, ProgramPropertyARB.InfoLogLength, ref length);
+            GL.GetProgrami(program, ProgramProperty.InfoLogLength, ref length);
             if (length == 0)
             {
                 info = string.Empty;

--- a/src/OpenTK.Graphics/OpenGL/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:43 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;
@@ -305,7 +305,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
         /// <param name="usage">Specifies the expected usage pattern of the data store. The symbolic constant must be GL_STREAM_DRAW, GL_STREAM_READ, GL_STREAM_COPY, GL_STATIC_DRAW, GL_STATIC_READ, GL_STATIC_COPY, GL_DYNAMIC_DRAW, GL_DYNAMIC_READ, or GL_DYNAMIC_COPY.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferData.xhtml" /></remarks>
-        public static void BufferData(BufferTarget target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
+        public static void BufferData(BufferTarget target, nint size, void* data, BufferUsage usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_buffer_storage]</b> <b>[entry point: <c>glBufferStorage</c>]</b><br/> Creates and initializes a buffer object&apos;s immutable data    store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glBufferStorage, which must be one of the buffer binding targets in the following table: </param>
@@ -5288,7 +5288,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void BlitNamedFramebuffer(int readFramebuffer, int drawFramebuffer, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter) => GLPointers._glBlitNamedFramebuffer_fnptr(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, (uint)mask, (uint)filter);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glBufferDataARB</c>]</b><br/>  </summary>
-            public static void BufferDataARB(BufferTarget target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferDataARB_fnptr((uint)target, size, data, (uint)usage);
+            public static void BufferDataARB(BufferTarget target, nint size, void* data, BufferUsage usage) => GLPointers._glBufferDataARB_fnptr((uint)target, size, data, (uint)usage);
             
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b> <b>[entry point: <c>glBufferPageCommitmentARB</c>]</b><br/>  </summary>
             public static void BufferPageCommitmentARB(All target, IntPtr offset, nint size, bool commit) => GLPointers._glBufferPageCommitmentARB_fnptr((uint)target, offset, size, (byte)(commit ? 1 : 0));

--- a/src/OpenTK.Graphics/OpenGL/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:49 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:43 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;
@@ -61,14 +61,14 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="target"> Specifies the target to which the buffer object is bound, which must be one of the buffer binding targets in the following table: </param>
         /// <param name="buffer"> Specifies the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffer.xhtml" /></remarks>
-        public static void BindBuffer(BufferTargetARB target, int buffer) => GLPointers._glBindBuffer_fnptr((uint)target, buffer);
+        public static void BindBuffer(BufferTarget target, int buffer) => GLPointers._glBindBuffer_fnptr((uint)target, buffer);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_uniform_buffer_object]</b> <b>[entry point: <c>glBindBufferBase</c>]</b><br/> Bind a buffer object to an indexed buffer target. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
         /// <param name="index"> Specify the index of the binding point within the array specified by target. </param>
         /// <param name="buffer"> The name of a buffer object to bind to the specified binding point. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferBase.xhtml" /></remarks>
-        public static void BindBufferBase(BufferTargetARB target, uint index, int buffer) => GLPointers._glBindBufferBase_fnptr((uint)target, index, buffer);
+        public static void BindBufferBase(BufferTarget target, uint index, int buffer) => GLPointers._glBindBufferBase_fnptr((uint)target, index, buffer);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_uniform_buffer_object]</b> <b>[entry point: <c>glBindBufferRange</c>]</b><br/> Bind a range within a buffer object to an indexed buffer target. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER, or GL_SHADER_STORAGE_BUFFER. </param>
@@ -77,7 +77,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="offset"> The starting offset in basic machine units into the buffer object buffer. </param>
         /// <param name="size"> The amount of data in machine units that can be read from the buffer object while used as an indexed target. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferRange.xhtml" /></remarks>
-        public static void BindBufferRange(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRange_fnptr((uint)target, index, buffer, offset, size);
+        public static void BindBufferRange(BufferTarget target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRange_fnptr((uint)target, index, buffer, offset, size);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> <b>[entry point: <c>glBindBuffersBase</c>]</b><br/> Bind one or more buffer objects to a sequence of indexed buffer targets. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -85,7 +85,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="count"> Specify the number of contiguous binding points to which to bind buffers. </param>
         /// <param name="buffers"> A pointer to an array of names of buffer objects to bind to the targets on the specified binding point, or NULL. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersBase.xhtml" /></remarks>
-        public static void BindBuffersBase(BufferTargetARB target, uint first, int count, int* buffers) => GLPointers._glBindBuffersBase_fnptr((uint)target, first, count, buffers);
+        public static void BindBuffersBase(BufferTarget target, uint first, int count, int* buffers) => GLPointers._glBindBuffersBase_fnptr((uint)target, first, count, buffers);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> <b>[entry point: <c>glBindBuffersRange</c>]</b><br/> Bind ranges of one or more buffer objects to a sequence of indexed buffer targets. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -95,7 +95,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="offsets"> A pointer to an array of offsets into the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
         /// <param name="sizes"> A pointer to an array of sizes of the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersRange.xhtml" /></remarks>
-        public static void BindBuffersRange(BufferTargetARB target, uint first, int count, int* buffers, IntPtr* offsets, nint* sizes) => GLPointers._glBindBuffersRange_fnptr((uint)target, first, count, buffers, offsets, sizes);
+        public static void BindBuffersRange(BufferTarget target, uint first, int count, int* buffers, IntPtr* offsets, nint* sizes) => GLPointers._glBindBuffersRange_fnptr((uint)target, first, count, buffers, offsets, sizes);
         
         /// <summary> <b>[requires: v3.0]</b> <b>[entry point: <c>glBindFragDataLocation</c>]</b><br/> Bind a user-defined varying out variable to a fragment shader color number. </summary>
         /// <param name="program"> The name of the program containing varying out variable whose binding to modify </param>
@@ -127,7 +127,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
         /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted stores. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTexture.xhtml" /></remarks>
-        public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._glBindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
+        public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccess access, InternalFormat format) => GLPointers._glBindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> <b>[entry point: <c>glBindImageTextures</c>]</b><br/> Bind one or more named texture images to a sequence of consecutive image units. </summary>
         /// <param name="first"> Specifies the first image unit to which a texture is to be bound. </param>
@@ -218,26 +218,26 @@ namespace OpenTK.Graphics.OpenGL
         /// <summary> <b>[requires: v1.4 | GL_ARB_imaging]</b> <b>[entry point: <c>glBlendEquation</c>]</b><br/> Specify the equation used for both the RGB blend equation and the Alpha blend equation. </summary>
         /// <param name="mode"> specifies how source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml" /></remarks>
-        public static void BlendEquation(BlendEquationModeEXT mode) => GLPointers._glBlendEquation_fnptr((uint)mode);
+        public static void BlendEquation(BlendEquationMode mode) => GLPointers._glBlendEquation_fnptr((uint)mode);
         
         /// <summary> <b>[requires: v4.0]</b> <b>[entry point: <c>glBlendEquationi</c>]</b><br/> Specify the equation used for both the RGB blend equation and the Alpha blend equation. </summary>
         /// <param name="buf"> for glBlendEquationi, specifies the index of the draw buffer for which to set the blend equation. </param>
         /// <param name="mode"> specifies how source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml" /></remarks>
-        public static void BlendEquationi(uint buf, BlendEquationModeEXT mode) => GLPointers._glBlendEquationi_fnptr(buf, (uint)mode);
+        public static void BlendEquationi(uint buf, BlendEquationMode mode) => GLPointers._glBlendEquationi_fnptr(buf, (uint)mode);
         
         /// <summary> <b>[requires: v2.0]</b> <b>[entry point: <c>glBlendEquationSeparate</c>]</b><br/> Set the RGB blend equation and the alpha blend equation separately. </summary>
         /// <param name="modeRGB"> specifies the RGB blend equation, how the red, green, and blue components of the source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <param name="modeAlpha"> specifies the alpha blend equation, how the alpha component of the source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquationSeparate.xhtml" /></remarks>
-        public static void BlendEquationSeparate(BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparate_fnptr((uint)modeRGB, (uint)modeAlpha);
+        public static void BlendEquationSeparate(BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparate_fnptr((uint)modeRGB, (uint)modeAlpha);
         
         /// <summary> <b>[requires: v4.0]</b> <b>[entry point: <c>glBlendEquationSeparatei</c>]</b><br/> Set the RGB blend equation and the alpha blend equation separately. </summary>
         /// <param name="buf"> for glBlendEquationSeparatei, specifies the index of the draw buffer for which to set the blend equations. </param>
         /// <param name="modeRGB"> specifies the RGB blend equation, how the red, green, and blue components of the source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <param name="modeAlpha"> specifies the alpha blend equation, how the alpha component of the source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquationSeparate.xhtml" /></remarks>
-        public static void BlendEquationSeparatei(uint buf, BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparatei_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
+        public static void BlendEquationSeparatei(uint buf, BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparatei_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glBlendFunc</c>]</b><br/> Specify pixel arithmetic. </summary>
         /// <param name="sfactor"> Specifies how the red, green, blue, and alpha source blending factors are computed. The initial value is GL_ONE. </param>
@@ -305,7 +305,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
         /// <param name="usage">Specifies the expected usage pattern of the data store. The symbolic constant must be GL_STREAM_DRAW, GL_STREAM_READ, GL_STREAM_COPY, GL_STATIC_DRAW, GL_STATIC_READ, GL_STATIC_COPY, GL_DYNAMIC_DRAW, GL_DYNAMIC_READ, or GL_DYNAMIC_COPY.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferData.xhtml" /></remarks>
-        public static void BufferData(BufferTargetARB target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
+        public static void BufferData(BufferTarget target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
         
         /// <summary> <b>[requires: v4.4 | GL_ARB_buffer_storage]</b> <b>[entry point: <c>glBufferStorage</c>]</b><br/> Creates and initializes a buffer object&apos;s immutable data    store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glBufferStorage, which must be one of the buffer binding targets in the following table: </param>
@@ -321,7 +321,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="size"> Specifies the size in bytes of the data store region being replaced. </param>
         /// <param name="data"> Specifies a pointer to the new data that will be copied into the data store. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferSubData.xhtml" /></remarks>
-        public static void BufferSubData(BufferTargetARB target, IntPtr offset, nint size, void* data) => GLPointers._glBufferSubData_fnptr((uint)target, offset, size, data);
+        public static void BufferSubData(BufferTarget target, IntPtr offset, nint size, void* data) => GLPointers._glBufferSubData_fnptr((uint)target, offset, size, data);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> <b>[entry point: <c>glCheckFramebufferStatus</c>]</b><br/> Check the completeness status of a framebuffer. </summary>
         /// <param name="target"> Specify the target to which the framebuffer is bound for glCheckFramebufferStatus, and the target against which framebuffer completeness of framebuffer is checked for glCheckNamedFramebufferStatus. </param>
@@ -385,7 +385,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="type"> The type of the data in memory addressed by data. </param>
         /// <param name="data"> The address of a memory location storing the data to be replicated into the buffer&apos;s data store. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBufferSubData.xhtml" /></remarks>
-        public static void ClearBufferSubData(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._glClearBufferSubData_fnptr((uint)target, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
+        public static void ClearBufferSubData(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._glClearBufferSubData_fnptr((uint)target, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
         
         /// <summary> <b>[requires: v3.0]</b> <b>[entry point: <c>glClearBufferuiv</c>]</b><br/> Clear individual buffers of a framebuffer. </summary>
         /// <param name="buffer"> Specify the buffer to clear. </param>
@@ -1235,7 +1235,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="offset"> Specifies the start of the buffer subrange, in basic machine units. </param>
         /// <param name="length"> Specifies the length of the buffer subrange, in basic machine units. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFlushMappedBufferRange.xhtml" /></remarks>
-        public static void FlushMappedBufferRange(BufferTargetARB target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRange_fnptr((uint)target, offset, length);
+        public static void FlushMappedBufferRange(BufferTarget target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRange_fnptr((uint)target, offset, length);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glFlushMappedNamedBufferRange</c>]</b><br/> Indicate modifications to a range of a mapped buffer. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glFlushMappedNamedBufferRange. </param>
@@ -1486,7 +1486,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="index"> Specifies the index of the particular element being queried. </param>
         /// <param name="data"> Returns the value or values of the specified parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGet.xhtml" /></remarks>
-        public static void GetBooleani_v(BufferTargetARB target, uint index, bool* data) => GLPointers._glGetBooleani_v_fnptr((uint)target, index, (byte*)data);
+        public static void GetBooleani_v(BufferTarget target, uint index, bool* data) => GLPointers._glGetBooleani_v_fnptr((uint)target, index, (byte*)data);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glGetBooleanv</c>]</b><br/> Return the value or values of a selected parameter. </summary>
         /// <param name="pname"> Specifies the parameter value to be returned for non-indexed versions of glGet. The symbolic constants in the list below are accepted. </param>
@@ -1499,21 +1499,21 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="value"> Specifies the name of the buffer object parameter to query. </param>
         /// <param name="data"> Returns the requested parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetBufferParameteri64v(BufferTargetARB target, BufferPNameARB pname, long* parameters) => GLPointers._glGetBufferParameteri64v_fnptr((uint)target, (uint)pname, parameters);
+        public static void GetBufferParameteri64v(BufferTarget target, BufferPName pname, long* parameters) => GLPointers._glGetBufferParameteri64v_fnptr((uint)target, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v1.5]</b> <b>[entry point: <c>glGetBufferParameteriv</c>]</b><br/> Return parameters of a buffer object. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glGetBufferParameteriv and glGetBufferParameteri64v. Must be one of the buffer binding targets in the following table: </param>
         /// <param name="value"> Specifies the name of the buffer object parameter to query. </param>
         /// <param name="data"> Returns the requested parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetBufferParameteriv(BufferTargetARB target, BufferPNameARB pname, int* parameters) => GLPointers._glGetBufferParameteriv_fnptr((uint)target, (uint)pname, parameters);
+        public static void GetBufferParameteriv(BufferTarget target, BufferPName pname, int* parameters) => GLPointers._glGetBufferParameteriv_fnptr((uint)target, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v1.5]</b> <b>[entry point: <c>glGetBufferPointerv</c>]</b><br/> Return the pointer to a mapped buffer object&apos;s data store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glGetBufferPointerv, which must be one of the buffer binding targets in the following table: </param>
         /// <param name="pname"> Specifies the name of the pointer to be returned. Must be GL_BUFFER_MAP_POINTER. </param>
         /// <param name="parameters"> Returns the pointer value specified by pname. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferPointerv.xhtml" /></remarks>
-        public static void GetBufferPointerv(BufferTargetARB target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointerv_fnptr((uint)target, (uint)pname, parameters);
+        public static void GetBufferPointerv(BufferTarget target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointerv_fnptr((uint)target, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v1.5]</b> <b>[entry point: <c>glGetBufferSubData</c>]</b><br/> Returns a subset of a buffer object&apos;s data store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glGetBufferSubData, which must be one of the buffer binding targets in the following table: </param>
@@ -1521,7 +1521,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="size"> Specifies the size in bytes of the data store region being returned. </param>
         /// <param name="data"> Specifies a pointer to the location where buffer object data is returned. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferSubData.xhtml" /></remarks>
-        public static void GetBufferSubData(BufferTargetARB target, IntPtr offset, nint size, void* data) => GLPointers._glGetBufferSubData_fnptr((uint)target, offset, size, data);
+        public static void GetBufferSubData(BufferTarget target, IntPtr offset, nint size, void* data) => GLPointers._glGetBufferSubData_fnptr((uint)target, offset, size, data);
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glGetCompressedTexImage</c>]</b><br/> Return a compressed texture image. </summary>
         /// <param name="target">Specifies the target to which the texture is bound for glGetCompressedTexImage and glGetnCompressedTexImage functions. GL_TEXTURE_1D, GL_TEXTURE_1D_ARRAY, GL_TEXTURE_2D, GL_TEXTURE_2D_ARRAY, GL_TEXTURE_3D, GL_TEXTURE_CUBE_MAP_ARRAY, GL_TEXTURE_CUBE_MAP_POSITIVE_X, GL_TEXTURE_CUBE_MAP_NEGATIVE_X, GL_TEXTURE_CUBE_MAP_POSITIVE_Y, GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, GL_TEXTURE_CUBE_MAP_POSITIVE_Z, and GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, GL_TEXTURE_RECTANGLE are accepted.</param>
@@ -1681,14 +1681,14 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname">!!missing documentation!!</param>
         /// <param name="parameters">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetNamedBufferParameteri64v(int buffer, BufferPNameARB pname, long* parameters) => GLPointers._glGetNamedBufferParameteri64v_fnptr(buffer, (uint)pname, parameters);
+        public static void GetNamedBufferParameteri64v(int buffer, BufferPName pname, long* parameters) => GLPointers._glGetNamedBufferParameteri64v_fnptr(buffer, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glGetNamedBufferParameteriv</c>]</b><br/> Return parameters of a buffer object. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferParameteriv and glGetNamedBufferParameteri64v. </param>
         /// <param name="pname">!!missing documentation!!</param>
         /// <param name="parameters">!!missing documentation!!</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetNamedBufferParameteriv(int buffer, BufferPNameARB pname, int* parameters) => GLPointers._glGetNamedBufferParameteriv_fnptr(buffer, (uint)pname, parameters);
+        public static void GetNamedBufferParameteriv(int buffer, BufferPName pname, int* parameters) => GLPointers._glGetNamedBufferParameteriv_fnptr(buffer, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glGetNamedBufferPointerv</c>]</b><br/> Return the pointer to a mapped buffer object&apos;s data store. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferPointerv. </param>
@@ -1824,7 +1824,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="pname">Specifies the object parameter. Accepted symbolic names are GL_DELETE_STATUS, GL_LINK_STATUS, GL_VALIDATE_STATUS, GL_INFO_LOG_LENGTH, GL_ATTACHED_SHADERS, GL_ACTIVE_ATOMIC_COUNTER_BUFFERS, GL_ACTIVE_ATTRIBUTES, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, GL_ACTIVE_UNIFORMS, GL_ACTIVE_UNIFORM_BLOCKS, GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH, GL_ACTIVE_UNIFORM_MAX_LENGTH, GL_COMPUTE_WORK_GROUP_SIZE GL_PROGRAM_BINARY_LENGTH, GL_TRANSFORM_FEEDBACK_BUFFER_MODE, GL_TRANSFORM_FEEDBACK_VARYINGS, GL_TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH, GL_GEOMETRY_VERTICES_OUT, GL_GEOMETRY_INPUT_TYPE, and GL_GEOMETRY_OUTPUT_TYPE.</param>
         /// <param name="parameters">Returns the requested object parameter.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetProgram.xhtml" /></remarks>
-        public static void GetProgramiv(int program, ProgramPropertyARB pname, int* parameters) => GLPointers._glGetProgramiv_fnptr(program, (uint)pname, parameters);
+        public static void GetProgramiv(int program, ProgramProperty pname, int* parameters) => GLPointers._glGetProgramiv_fnptr(program, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v4.1 | GL_ARB_separate_shader_objects]</b> <b>[entry point: <c>glGetProgramPipelineInfoLog</c>]</b><br/> Retrieve the info log string from a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies the name of a program pipeline object from which to retrieve the info log. </param>
@@ -2513,7 +2513,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="target"> Specifies the target to which the buffer object is bound for glMapBuffer, which must be one of the buffer binding targets in the following table: </param>
         /// <param name="access"> Specifies the access policy for glMapBuffer and glMapNamedBuffer, indicating whether it will be possible to read from, write to, or both read from and write to the buffer object&apos;s mapped data store. The symbolic constant must be GL_READ_ONLY, GL_WRITE_ONLY, or GL_READ_WRITE. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBuffer.xhtml" /></remarks>
-        public static void* MapBuffer(BufferTargetARB target, BufferAccessARB access) => GLPointers._glMapBuffer_fnptr((uint)target, (uint)access);
+        public static void* MapBuffer(BufferTarget target, BufferAccess access) => GLPointers._glMapBuffer_fnptr((uint)target, (uint)access);
         
         /// <summary> <b>[requires: v3.0 | GL_ARB_map_buffer_range]</b> <b>[entry point: <c>glMapBufferRange</c>]</b><br/> Map all or part of a buffer object&apos;s data store into the client&apos;s address space. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glMapBufferRange, which must be one of the buffer binding targets in the following table: </param>
@@ -2521,13 +2521,13 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="length"> Specifies the length of the range to be mapped. </param>
         /// <param name="access"> Specifies a combination of access flags indicating the desired access to the mapped range. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBufferRange.xhtml" /></remarks>
-        public static void* MapBufferRange(BufferTargetARB target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRange_fnptr((uint)target, offset, length, (uint)access);
+        public static void* MapBufferRange(BufferTarget target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRange_fnptr((uint)target, offset, length, (uint)access);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glMapNamedBuffer</c>]</b><br/> Map all of a buffer object&apos;s data store into the client&apos;s address space. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBuffer. </param>
         /// <param name="access"> Specifies the access policy for glMapBuffer and glMapNamedBuffer, indicating whether it will be possible to read from, write to, or both read from and write to the buffer object&apos;s mapped data store. The symbolic constant must be GL_READ_ONLY, GL_WRITE_ONLY, or GL_READ_WRITE. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBuffer.xhtml" /></remarks>
-        public static void* MapNamedBuffer(int buffer, BufferAccessARB access) => GLPointers._glMapNamedBuffer_fnptr(buffer, (uint)access);
+        public static void* MapNamedBuffer(int buffer, BufferAccess access) => GLPointers._glMapNamedBuffer_fnptr(buffer, (uint)access);
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glMapNamedBufferRange</c>]</b><br/> Map all or part of a buffer object&apos;s data store into the client&apos;s address space. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBufferRange. </param>
@@ -4063,7 +4063,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <summary> <b>[requires: v1.5]</b> <b>[entry point: <c>glUnmapBuffer</c>]</b><br/> Release the mapping of a buffer object&apos;s data store into the client&apos;s address space. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glUnmapBuffer, which must be one of the buffer binding targets in the following table: </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glUnmapBuffer.xhtml" /></remarks>
-        public static bool UnmapBuffer(BufferTargetARB target) => GLPointers._glUnmapBuffer_fnptr((uint)target) != 0;
+        public static bool UnmapBuffer(BufferTarget target) => GLPointers._glUnmapBuffer_fnptr((uint)target) != 0;
         
         /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glUnmapNamedBuffer</c>]</b><br/> Release the mapping of a buffer object&apos;s data store into the client&apos;s address space. </summary>
         /// <param name="buffer"> Specifies the name of the buffer object for glUnmapNamedBuffer. </param>
@@ -4748,10 +4748,10 @@ namespace OpenTK.Graphics.OpenGL
             public static void BeginPerfMonitorAMD(uint monitor) => GLPointers._glBeginPerfMonitorAMD_fnptr(monitor);
             
             /// <summary> <b>[requires: GL_AMD_draw_buffers_blend]</b> <b>[entry point: <c>glBlendEquationIndexedAMD</c>]</b><br/>  </summary>
-            public static void BlendEquationIndexedAMD(uint buf, BlendEquationModeEXT mode) => GLPointers._glBlendEquationIndexedAMD_fnptr(buf, (uint)mode);
+            public static void BlendEquationIndexedAMD(uint buf, BlendEquationMode mode) => GLPointers._glBlendEquationIndexedAMD_fnptr(buf, (uint)mode);
             
             /// <summary> <b>[requires: GL_AMD_draw_buffers_blend]</b> <b>[entry point: <c>glBlendEquationSeparateIndexedAMD</c>]</b><br/>  </summary>
-            public static void BlendEquationSeparateIndexedAMD(uint buf, BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparateIndexedAMD_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
+            public static void BlendEquationSeparateIndexedAMD(uint buf, BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparateIndexedAMD_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
             
             /// <summary> <b>[requires: GL_AMD_draw_buffers_blend]</b> <b>[entry point: <c>glBlendFuncIndexedAMD</c>]</b><br/>  </summary>
             public static void BlendFuncIndexedAMD(uint buf, All src, All dst) => GLPointers._glBlendFuncIndexedAMD_fnptr(buf, (uint)src, (uint)dst);
@@ -4998,7 +4998,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void FinishObjectAPPLE(ObjectTypeAPPLE obj, int name) => GLPointers._glFinishObjectAPPLE_fnptr((uint)obj, name);
             
             /// <summary> <b>[requires: GL_APPLE_flush_buffer_range]</b> <b>[entry point: <c>glFlushMappedBufferRangeAPPLE</c>]</b><br/>  </summary>
-            public static void FlushMappedBufferRangeAPPLE(BufferTargetARB target, IntPtr offset, nint size) => GLPointers._glFlushMappedBufferRangeAPPLE_fnptr((uint)target, offset, size);
+            public static void FlushMappedBufferRangeAPPLE(BufferTarget target, IntPtr offset, nint size) => GLPointers._glFlushMappedBufferRangeAPPLE_fnptr((uint)target, offset, size);
             
             /// <summary> <b>[requires: GL_APPLE_vertex_array_range]</b> <b>[entry point: <c>glFlushVertexArrayRangeAPPLE</c>]</b><br/>  </summary>
             public static void FlushVertexArrayRangeAPPLE(int length, void* pointer) => GLPointers._glFlushVertexArrayRangeAPPLE_fnptr(length, pointer);
@@ -5096,14 +5096,14 @@ namespace OpenTK.Graphics.OpenGL
             public static void BindAttribLocationARB(GLHandleARB programObj, uint index, byte* name) => GLPointers._glBindAttribLocationARB_fnptr((IntPtr)programObj, index, name);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glBindBufferARB</c>]</b><br/>  </summary>
-            public static void BindBufferARB(BufferTargetARB target, int buffer) => GLPointers._glBindBufferARB_fnptr((uint)target, buffer);
+            public static void BindBufferARB(BufferTarget target, int buffer) => GLPointers._glBindBufferARB_fnptr((uint)target, buffer);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_uniform_buffer_object]</b> <b>[entry point: <c>glBindBufferBase</c>]</b><br/> Bind a buffer object to an indexed buffer target. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
             /// <param name="index"> Specify the index of the binding point within the array specified by target. </param>
             /// <param name="buffer"> The name of a buffer object to bind to the specified binding point. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferBase.xhtml" /></remarks>
-            public static void BindBufferBase(BufferTargetARB target, uint index, int buffer) => GLPointers._glBindBufferBase_fnptr((uint)target, index, buffer);
+            public static void BindBufferBase(BufferTarget target, uint index, int buffer) => GLPointers._glBindBufferBase_fnptr((uint)target, index, buffer);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_uniform_buffer_object]</b> <b>[entry point: <c>glBindBufferRange</c>]</b><br/> Bind a range within a buffer object to an indexed buffer target. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER, or GL_SHADER_STORAGE_BUFFER. </param>
@@ -5112,7 +5112,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="offset"> The starting offset in basic machine units into the buffer object buffer. </param>
             /// <param name="size"> The amount of data in machine units that can be read from the buffer object while used as an indexed target. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBufferRange.xhtml" /></remarks>
-            public static void BindBufferRange(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRange_fnptr((uint)target, index, buffer, offset, size);
+            public static void BindBufferRange(BufferTarget target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRange_fnptr((uint)target, index, buffer, offset, size);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> <b>[entry point: <c>glBindBuffersBase</c>]</b><br/> Bind one or more buffer objects to a sequence of indexed buffer targets. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -5120,7 +5120,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="count"> Specify the number of contiguous binding points to which to bind buffers. </param>
             /// <param name="buffers"> A pointer to an array of names of buffer objects to bind to the targets on the specified binding point, or NULL. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersBase.xhtml" /></remarks>
-            public static void BindBuffersBase(BufferTargetARB target, uint first, int count, int* buffers) => GLPointers._glBindBuffersBase_fnptr((uint)target, first, count, buffers);
+            public static void BindBuffersBase(BufferTarget target, uint first, int count, int* buffers) => GLPointers._glBindBuffersBase_fnptr((uint)target, first, count, buffers);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> <b>[entry point: <c>glBindBuffersRange</c>]</b><br/> Bind ranges of one or more buffer objects to a sequence of indexed buffer targets. </summary>
             /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER, GL_UNIFORM_BUFFER or GL_SHADER_STORAGE_BUFFER. </param>
@@ -5130,7 +5130,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="offsets"> A pointer to an array of offsets into the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
             /// <param name="sizes"> A pointer to an array of sizes of the corresponding buffer in buffers to bind, or NULL if buffers is NULL. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindBuffersRange.xhtml" /></remarks>
-            public static void BindBuffersRange(BufferTargetARB target, uint first, int count, int* buffers, IntPtr* offsets, nint* sizes) => GLPointers._glBindBuffersRange_fnptr((uint)target, first, count, buffers, offsets, sizes);
+            public static void BindBuffersRange(BufferTarget target, uint first, int count, int* buffers, IntPtr* offsets, nint* sizes) => GLPointers._glBindBuffersRange_fnptr((uint)target, first, count, buffers, offsets, sizes);
             
             /// <summary> <b>[requires: v3.3 | GL_ARB_blend_func_extended]</b> <b>[entry point: <c>glBindFragDataLocationIndexed</c>]</b><br/> Bind a user-defined varying out variable to a fragment shader color number and index. </summary>
             /// <param name="program"> The name of the program containing varying out variable whose binding to modify </param>
@@ -5155,7 +5155,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
             /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted stores. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindImageTexture.xhtml" /></remarks>
-            public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._glBindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
+            public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccess access, InternalFormat format) => GLPointers._glBindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
             
             /// <summary> <b>[requires: v4.4 | GL_ARB_multi_bind]</b> <b>[entry point: <c>glBindImageTextures</c>]</b><br/> Bind one or more named texture images to a sequence of consecutive image units. </summary>
             /// <param name="first"> Specifies the first image unit to which a texture is to be bound. </param>
@@ -5243,13 +5243,13 @@ namespace OpenTK.Graphics.OpenGL
             /// <summary> <b>[requires: v1.4 | GL_ARB_imaging]</b> <b>[entry point: <c>glBlendEquation</c>]</b><br/> Specify the equation used for both the RGB blend equation and the Alpha blend equation. </summary>
             /// <param name="mode"> specifies how source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml" /></remarks>
-            public static void BlendEquation(BlendEquationModeEXT mode) => GLPointers._glBlendEquation_fnptr((uint)mode);
+            public static void BlendEquation(BlendEquationMode mode) => GLPointers._glBlendEquation_fnptr((uint)mode);
             
             /// <summary> <b>[requires: GL_ARB_draw_buffers_blend]</b> <b>[entry point: <c>glBlendEquationiARB</c>]</b><br/>  </summary>
-            public static void BlendEquationiARB(uint buf, BlendEquationModeEXT mode) => GLPointers._glBlendEquationiARB_fnptr(buf, (uint)mode);
+            public static void BlendEquationiARB(uint buf, BlendEquationMode mode) => GLPointers._glBlendEquationiARB_fnptr(buf, (uint)mode);
             
             /// <summary> <b>[requires: GL_ARB_draw_buffers_blend]</b> <b>[entry point: <c>glBlendEquationSeparateiARB</c>]</b><br/>  </summary>
-            public static void BlendEquationSeparateiARB(uint buf, BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparateiARB_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
+            public static void BlendEquationSeparateiARB(uint buf, BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparateiARB_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
             
             /// <summary> <b>[requires: GL_ARB_draw_buffers_blend]</b> <b>[entry point: <c>glBlendFunciARB</c>]</b><br/>  </summary>
             public static void BlendFunciARB(uint buf, BlendingFactor src, BlendingFactor dst) => GLPointers._glBlendFunciARB_fnptr(buf, (uint)src, (uint)dst);
@@ -5288,7 +5288,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void BlitNamedFramebuffer(int readFramebuffer, int drawFramebuffer, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter) => GLPointers._glBlitNamedFramebuffer_fnptr(readFramebuffer, drawFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, (uint)mask, (uint)filter);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glBufferDataARB</c>]</b><br/>  </summary>
-            public static void BufferDataARB(BufferTargetARB target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferDataARB_fnptr((uint)target, size, data, (uint)usage);
+            public static void BufferDataARB(BufferTarget target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferDataARB_fnptr((uint)target, size, data, (uint)usage);
             
             /// <summary> <b>[requires: GL_ARB_sparse_buffer]</b> <b>[entry point: <c>glBufferPageCommitmentARB</c>]</b><br/>  </summary>
             public static void BufferPageCommitmentARB(All target, IntPtr offset, nint size, bool commit) => GLPointers._glBufferPageCommitmentARB_fnptr((uint)target, offset, size, (byte)(commit ? 1 : 0));
@@ -5302,7 +5302,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void BufferStorage(BufferStorageTarget target, nint size, void* data, BufferStorageMask flags) => GLPointers._glBufferStorage_fnptr((uint)target, size, data, (uint)flags);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glBufferSubDataARB</c>]</b><br/>  </summary>
-            public static void BufferSubDataARB(BufferTargetARB target, IntPtr offset, nint size, void* data) => GLPointers._glBufferSubDataARB_fnptr((uint)target, offset, size, data);
+            public static void BufferSubDataARB(BufferTarget target, IntPtr offset, nint size, void* data) => GLPointers._glBufferSubDataARB_fnptr((uint)target, offset, size, data);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_framebuffer_object]</b> <b>[entry point: <c>glCheckFramebufferStatus</c>]</b><br/> Check the completeness status of a framebuffer. </summary>
             /// <param name="target"> Specify the target to which the framebuffer is bound for glCheckFramebufferStatus, and the target against which framebuffer completeness of framebuffer is checked for glCheckNamedFramebufferStatus. </param>
@@ -5336,7 +5336,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="type"> The type of the data in memory addressed by data. </param>
             /// <param name="data"> The address of a memory location storing the data to be replicated into the buffer&apos;s data store. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBufferSubData.xhtml" /></remarks>
-            public static void ClearBufferSubData(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._glClearBufferSubData_fnptr((uint)target, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
+            public static void ClearBufferSubData(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, void* data) => GLPointers._glClearBufferSubData_fnptr((uint)target, (uint)internalformat, offset, size, (uint)format, (uint)type, data);
             
             /// <summary> <b>[requires: v4.1 | GL_ARB_ES2_compatibility]</b> <b>[entry point: <c>glClearDepthf</c>]</b><br/> Specify the clear value for the depth buffer. </summary>
             /// <param name="depth"> Specifies the depth value used when the depth buffer is cleared. The initial value is 1. </param>
@@ -5960,7 +5960,7 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="offset"> Specifies the start of the buffer subrange, in basic machine units. </param>
             /// <param name="length"> Specifies the length of the buffer subrange, in basic machine units. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFlushMappedBufferRange.xhtml" /></remarks>
-            public static void FlushMappedBufferRange(BufferTargetARB target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRange_fnptr((uint)target, offset, length);
+            public static void FlushMappedBufferRange(BufferTarget target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRange_fnptr((uint)target, offset, length);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glFlushMappedNamedBufferRange</c>]</b><br/> Indicate modifications to a range of a mapped buffer. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glFlushMappedNamedBufferRange. </param>
@@ -6173,13 +6173,13 @@ namespace OpenTK.Graphics.OpenGL
             public static int GetAttribLocationARB(GLHandleARB programObj, byte* name) => GLPointers._glGetAttribLocationARB_fnptr((IntPtr)programObj, name);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glGetBufferParameterivARB</c>]</b><br/>  </summary>
-            public static void GetBufferParameterivARB(BufferTargetARB target, BufferPNameARB pname, int* parameters) => GLPointers._glGetBufferParameterivARB_fnptr((uint)target, (uint)pname, parameters);
+            public static void GetBufferParameterivARB(BufferTarget target, BufferPName pname, int* parameters) => GLPointers._glGetBufferParameterivARB_fnptr((uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glGetBufferPointervARB</c>]</b><br/>  </summary>
-            public static void GetBufferPointervARB_(BufferTargetARB target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointervARB_fnptr((uint)target, (uint)pname, parameters);
+            public static void GetBufferPointervARB_(BufferTarget target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointervARB_fnptr((uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glGetBufferSubDataARB</c>]</b><br/>  </summary>
-            public static void GetBufferSubDataARB(BufferTargetARB target, IntPtr offset, nint size, void* data) => GLPointers._glGetBufferSubDataARB_fnptr((uint)target, offset, size, data);
+            public static void GetBufferSubDataARB(BufferTarget target, IntPtr offset, nint size, void* data) => GLPointers._glGetBufferSubDataARB_fnptr((uint)target, offset, size, data);
             
             /// <summary> <b>[requires: GL_ARB_imaging]</b> <b>[entry point: <c>glGetColorTable</c>]</b><br/>  </summary>
             public static void GetColorTable(ColorTableTarget target, PixelFormat format, PixelType type, void* table) => GLPointers._glGetColorTable_fnptr((uint)target, (uint)format, (uint)type, table);
@@ -6335,14 +6335,14 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="pname">!!missing documentation!!</param>
             /// <param name="parameters">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-            public static void GetNamedBufferParameteri64v(int buffer, BufferPNameARB pname, long* parameters) => GLPointers._glGetNamedBufferParameteri64v_fnptr(buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameteri64v(int buffer, BufferPName pname, long* parameters) => GLPointers._glGetNamedBufferParameteri64v_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glGetNamedBufferParameteriv</c>]</b><br/> Return parameters of a buffer object. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferParameteriv and glGetNamedBufferParameteri64v. </param>
             /// <param name="pname">!!missing documentation!!</param>
             /// <param name="parameters">!!missing documentation!!</param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetBufferParameter.xhtml" /></remarks>
-            public static void GetNamedBufferParameteriv(int buffer, BufferPNameARB pname, int* parameters) => GLPointers._glGetNamedBufferParameteriv_fnptr(buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameteriv(int buffer, BufferPName pname, int* parameters) => GLPointers._glGetNamedBufferParameteriv_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glGetNamedBufferPointerv</c>]</b><br/> Return the pointer to a mapped buffer object&apos;s data store. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glGetNamedBufferPointerv. </param>
@@ -6477,7 +6477,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void GetProgramInterfaceiv(int program, ProgramInterface programInterface, ProgramInterfacePName pname, int* parameters) => GLPointers._glGetProgramInterfaceiv_fnptr(program, (uint)programInterface, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b> <b>[entry point: <c>glGetProgramivARB</c>]</b><br/>  </summary>
-            public static void GetProgramivARB(ProgramTarget target, ProgramPropertyARB pname, int* parameters) => GLPointers._glGetProgramivARB_fnptr((uint)target, (uint)pname, parameters);
+            public static void GetProgramivARB(ProgramTarget target, ProgramProperty pname, int* parameters) => GLPointers._glGetProgramivARB_fnptr((uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_ARB_fragment_program | GL_ARB_vertex_program]</b> <b>[entry point: <c>glGetProgramLocalParameterdvARB</c>]</b><br/>  </summary>
             public static void GetProgramLocalParameterdvARB(ProgramTarget target, uint index, double* parameters) => GLPointers._glGetProgramLocalParameterdvARB_fnptr((uint)target, index, parameters);
@@ -7020,7 +7020,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void MakeTextureHandleResidentARB(ulong handle) => GLPointers._glMakeTextureHandleResidentARB_fnptr(handle);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glMapBufferARB</c>]</b><br/>  </summary>
-            public static void* MapBufferARB(BufferTargetARB target, BufferAccessARB access) => GLPointers._glMapBufferARB_fnptr((uint)target, (uint)access);
+            public static void* MapBufferARB(BufferTarget target, BufferAccess access) => GLPointers._glMapBufferARB_fnptr((uint)target, (uint)access);
             
             /// <summary> <b>[requires: v3.0 | GL_ARB_map_buffer_range]</b> <b>[entry point: <c>glMapBufferRange</c>]</b><br/> Map all or part of a buffer object&apos;s data store into the client&apos;s address space. </summary>
             /// <param name="target"> Specifies the target to which the buffer object is bound for glMapBufferRange, which must be one of the buffer binding targets in the following table: </param>
@@ -7028,13 +7028,13 @@ namespace OpenTK.Graphics.OpenGL
             /// <param name="length"> Specifies the length of the range to be mapped. </param>
             /// <param name="access"> Specifies a combination of access flags indicating the desired access to the mapped range. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBufferRange.xhtml" /></remarks>
-            public static void* MapBufferRange(BufferTargetARB target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRange_fnptr((uint)target, offset, length, (uint)access);
+            public static void* MapBufferRange(BufferTarget target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRange_fnptr((uint)target, offset, length, (uint)access);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glMapNamedBuffer</c>]</b><br/> Map all of a buffer object&apos;s data store into the client&apos;s address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBuffer. </param>
             /// <param name="access"> Specifies the access policy for glMapBuffer and glMapNamedBuffer, indicating whether it will be possible to read from, write to, or both read from and write to the buffer object&apos;s mapped data store. The symbolic constant must be GL_READ_ONLY, GL_WRITE_ONLY, or GL_READ_WRITE. </param>
             /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBuffer.xhtml" /></remarks>
-            public static void* MapNamedBuffer(int buffer, BufferAccessARB access) => GLPointers._glMapNamedBuffer_fnptr(buffer, (uint)access);
+            public static void* MapNamedBuffer(int buffer, BufferAccess access) => GLPointers._glMapNamedBuffer_fnptr(buffer, (uint)access);
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glMapNamedBufferRange</c>]</b><br/> Map all or part of a buffer object&apos;s data store into the client&apos;s address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glMapNamedBufferRange. </param>
@@ -8412,7 +8412,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void UniformSubroutinesuiv(ShaderType shadertype, int count, uint* indices) => GLPointers._glUniformSubroutinesuiv_fnptr((uint)shadertype, count, indices);
             
             /// <summary> <b>[requires: GL_ARB_vertex_buffer_object]</b> <b>[entry point: <c>glUnmapBufferARB</c>]</b><br/>  </summary>
-            public static bool UnmapBufferARB(BufferTargetARB target) => GLPointers._glUnmapBufferARB_fnptr((uint)target) != 0;
+            public static bool UnmapBufferARB(BufferTarget target) => GLPointers._glUnmapBufferARB_fnptr((uint)target) != 0;
             
             /// <summary> <b>[requires: v4.5 | GL_ARB_direct_state_access]</b> <b>[entry point: <c>glUnmapNamedBuffer</c>]</b><br/> Release the mapping of a buffer object&apos;s data store into the client&apos;s address space. </summary>
             /// <param name="buffer"> Specifies the name of the buffer object for glUnmapNamedBuffer. </param>
@@ -9193,13 +9193,13 @@ namespace OpenTK.Graphics.OpenGL
             public static void BeginVertexShaderEXT() => GLPointers._glBeginVertexShaderEXT_fnptr();
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b> <b>[entry point: <c>glBindBufferBaseEXT</c>]</b><br/>  </summary>
-            public static void BindBufferBaseEXT(BufferTargetARB target, uint index, int buffer) => GLPointers._glBindBufferBaseEXT_fnptr((uint)target, index, buffer);
+            public static void BindBufferBaseEXT(BufferTarget target, uint index, int buffer) => GLPointers._glBindBufferBaseEXT_fnptr((uint)target, index, buffer);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b> <b>[entry point: <c>glBindBufferOffsetEXT</c>]</b><br/>  </summary>
-            public static void BindBufferOffsetEXT(BufferTargetARB target, uint index, int buffer, IntPtr offset) => GLPointers._glBindBufferOffsetEXT_fnptr((uint)target, index, buffer, offset);
+            public static void BindBufferOffsetEXT(BufferTarget target, uint index, int buffer, IntPtr offset) => GLPointers._glBindBufferOffsetEXT_fnptr((uint)target, index, buffer, offset);
             
             /// <summary> <b>[requires: GL_EXT_transform_feedback]</b> <b>[entry point: <c>glBindBufferRangeEXT</c>]</b><br/>  </summary>
-            public static void BindBufferRangeEXT(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRangeEXT_fnptr((uint)target, index, buffer, offset, size);
+            public static void BindBufferRangeEXT(BufferTarget target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRangeEXT_fnptr((uint)target, index, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_EXT_gpu_shader4]</b> <b>[entry point: <c>glBindFragDataLocationEXT</c>]</b><br/>  </summary>
             public static void BindFragDataLocationEXT(int program, uint color, byte* name) => GLPointers._glBindFragDataLocationEXT_fnptr(program, color, name);
@@ -9208,7 +9208,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void BindFramebufferEXT(FramebufferTarget target, int framebuffer) => GLPointers._glBindFramebufferEXT_fnptr((uint)target, framebuffer);
             
             /// <summary> <b>[requires: GL_EXT_shader_image_load_store]</b> <b>[entry point: <c>glBindImageTextureEXT</c>]</b><br/>  </summary>
-            public static void BindImageTextureEXT(uint index, int texture, int level, bool layered, int layer, BufferAccessARB access, int format) => GLPointers._glBindImageTextureEXT_fnptr(index, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, format);
+            public static void BindImageTextureEXT(uint index, int texture, int level, bool layered, int layer, BufferAccess access, int format) => GLPointers._glBindImageTextureEXT_fnptr(index, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, format);
             
             /// <summary> <b>[requires: GL_EXT_vertex_shader]</b> <b>[entry point: <c>glBindLightParameterEXT</c>]</b><br/>  </summary>
             public static uint BindLightParameterEXT(LightName light, LightParameter value) => GLPointers._glBindLightParameterEXT_fnptr((uint)light, (uint)value);
@@ -9277,10 +9277,10 @@ namespace OpenTK.Graphics.OpenGL
             public static void BlendColorEXT(float red, float green, float blue, float alpha) => GLPointers._glBlendColorEXT_fnptr(red, green, blue, alpha);
             
             /// <summary> <b>[requires: GL_EXT_blend_minmax]</b> <b>[entry point: <c>glBlendEquationEXT</c>]</b><br/>  </summary>
-            public static void BlendEquationEXT(BlendEquationModeEXT mode) => GLPointers._glBlendEquationEXT_fnptr((uint)mode);
+            public static void BlendEquationEXT(BlendEquationMode mode) => GLPointers._glBlendEquationEXT_fnptr((uint)mode);
             
             /// <summary> <b>[requires: GL_EXT_blend_equation_separate]</b> <b>[entry point: <c>glBlendEquationSeparateEXT</c>]</b><br/>  </summary>
-            public static void BlendEquationSeparateEXT(BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparateEXT_fnptr((uint)modeRGB, (uint)modeAlpha);
+            public static void BlendEquationSeparateEXT(BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparateEXT_fnptr((uint)modeRGB, (uint)modeAlpha);
             
             /// <summary> <b>[requires: GL_EXT_blend_func_separate]</b> <b>[entry point: <c>glBlendFuncSeparateEXT</c>]</b><br/>  </summary>
             public static void BlendFuncSeparateEXT(BlendingFactor sfactorRGB, BlendingFactor dfactorRGB, BlendingFactor sfactorAlpha, BlendingFactor dfactorAlpha) => GLPointers._glBlendFuncSeparateEXT_fnptr((uint)sfactorRGB, (uint)dfactorRGB, (uint)sfactorAlpha, (uint)dfactorAlpha);
@@ -9298,7 +9298,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void BufferStorageExternalEXT(All target, IntPtr offset, nint size, void* clientBuffer, BufferStorageMask flags) => GLPointers._glBufferStorageExternalEXT_fnptr((uint)target, offset, size, clientBuffer, (uint)flags);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b> <b>[entry point: <c>glBufferStorageMemEXT</c>]</b><br/>  </summary>
-            public static void BufferStorageMemEXT(BufferTargetARB target, nint size, uint memory, ulong offset) => GLPointers._glBufferStorageMemEXT_fnptr((uint)target, size, memory, offset);
+            public static void BufferStorageMemEXT(BufferTarget target, nint size, uint memory, ulong offset) => GLPointers._glBufferStorageMemEXT_fnptr((uint)target, size, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_framebuffer_object]</b> <b>[entry point: <c>glCheckFramebufferStatusEXT</c>]</b><br/>  </summary>
             public static FramebufferStatus CheckFramebufferStatusEXT(FramebufferTarget target) => (FramebufferStatus) GLPointers._glCheckFramebufferStatusEXT_fnptr((uint)target);
@@ -9622,7 +9622,7 @@ namespace OpenTK.Graphics.OpenGL
             public static uint GenVertexShadersEXT(uint range) => GLPointers._glGenVertexShadersEXT_fnptr(range);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access | GL_EXT_draw_buffers2]</b> <b>[entry point: <c>glGetBooleanIndexedvEXT</c>]</b><br/>  </summary>
-            public static void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, bool* data) => GLPointers._glGetBooleanIndexedvEXT_fnptr((uint)target, index, (byte*)data);
+            public static void GetBooleanIndexedvEXT(BufferTarget target, uint index, bool* data) => GLPointers._glGetBooleanIndexedvEXT_fnptr((uint)target, index, (byte*)data);
             
             /// <summary> <b>[requires: GL_EXT_paletted_texture]</b> <b>[entry point: <c>glGetColorTableEXT</c>]</b><br/>  </summary>
             public static void GetColorTableEXT(ColorTableTarget target, PixelFormat format, PixelType type, void* data) => GLPointers._glGetColorTableEXT_fnptr((uint)target, (uint)format, (uint)type, data);
@@ -9748,7 +9748,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void GetMultiTexParameterivEXT(TextureUnit texunit, TextureTarget target, GetTextureParameter pname, int* parameters) => GLPointers._glGetMultiTexParameterivEXT_fnptr((uint)texunit, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b> <b>[entry point: <c>glGetNamedBufferParameterivEXT</c>]</b><br/>  </summary>
-            public static void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, int* parameters) => GLPointers._glGetNamedBufferParameterivEXT_fnptr(buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameterivEXT(int buffer, BufferPName pname, int* parameters) => GLPointers._glGetNamedBufferParameterivEXT_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b> <b>[entry point: <c>glGetNamedBufferPointervEXT</c>]</b><br/>  </summary>
             public static void GetNamedBufferPointervEXT_(int buffer, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetNamedBufferPointervEXT_fnptr(buffer, (uint)pname, parameters);
@@ -9763,7 +9763,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void GetNamedFramebufferParameterivEXT(int framebuffer, GetFramebufferParameter pname, int* parameters) => GLPointers._glGetNamedFramebufferParameterivEXT_fnptr(framebuffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b> <b>[entry point: <c>glGetNamedProgramivEXT</c>]</b><br/>  </summary>
-            public static void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, int* parameters) => GLPointers._glGetNamedProgramivEXT_fnptr(program, (uint)target, (uint)pname, parameters);
+            public static void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramProperty pname, int* parameters) => GLPointers._glGetNamedProgramivEXT_fnptr(program, (uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b> <b>[entry point: <c>glGetNamedProgramLocalParameterdvEXT</c>]</b><br/>  </summary>
             public static void GetNamedProgramLocalParameterdvEXT(int program, ProgramTarget target, uint index, double* parameters) => GLPointers._glGetNamedProgramLocalParameterdvEXT_fnptr(program, (uint)target, index, parameters);
@@ -9970,7 +9970,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void LockArraysEXT(int first, int count) => GLPointers._glLockArraysEXT_fnptr(first, count);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b> <b>[entry point: <c>glMapNamedBufferEXT</c>]</b><br/>  </summary>
-            public static void* MapNamedBufferEXT(int buffer, BufferAccessARB access) => GLPointers._glMapNamedBufferEXT_fnptr(buffer, (uint)access);
+            public static void* MapNamedBufferEXT(int buffer, BufferAccess access) => GLPointers._glMapNamedBufferEXT_fnptr(buffer, (uint)access);
             
             /// <summary> <b>[requires: GL_EXT_direct_state_access]</b> <b>[entry point: <c>glMapNamedBufferRangeEXT</c>]</b><br/>  </summary>
             public static void* MapNamedBufferRangeEXT(int buffer, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapNamedBufferRangeEXT_fnptr(buffer, offset, length, (uint)access);
@@ -11354,13 +11354,13 @@ namespace OpenTK.Graphics.OpenGL
             public static void BeginVideoCaptureNV(uint video_capture_slot) => GLPointers._glBeginVideoCaptureNV_fnptr(video_capture_slot);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b> <b>[entry point: <c>glBindBufferBaseNV</c>]</b><br/>  </summary>
-            public static void BindBufferBaseNV(BufferTargetARB target, uint index, int buffer) => GLPointers._glBindBufferBaseNV_fnptr((uint)target, index, buffer);
+            public static void BindBufferBaseNV(BufferTarget target, uint index, int buffer) => GLPointers._glBindBufferBaseNV_fnptr((uint)target, index, buffer);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b> <b>[entry point: <c>glBindBufferOffsetNV</c>]</b><br/>  </summary>
-            public static void BindBufferOffsetNV(BufferTargetARB target, uint index, int buffer, IntPtr offset) => GLPointers._glBindBufferOffsetNV_fnptr((uint)target, index, buffer, offset);
+            public static void BindBufferOffsetNV(BufferTarget target, uint index, int buffer, IntPtr offset) => GLPointers._glBindBufferOffsetNV_fnptr((uint)target, index, buffer, offset);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback]</b> <b>[entry point: <c>glBindBufferRangeNV</c>]</b><br/>  </summary>
-            public static void BindBufferRangeNV(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRangeNV_fnptr((uint)target, index, buffer, offset, size);
+            public static void BindBufferRangeNV(BufferTarget target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRangeNV_fnptr((uint)target, index, buffer, offset, size);
             
             /// <summary> <b>[requires: GL_NV_vertex_program]</b> <b>[entry point: <c>glBindProgramNV</c>]</b><br/>  </summary>
             public static void BindProgramNV(VertexAttribEnumNV target, int id) => GLPointers._glBindProgramNV_fnptr((uint)target, id);
@@ -11369,7 +11369,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void BindShadingRateImageNV(int texture) => GLPointers._glBindShadingRateImageNV_fnptr(texture);
             
             /// <summary> <b>[requires: GL_NV_transform_feedback2]</b> <b>[entry point: <c>glBindTransformFeedbackNV</c>]</b><br/>  </summary>
-            public static void BindTransformFeedbackNV(BufferTargetARB target, int id) => GLPointers._glBindTransformFeedbackNV_fnptr((uint)target, id);
+            public static void BindTransformFeedbackNV(BufferTarget target, int id) => GLPointers._glBindTransformFeedbackNV_fnptr((uint)target, id);
             
             /// <summary> <b>[requires: GL_NV_video_capture]</b> <b>[entry point: <c>glBindVideoCaptureStreamBufferNV</c>]</b><br/>  </summary>
             public static void BindVideoCaptureStreamBufferNV(uint video_capture_slot, uint stream, All frame_region, IntPtr offset) => GLPointers._glBindVideoCaptureStreamBufferNV_fnptr(video_capture_slot, stream, (uint)frame_region, offset);
@@ -11387,7 +11387,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void BufferAddressRangeNV(All pname, uint index, ulong address, nint length) => GLPointers._glBufferAddressRangeNV_fnptr((uint)pname, index, address, length);
             
             /// <summary> <b>[requires: GL_NV_memory_attachment]</b> <b>[entry point: <c>glBufferAttachMemoryNV</c>]</b><br/>  </summary>
-            public static void BufferAttachMemoryNV(BufferTargetARB target, uint memory, ulong offset) => GLPointers._glBufferAttachMemoryNV_fnptr((uint)target, memory, offset);
+            public static void BufferAttachMemoryNV(BufferTarget target, uint memory, ulong offset) => GLPointers._glBufferAttachMemoryNV_fnptr((uint)target, memory, offset);
             
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b> <b>[entry point: <c>glBufferPageCommitmentMemNV</c>]</b><br/>  </summary>
             public static void BufferPageCommitmentMemNV(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => GLPointers._glBufferPageCommitmentMemNV_fnptr((uint)target, offset, size, memory, memOffset, (byte)(commit ? 1 : 0));
@@ -11615,7 +11615,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void GetActiveVaryingNV(int program, uint index, int bufSize, int* length, int* size, All* type, byte* name) => GLPointers._glGetActiveVaryingNV_fnptr(program, index, bufSize, length, size, (uint*)type, name);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b> <b>[entry point: <c>glGetBufferParameterui64vNV</c>]</b><br/>  </summary>
-            public static void GetBufferParameterui64vNV(BufferTargetARB target, All pname, ulong* parameters) => GLPointers._glGetBufferParameterui64vNV_fnptr((uint)target, (uint)pname, parameters);
+            public static void GetBufferParameterui64vNV(BufferTarget target, All pname, ulong* parameters) => GLPointers._glGetBufferParameterui64vNV_fnptr((uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_NV_register_combiners]</b> <b>[entry point: <c>glGetCombinerInputParameterfvNV</c>]</b><br/>  </summary>
             public static void GetCombinerInputParameterfvNV(CombinerStageNV stage, CombinerPortionNV portion, CombinerVariableNV variable, CombinerParameterNV pname, float* parameters) => GLPointers._glGetCombinerInputParameterfvNV_fnptr((uint)stage, (uint)portion, (uint)variable, (uint)pname, parameters);
@@ -11681,7 +11681,7 @@ namespace OpenTK.Graphics.OpenGL
             public static void GetMultisamplefvNV(GetMultisamplePNameNV pname, uint index, float* val) => GLPointers._glGetMultisamplefvNV_fnptr((uint)pname, index, val);
             
             /// <summary> <b>[requires: GL_NV_shader_buffer_load]</b> <b>[entry point: <c>glGetNamedBufferParameterui64vNV</c>]</b><br/>  </summary>
-            public static void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, ulong* parameters) => GLPointers._glGetNamedBufferParameterui64vNV_fnptr(buffer, (uint)pname, parameters);
+            public static void GetNamedBufferParameterui64vNV(int buffer, BufferPName pname, ulong* parameters) => GLPointers._glGetNamedBufferParameterui64vNV_fnptr(buffer, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_NV_occlusion_query]</b> <b>[entry point: <c>glGetOcclusionQueryivNV</c>]</b><br/>  </summary>
             public static void GetOcclusionQueryivNV(uint id, OcclusionQueryParameterNameNV pname, int* parameters) => GLPointers._glGetOcclusionQueryivNV_fnptr(id, (uint)pname, parameters);

--- a/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -212,14 +212,14 @@ namespace OpenTK.Graphics.OpenGL
                 BindVertexBuffers(first, count, buffers_ptr, offsets_ptr, strides_ptr);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData(BufferTarget target, nint size, IntPtr data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData(BufferTarget target, nint size, IntPtr data, BufferUsage usage)
         {
             void* data_vptr = (void*)data;
             BufferData(target, size, data_vptr, usage);
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsage usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -228,8 +228,8 @@ namespace OpenTK.Graphics.OpenGL
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTarget target, T1[] data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, T1[] data, BufferUsage usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -238,8 +238,8 @@ namespace OpenTK.Graphics.OpenGL
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTarget target, nint size, in T1 data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, nint size, in T1 data, BufferUsage usage)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -13481,14 +13481,14 @@ namespace OpenTK.Graphics.OpenGL
                     BindVertexBuffers(first, count, buffers_ptr, offsets_ptr, strides_ptr);
                 }
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB(BufferTarget target, nint size, IntPtr data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsage)"/>
+            public static unsafe void BufferDataARB(BufferTarget target, nint size, IntPtr data, BufferUsage usage)
             {
                 void* data_vptr = (void*)data;
                 BufferDataARB(target, size, data_vptr, usage);
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsage)"/>
+            public static unsafe void BufferDataARB<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsage usage)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -13497,8 +13497,8 @@ namespace OpenTK.Graphics.OpenGL
                     BufferDataARB(target, size, data_ptr, usage);
                 }
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB<T1>(BufferTarget target, T1[] data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsage)"/>
+            public static unsafe void BufferDataARB<T1>(BufferTarget target, T1[] data, BufferUsage usage)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -13507,8 +13507,8 @@ namespace OpenTK.Graphics.OpenGL
                     BufferDataARB(target, size, data_ptr, usage);
                 }
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB<T1>(BufferTarget target, nint size, in T1 data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsage)"/>
+            public static unsafe void BufferDataARB<T1>(BufferTarget target, nint size, in T1 data, BufferUsage usage)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)

--- a/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:49 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -18,8 +18,8 @@ namespace OpenTK.Graphics.OpenGL
             BindAttribLocation(program, index, name_ptr);
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
         }
-        /// <inheritdoc cref="BindBuffersBase(BufferTargetARB, uint, int, int*)"/>
-        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, ReadOnlySpan<int> buffers)
+        /// <inheritdoc cref="BindBuffersBase(BufferTarget, uint, int, int*)"/>
+        public static unsafe void BindBuffersBase(BufferTarget target, uint first, ReadOnlySpan<int> buffers)
         {
             int count = (int)(buffers.Length);
             fixed (int* buffers_ptr = buffers)
@@ -27,8 +27,8 @@ namespace OpenTK.Graphics.OpenGL
                 BindBuffersBase(target, first, count, buffers_ptr);
             }
         }
-        /// <inheritdoc cref="BindBuffersBase(BufferTargetARB, uint, int, int*)"/>
-        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int[] buffers)
+        /// <inheritdoc cref="BindBuffersBase(BufferTarget, uint, int, int*)"/>
+        public static unsafe void BindBuffersBase(BufferTarget target, uint first, int[] buffers)
         {
             int count = (int)(buffers.Length);
             fixed (int* buffers_ptr = buffers)
@@ -36,16 +36,16 @@ namespace OpenTK.Graphics.OpenGL
                 BindBuffersBase(target, first, count, buffers_ptr);
             }
         }
-        /// <inheritdoc cref="BindBuffersBase(BufferTargetARB, uint, int, int*)"/>
-        public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int count, in int buffers)
+        /// <inheritdoc cref="BindBuffersBase(BufferTarget, uint, int, int*)"/>
+        public static unsafe void BindBuffersBase(BufferTarget target, uint first, int count, in int buffers)
         {
             fixed (int* buffers_ptr = &buffers)
             {
                 BindBuffersBase(target, first, count, buffers_ptr);
             }
         }
-        /// <inheritdoc cref="BindBuffersRange(BufferTargetARB, uint, int, int*, IntPtr*, nint*)"/>
-        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
+        /// <inheritdoc cref="BindBuffersRange(BufferTarget, uint, int, int*, IntPtr*, nint*)"/>
+        public static unsafe void BindBuffersRange(BufferTarget target, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
         {
             fixed (int* buffers_ptr = buffers)
             {
@@ -58,8 +58,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
         }
-        /// <inheritdoc cref="BindBuffersRange(BufferTargetARB, uint, int, int*, IntPtr*, nint*)"/>
-        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, int[] buffers, IntPtr[] offsets, nint[] sizes)
+        /// <inheritdoc cref="BindBuffersRange(BufferTarget, uint, int, int*, IntPtr*, nint*)"/>
+        public static unsafe void BindBuffersRange(BufferTarget target, uint first, int count, int[] buffers, IntPtr[] offsets, nint[] sizes)
         {
             fixed (int* buffers_ptr = buffers)
             {
@@ -72,8 +72,8 @@ namespace OpenTK.Graphics.OpenGL
                 }
             }
         }
-        /// <inheritdoc cref="BindBuffersRange(BufferTargetARB, uint, int, int*, IntPtr*, nint*)"/>
-        public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, in int buffers, in IntPtr offsets, in nint sizes)
+        /// <inheritdoc cref="BindBuffersRange(BufferTarget, uint, int, int*, IntPtr*, nint*)"/>
+        public static unsafe void BindBuffersRange(BufferTarget target, uint first, int count, in int buffers, in IntPtr offsets, in nint sizes)
         {
             fixed (int* buffers_ptr = &buffers)
             fixed (IntPtr* offsets_ptr = &offsets)
@@ -212,14 +212,14 @@ namespace OpenTK.Graphics.OpenGL
                 BindVertexBuffers(first, count, buffers_ptr, offsets_ptr, strides_ptr);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData(BufferTargetARB target, nint size, IntPtr data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData(BufferTarget target, nint size, IntPtr data, BufferUsageARB usage)
         {
             void* data_vptr = (void*)data;
             BufferData(target, size, data_vptr, usage);
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTargetARB target, ReadOnlySpan<T1> data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsageARB usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -228,8 +228,8 @@ namespace OpenTK.Graphics.OpenGL
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTargetARB target, T1[] data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, T1[] data, BufferUsageARB usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -238,8 +238,8 @@ namespace OpenTK.Graphics.OpenGL
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTargetARB target, nint size, in T1 data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, nint size, in T1 data, BufferUsageARB usage)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -282,14 +282,14 @@ namespace OpenTK.Graphics.OpenGL
                 BufferStorage(target, size, data_ptr, flags);
             }
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData(BufferTargetARB target, IntPtr offset, nint size, IntPtr data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData(BufferTarget target, IntPtr offset, nint size, IntPtr data)
         {
             void* data_vptr = (void*)data;
             BufferSubData(target, offset, size, data_vptr);
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData<T1>(BufferTargetARB target, IntPtr offset, ReadOnlySpan<T1> data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData<T1>(BufferTarget target, IntPtr offset, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -298,8 +298,8 @@ namespace OpenTK.Graphics.OpenGL
                 BufferSubData(target, offset, size, data_ptr);
             }
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData<T1>(BufferTargetARB target, IntPtr offset, T1[] data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData<T1>(BufferTarget target, IntPtr offset, T1[] data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -308,8 +308,8 @@ namespace OpenTK.Graphics.OpenGL
                 BufferSubData(target, offset, size, data_ptr);
             }
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData<T1>(BufferTargetARB target, IntPtr offset, nint size, in T1 data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData<T1>(BufferTarget target, IntPtr offset, nint size, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -403,14 +403,14 @@ namespace OpenTK.Graphics.OpenGL
                 ClearBufferiv(buffer, drawbuffer, value_ptr);
             }
         }
-        /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-        public static unsafe void ClearBufferSubData(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
+        /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+        public static unsafe void ClearBufferSubData(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
         {
             void* data_vptr = (void*)data;
             ClearBufferSubData(target, internalformat, offset, size, format, type, data_vptr);
         }
-        /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-        public static unsafe void ClearBufferSubData<T1>(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+        /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+        public static unsafe void ClearBufferSubData<T1>(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -418,8 +418,8 @@ namespace OpenTK.Graphics.OpenGL
                 ClearBufferSubData(target, internalformat, offset, size, format, type, data_ptr);
             }
         }
-        /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-        public static unsafe void ClearBufferSubData<T1>(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
+        /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+        public static unsafe void ClearBufferSubData<T1>(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = data)
@@ -427,8 +427,8 @@ namespace OpenTK.Graphics.OpenGL
                 ClearBufferSubData(target, internalformat, offset, size, format, type, data_ptr);
             }
         }
-        /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-        public static unsafe void ClearBufferSubData<T1>(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
+        /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+        public static unsafe void ClearBufferSubData<T1>(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -3291,32 +3291,32 @@ namespace OpenTK.Graphics.OpenGL
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             return returnValue;
         }
-        /// <inheritdoc cref="GetBooleani_v(BufferTargetARB, uint, bool*)"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, Span<bool> data)
+        /// <inheritdoc cref="GetBooleani_v(BufferTarget, uint, bool*)"/>
+        public static unsafe void GetBoolean(BufferTarget target, uint index, Span<bool> data)
         {
             fixed (bool* data_ptr = data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
-        /// <inheritdoc cref="GetBooleani_v(BufferTargetARB, uint, bool*)"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, bool[] data)
+        /// <inheritdoc cref="GetBooleani_v(BufferTarget, uint, bool*)"/>
+        public static unsafe void GetBoolean(BufferTarget target, uint index, bool[] data)
         {
             fixed (bool* data_ptr = data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
-        /// <inheritdoc cref="GetBooleani_v(BufferTargetARB, uint, bool*)"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, ref bool data)
+        /// <inheritdoc cref="GetBooleani_v(BufferTarget, uint, bool*)"/>
+        public static unsafe void GetBoolean(BufferTarget target, uint index, ref bool data)
         {
             fixed (bool* data_ptr = &data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
-        /// <inheritdoc cref="GetBooleani_v(BufferTargetARB, uint, bool*)"/>
-        public static unsafe bool GetBoolean(BufferTargetARB target, uint index)
+        /// <inheritdoc cref="GetBooleani_v(BufferTarget, uint, bool*)"/>
+        public static unsafe bool GetBoolean(BufferTarget target, uint index)
         {
             bool data_val;
             bool* data = &data_val;
@@ -3355,91 +3355,91 @@ namespace OpenTK.Graphics.OpenGL
             GetBooleanv(pname, data);
             return data_val;
         }
-        /// <inheritdoc cref="GetBufferParameteri64v(BufferTargetARB, BufferPNameARB, long*)"/>
-        public static unsafe void GetBufferParameteri64(BufferTargetARB target, BufferPNameARB pname, Span<long> parameters)
+        /// <inheritdoc cref="GetBufferParameteri64v(BufferTarget, BufferPName, long*)"/>
+        public static unsafe void GetBufferParameteri64(BufferTarget target, BufferPName pname, Span<long> parameters)
         {
             fixed (long* parameters_ptr = parameters)
             {
                 GetBufferParameteri64v(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteri64v(BufferTargetARB, BufferPNameARB, long*)"/>
-        public static unsafe void GetBufferParameteri64(BufferTargetARB target, BufferPNameARB pname, long[] parameters)
+        /// <inheritdoc cref="GetBufferParameteri64v(BufferTarget, BufferPName, long*)"/>
+        public static unsafe void GetBufferParameteri64(BufferTarget target, BufferPName pname, long[] parameters)
         {
             fixed (long* parameters_ptr = parameters)
             {
                 GetBufferParameteri64v(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteri64v(BufferTargetARB, BufferPNameARB, long*)"/>
-        public static unsafe void GetBufferParameteri64(BufferTargetARB target, BufferPNameARB pname, ref long parameters)
+        /// <inheritdoc cref="GetBufferParameteri64v(BufferTarget, BufferPName, long*)"/>
+        public static unsafe void GetBufferParameteri64(BufferTarget target, BufferPName pname, ref long parameters)
         {
             fixed (long* parameters_ptr = &parameters)
             {
                 GetBufferParameteri64v(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteri64v(BufferTargetARB, BufferPNameARB, long*)"/>
-        public static unsafe long GetBufferParameteri64(BufferTargetARB target, BufferPNameARB pname)
+        /// <inheritdoc cref="GetBufferParameteri64v(BufferTarget, BufferPName, long*)"/>
+        public static unsafe long GetBufferParameteri64(BufferTarget target, BufferPName pname)
         {
             long parameters_val;
             long* parameters = &parameters_val;
             GetBufferParameteri64v(target, pname, parameters);
             return parameters_val;
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe void GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname, Span<int> parameters)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe void GetBufferParameteri(BufferTarget target, BufferPName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetBufferParameteriv(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe void GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname, int[] parameters)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe void GetBufferParameteri(BufferTarget target, BufferPName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetBufferParameteriv(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe void GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname, ref int parameters)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe void GetBufferParameteri(BufferTarget target, BufferPName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
                 GetBufferParameteriv(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe int GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe int GetBufferParameteri(BufferTarget target, BufferPName pname)
         {
             int parameters_val;
             int* parameters = &parameters_val;
             GetBufferParameteriv(target, pname, parameters);
             return parameters_val;
         }
-        /// <inheritdoc cref="GetBufferPointerv(BufferTargetARB, BufferPointerNameARB, void**)"/>
-        public static unsafe void GetBufferPointer(BufferTargetARB target, BufferPointerNameARB pname, void** parameters)
+        /// <inheritdoc cref="GetBufferPointerv(BufferTarget, BufferPointerNameARB, void**)"/>
+        public static unsafe void GetBufferPointer(BufferTarget target, BufferPointerNameARB pname, void** parameters)
         {
             GetBufferPointerv(target, pname, parameters);
         }
-        /// <inheritdoc cref="GetBufferPointerv(BufferTargetARB, BufferPointerNameARB, void**)"/>
-        public static unsafe void* GetBufferPointer(BufferTargetARB target, BufferPointerNameARB pname)
+        /// <inheritdoc cref="GetBufferPointerv(BufferTarget, BufferPointerNameARB, void**)"/>
+        public static unsafe void* GetBufferPointer(BufferTarget target, BufferPointerNameARB pname)
         {
             void* parameters_val;
             void** parameters = &parameters_val;
             GetBufferPointerv(target, pname, parameters);
             return parameters_val;
         }
-        /// <inheritdoc cref="GetBufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void GetBufferSubData(BufferTargetARB target, IntPtr offset, nint size, IntPtr data)
+        /// <inheritdoc cref="GetBufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void GetBufferSubData(BufferTarget target, IntPtr offset, nint size, IntPtr data)
         {
             void* data_vptr = (void*)data;
             GetBufferSubData(target, offset, size, data_vptr);
         }
-        /// <inheritdoc cref="GetBufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void GetBufferSubData<T1>(BufferTargetARB target, IntPtr offset, Span<T1> data)
+        /// <inheritdoc cref="GetBufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void GetBufferSubData<T1>(BufferTarget target, IntPtr offset, Span<T1> data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -3448,8 +3448,8 @@ namespace OpenTK.Graphics.OpenGL
                 GetBufferSubData(target, offset, size, data_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void GetBufferSubData<T1>(BufferTargetARB target, IntPtr offset, T1[] data)
+        /// <inheritdoc cref="GetBufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void GetBufferSubData<T1>(BufferTarget target, IntPtr offset, T1[] data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -3458,8 +3458,8 @@ namespace OpenTK.Graphics.OpenGL
                 GetBufferSubData(target, offset, size, data_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void GetBufferSubData<T1>(BufferTargetARB target, IntPtr offset, nint size, ref T1 data)
+        /// <inheritdoc cref="GetBufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void GetBufferSubData<T1>(BufferTarget target, IntPtr offset, nint size, ref T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -4075,32 +4075,32 @@ namespace OpenTK.Graphics.OpenGL
             GetMultisamplefv(pname, index, val);
             return val_val;
         }
-        /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPNameARB, long*)"/>
-        public static unsafe void GetNamedBufferParameteri64(int buffer, BufferPNameARB pname, ref long parameters)
+        /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPName, long*)"/>
+        public static unsafe void GetNamedBufferParameteri64(int buffer, BufferPName pname, ref long parameters)
         {
             fixed (long* parameters_ptr = &parameters)
             {
                 GetNamedBufferParameteri64v(buffer, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPNameARB, long*)"/>
-        public static unsafe long GetNamedBufferParameteri64(int buffer, BufferPNameARB pname)
+        /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPName, long*)"/>
+        public static unsafe long GetNamedBufferParameteri64(int buffer, BufferPName pname)
         {
             long parameters_val;
             long* parameters = &parameters_val;
             GetNamedBufferParameteri64v(buffer, pname, parameters);
             return parameters_val;
         }
-        /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPNameARB, int*)"/>
-        public static unsafe void GetNamedBufferParameteri(int buffer, BufferPNameARB pname, ref int parameters)
+        /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPName, int*)"/>
+        public static unsafe void GetNamedBufferParameteri(int buffer, BufferPName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
                 GetNamedBufferParameteriv(buffer, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPNameARB, int*)"/>
-        public static unsafe int GetNamedBufferParameteri(int buffer, BufferPNameARB pname)
+        /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPName, int*)"/>
+        public static unsafe int GetNamedBufferParameteri(int buffer, BufferPName pname)
         {
             int parameters_val;
             int* parameters = &parameters_val;
@@ -4832,32 +4832,32 @@ namespace OpenTK.Graphics.OpenGL
             GetProgramInterfaceiv(program, programInterface, pname, parameters);
             return parameters_val;
         }
-        /// <inheritdoc cref="GetProgramiv(int, ProgramPropertyARB, int*)"/>
-        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, Span<int> parameters)
+        /// <inheritdoc cref="GetProgramiv(int, ProgramProperty, int*)"/>
+        public static unsafe void GetProgrami(int program, ProgramProperty pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetProgramiv(program, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetProgramiv(int, ProgramPropertyARB, int*)"/>
-        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, int[] parameters)
+        /// <inheritdoc cref="GetProgramiv(int, ProgramProperty, int*)"/>
+        public static unsafe void GetProgrami(int program, ProgramProperty pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetProgramiv(program, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetProgramiv(int, ProgramPropertyARB, int*)"/>
-        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, ref int parameters)
+        /// <inheritdoc cref="GetProgramiv(int, ProgramProperty, int*)"/>
+        public static unsafe void GetProgrami(int program, ProgramProperty pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
                 GetProgramiv(program, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetProgramiv(int, ProgramPropertyARB, int*)"/>
-        public static unsafe int GetProgrami(int program, ProgramPropertyARB pname)
+        /// <inheritdoc cref="GetProgramiv(int, ProgramProperty, int*)"/>
+        public static unsafe int GetProgrami(int program, ProgramProperty pname)
         {
             int parameters_val;
             int* parameters = &parameters_val;
@@ -13294,8 +13294,8 @@ namespace OpenTK.Graphics.OpenGL
                 BindAttribLocationARB(programObj, index, name_ptr);
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             }
-            /// <inheritdoc cref="BindBuffersBase(BufferTargetARB, uint, int, int*)"/>
-            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, ReadOnlySpan<int> buffers)
+            /// <inheritdoc cref="BindBuffersBase(BufferTarget, uint, int, int*)"/>
+            public static unsafe void BindBuffersBase(BufferTarget target, uint first, ReadOnlySpan<int> buffers)
             {
                 int count = (int)(buffers.Length);
                 fixed (int* buffers_ptr = buffers)
@@ -13303,8 +13303,8 @@ namespace OpenTK.Graphics.OpenGL
                     BindBuffersBase(target, first, count, buffers_ptr);
                 }
             }
-            /// <inheritdoc cref="BindBuffersBase(BufferTargetARB, uint, int, int*)"/>
-            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int[] buffers)
+            /// <inheritdoc cref="BindBuffersBase(BufferTarget, uint, int, int*)"/>
+            public static unsafe void BindBuffersBase(BufferTarget target, uint first, int[] buffers)
             {
                 int count = (int)(buffers.Length);
                 fixed (int* buffers_ptr = buffers)
@@ -13312,16 +13312,16 @@ namespace OpenTK.Graphics.OpenGL
                     BindBuffersBase(target, first, count, buffers_ptr);
                 }
             }
-            /// <inheritdoc cref="BindBuffersBase(BufferTargetARB, uint, int, int*)"/>
-            public static unsafe void BindBuffersBase(BufferTargetARB target, uint first, int count, in int buffers)
+            /// <inheritdoc cref="BindBuffersBase(BufferTarget, uint, int, int*)"/>
+            public static unsafe void BindBuffersBase(BufferTarget target, uint first, int count, in int buffers)
             {
                 fixed (int* buffers_ptr = &buffers)
                 {
                     BindBuffersBase(target, first, count, buffers_ptr);
                 }
             }
-            /// <inheritdoc cref="BindBuffersRange(BufferTargetARB, uint, int, int*, IntPtr*, nint*)"/>
-            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
+            /// <inheritdoc cref="BindBuffersRange(BufferTarget, uint, int, int*, IntPtr*, nint*)"/>
+            public static unsafe void BindBuffersRange(BufferTarget target, uint first, int count, ReadOnlySpan<int> buffers, ReadOnlySpan<IntPtr> offsets, ReadOnlySpan<nint> sizes)
             {
                 fixed (int* buffers_ptr = buffers)
                 {
@@ -13334,8 +13334,8 @@ namespace OpenTK.Graphics.OpenGL
                     }
                 }
             }
-            /// <inheritdoc cref="BindBuffersRange(BufferTargetARB, uint, int, int*, IntPtr*, nint*)"/>
-            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, int[] buffers, IntPtr[] offsets, nint[] sizes)
+            /// <inheritdoc cref="BindBuffersRange(BufferTarget, uint, int, int*, IntPtr*, nint*)"/>
+            public static unsafe void BindBuffersRange(BufferTarget target, uint first, int count, int[] buffers, IntPtr[] offsets, nint[] sizes)
             {
                 fixed (int* buffers_ptr = buffers)
                 {
@@ -13348,8 +13348,8 @@ namespace OpenTK.Graphics.OpenGL
                     }
                 }
             }
-            /// <inheritdoc cref="BindBuffersRange(BufferTargetARB, uint, int, int*, IntPtr*, nint*)"/>
-            public static unsafe void BindBuffersRange(BufferTargetARB target, uint first, int count, in int buffers, in IntPtr offsets, in nint sizes)
+            /// <inheritdoc cref="BindBuffersRange(BufferTarget, uint, int, int*, IntPtr*, nint*)"/>
+            public static unsafe void BindBuffersRange(BufferTarget target, uint first, int count, in int buffers, in IntPtr offsets, in nint sizes)
             {
                 fixed (int* buffers_ptr = &buffers)
                 fixed (IntPtr* offsets_ptr = &offsets)
@@ -13481,14 +13481,14 @@ namespace OpenTK.Graphics.OpenGL
                     BindVertexBuffers(first, count, buffers_ptr, offsets_ptr, strides_ptr);
                 }
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB(BufferTargetARB target, nint size, IntPtr data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
+            public static unsafe void BufferDataARB(BufferTarget target, nint size, IntPtr data, BufferUsageARB usage)
             {
                 void* data_vptr = (void*)data;
                 BufferDataARB(target, size, data_vptr, usage);
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB<T1>(BufferTargetARB target, ReadOnlySpan<T1> data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
+            public static unsafe void BufferDataARB<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsageARB usage)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -13497,8 +13497,8 @@ namespace OpenTK.Graphics.OpenGL
                     BufferDataARB(target, size, data_ptr, usage);
                 }
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB<T1>(BufferTargetARB target, T1[] data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
+            public static unsafe void BufferDataARB<T1>(BufferTarget target, T1[] data, BufferUsageARB usage)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -13507,8 +13507,8 @@ namespace OpenTK.Graphics.OpenGL
                     BufferDataARB(target, size, data_ptr, usage);
                 }
             }
-            /// <inheritdoc cref="BufferDataARB(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-            public static unsafe void BufferDataARB<T1>(BufferTargetARB target, nint size, in T1 data, BufferUsageARB usage)
+            /// <inheritdoc cref="BufferDataARB(BufferTarget, nint, void*, BufferUsageARB)"/>
+            public static unsafe void BufferDataARB<T1>(BufferTarget target, nint size, in T1 data, BufferUsageARB usage)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -13551,14 +13551,14 @@ namespace OpenTK.Graphics.OpenGL
                     BufferStorage(target, size, data_ptr, flags);
                 }
             }
-            /// <inheritdoc cref="BufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void BufferSubDataARB(BufferTargetARB target, IntPtr offset, nint size, IntPtr data)
+            /// <inheritdoc cref="BufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void BufferSubDataARB(BufferTarget target, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 BufferSubDataARB(target, offset, size, data_vptr);
             }
-            /// <inheritdoc cref="BufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void BufferSubDataARB<T1>(BufferTargetARB target, IntPtr offset, ReadOnlySpan<T1> data)
+            /// <inheritdoc cref="BufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void BufferSubDataARB<T1>(BufferTarget target, IntPtr offset, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -13567,8 +13567,8 @@ namespace OpenTK.Graphics.OpenGL
                     BufferSubDataARB(target, offset, size, data_ptr);
                 }
             }
-            /// <inheritdoc cref="BufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void BufferSubDataARB<T1>(BufferTargetARB target, IntPtr offset, T1[] data)
+            /// <inheritdoc cref="BufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void BufferSubDataARB<T1>(BufferTarget target, IntPtr offset, T1[] data)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -13577,8 +13577,8 @@ namespace OpenTK.Graphics.OpenGL
                     BufferSubDataARB(target, offset, size, data_ptr);
                 }
             }
-            /// <inheritdoc cref="BufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void BufferSubDataARB<T1>(BufferTargetARB target, IntPtr offset, nint size, in T1 data)
+            /// <inheritdoc cref="BufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void BufferSubDataARB<T1>(BufferTarget target, IntPtr offset, nint size, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -13619,14 +13619,14 @@ namespace OpenTK.Graphics.OpenGL
                     ClearBufferData(target, internalformat, format, type, data_ptr);
                 }
             }
-            /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-            public static unsafe void ClearBufferSubData(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
+            /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+            public static unsafe void ClearBufferSubData(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 ClearBufferSubData(target, internalformat, offset, size, format, type, data_vptr);
             }
-            /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-            public static unsafe void ClearBufferSubData<T1>(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
+            /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+            public static unsafe void ClearBufferSubData<T1>(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, ReadOnlySpan<T1> data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -13634,8 +13634,8 @@ namespace OpenTK.Graphics.OpenGL
                     ClearBufferSubData(target, internalformat, offset, size, format, type, data_ptr);
                 }
             }
-            /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-            public static unsafe void ClearBufferSubData<T1>(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
+            /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+            public static unsafe void ClearBufferSubData<T1>(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, T1[] data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = data)
@@ -13643,8 +13643,8 @@ namespace OpenTK.Graphics.OpenGL
                     ClearBufferSubData(target, internalformat, offset, size, format, type, data_ptr);
                 }
             }
-            /// <inheritdoc cref="ClearBufferSubData(BufferTargetARB, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
-            public static unsafe void ClearBufferSubData<T1>(BufferTargetARB target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
+            /// <inheritdoc cref="ClearBufferSubData(BufferTarget, SizedInternalFormat, IntPtr, nint, PixelFormat, PixelType, void*)"/>
+            public static unsafe void ClearBufferSubData<T1>(BufferTarget target, SizedInternalFormat internalformat, IntPtr offset, nint size, PixelFormat format, PixelType type, in T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -16696,59 +16696,59 @@ namespace OpenTK.Graphics.OpenGL
                 Marshal.FreeCoTaskMem((IntPtr)name_ptr);
                 return returnValue;
             }
-            /// <inheritdoc cref="GetBufferParameterivARB(BufferTargetARB, BufferPNameARB, int*)"/>
-            public static unsafe void GetBufferParameterivARB(BufferTargetARB target, BufferPNameARB pname, Span<int> parameters)
+            /// <inheritdoc cref="GetBufferParameterivARB(BufferTarget, BufferPName, int*)"/>
+            public static unsafe void GetBufferParameterivARB(BufferTarget target, BufferPName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetBufferParameterivARB(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterivARB(BufferTargetARB, BufferPNameARB, int*)"/>
-            public static unsafe void GetBufferParameterivARB(BufferTargetARB target, BufferPNameARB pname, int[] parameters)
+            /// <inheritdoc cref="GetBufferParameterivARB(BufferTarget, BufferPName, int*)"/>
+            public static unsafe void GetBufferParameterivARB(BufferTarget target, BufferPName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetBufferParameterivARB(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterivARB(BufferTargetARB, BufferPNameARB, int*)"/>
-            public static unsafe void GetBufferParameterivARB(BufferTargetARB target, BufferPNameARB pname, ref int parameters)
+            /// <inheritdoc cref="GetBufferParameterivARB(BufferTarget, BufferPName, int*)"/>
+            public static unsafe void GetBufferParameterivARB(BufferTarget target, BufferPName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
                     GetBufferParameterivARB(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterivARB(BufferTargetARB, BufferPNameARB, int*)"/>
-            public static unsafe int GetBufferParameterivARB(BufferTargetARB target, BufferPNameARB pname)
+            /// <inheritdoc cref="GetBufferParameterivARB(BufferTarget, BufferPName, int*)"/>
+            public static unsafe int GetBufferParameterivARB(BufferTarget target, BufferPName pname)
             {
                 int parameters_val;
                 int* parameters = &parameters_val;
                 GetBufferParameterivARB(target, pname, parameters);
                 return parameters_val;
             }
-            /// <inheritdoc cref="GetBufferPointervARB(BufferTargetARB, BufferPointerNameARB, void**)"/>
-            public static unsafe void GetBufferPointervARB(BufferTargetARB target, BufferPointerNameARB pname, void** parameters)
+            /// <inheritdoc cref="GetBufferPointervARB(BufferTarget, BufferPointerNameARB, void**)"/>
+            public static unsafe void GetBufferPointervARB(BufferTarget target, BufferPointerNameARB pname, void** parameters)
             {
                 GetBufferPointervARB_(target, pname, parameters);
             }
-            /// <inheritdoc cref="GetBufferPointervARB(BufferTargetARB, BufferPointerNameARB, void**)"/>
-            public static unsafe void* GetBufferPointervARB(BufferTargetARB target, BufferPointerNameARB pname)
+            /// <inheritdoc cref="GetBufferPointervARB(BufferTarget, BufferPointerNameARB, void**)"/>
+            public static unsafe void* GetBufferPointervARB(BufferTarget target, BufferPointerNameARB pname)
             {
                 void* parameters_val;
                 void** parameters = &parameters_val;
                 GetBufferPointervARB_(target, pname, parameters);
                 return parameters_val;
             }
-            /// <inheritdoc cref="GetBufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void GetBufferSubDataARB(BufferTargetARB target, IntPtr offset, nint size, IntPtr data)
+            /// <inheritdoc cref="GetBufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void GetBufferSubDataARB(BufferTarget target, IntPtr offset, nint size, IntPtr data)
             {
                 void* data_vptr = (void*)data;
                 GetBufferSubDataARB(target, offset, size, data_vptr);
             }
-            /// <inheritdoc cref="GetBufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void GetBufferSubDataARB<T1>(BufferTargetARB target, IntPtr offset, Span<T1> data)
+            /// <inheritdoc cref="GetBufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void GetBufferSubDataARB<T1>(BufferTarget target, IntPtr offset, Span<T1> data)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -16757,8 +16757,8 @@ namespace OpenTK.Graphics.OpenGL
                     GetBufferSubDataARB(target, offset, size, data_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void GetBufferSubDataARB<T1>(BufferTargetARB target, IntPtr offset, T1[] data)
+            /// <inheritdoc cref="GetBufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void GetBufferSubDataARB<T1>(BufferTarget target, IntPtr offset, T1[] data)
                 where T1 : unmanaged
             {
                 nint size = (nint)(data.Length * sizeof(T1));
@@ -16767,8 +16767,8 @@ namespace OpenTK.Graphics.OpenGL
                     GetBufferSubDataARB(target, offset, size, data_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferSubDataARB(BufferTargetARB, IntPtr, nint, void*)"/>
-            public static unsafe void GetBufferSubDataARB<T1>(BufferTargetARB target, IntPtr offset, nint size, ref T1 data)
+            /// <inheritdoc cref="GetBufferSubDataARB(BufferTarget, IntPtr, nint, void*)"/>
+            public static unsafe void GetBufferSubDataARB<T1>(BufferTarget target, IntPtr offset, nint size, ref T1 data)
                 where T1 : unmanaged
             {
                 fixed (void* data_ptr = &data)
@@ -17707,32 +17707,32 @@ namespace OpenTK.Graphics.OpenGL
                 GetMultisamplefv(pname, index, val);
                 return val_val;
             }
-            /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPNameARB, long*)"/>
-            public static unsafe void GetNamedBufferParameteri64(int buffer, BufferPNameARB pname, ref long parameters)
+            /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPName, long*)"/>
+            public static unsafe void GetNamedBufferParameteri64(int buffer, BufferPName pname, ref long parameters)
             {
                 fixed (long* parameters_ptr = &parameters)
                 {
                     GetNamedBufferParameteri64v(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPNameARB, long*)"/>
-            public static unsafe long GetNamedBufferParameteri64(int buffer, BufferPNameARB pname)
+            /// <inheritdoc cref="GetNamedBufferParameteri64v(int, BufferPName, long*)"/>
+            public static unsafe long GetNamedBufferParameteri64(int buffer, BufferPName pname)
             {
                 long parameters_val;
                 long* parameters = &parameters_val;
                 GetNamedBufferParameteri64v(buffer, pname, parameters);
                 return parameters_val;
             }
-            /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPNameARB, int*)"/>
-            public static unsafe void GetNamedBufferParameteri(int buffer, BufferPNameARB pname, ref int parameters)
+            /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPName, int*)"/>
+            public static unsafe void GetNamedBufferParameteri(int buffer, BufferPName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
                     GetNamedBufferParameteriv(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPNameARB, int*)"/>
-            public static unsafe int GetNamedBufferParameteri(int buffer, BufferPNameARB pname)
+            /// <inheritdoc cref="GetNamedBufferParameteriv(int, BufferPName, int*)"/>
+            public static unsafe int GetNamedBufferParameteri(int buffer, BufferPName pname)
             {
                 int parameters_val;
                 int* parameters = &parameters_val;
@@ -18907,32 +18907,32 @@ namespace OpenTK.Graphics.OpenGL
                 GetProgramInterfaceiv(program, programInterface, pname, parameters);
                 return parameters_val;
             }
-            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe void GetProgramivARB(ProgramTarget target, ProgramPropertyARB pname, Span<int> parameters)
+            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe void GetProgramivARB(ProgramTarget target, ProgramProperty pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetProgramivARB(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe void GetProgramivARB(ProgramTarget target, ProgramPropertyARB pname, int[] parameters)
+            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe void GetProgramivARB(ProgramTarget target, ProgramProperty pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetProgramivARB(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe void GetProgramivARB(ProgramTarget target, ProgramPropertyARB pname, ref int parameters)
+            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe void GetProgramivARB(ProgramTarget target, ProgramProperty pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
                     GetProgramivARB(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe int GetProgramivARB(ProgramTarget target, ProgramPropertyARB pname)
+            /// <inheritdoc cref="GetProgramivARB(ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe int GetProgramivARB(ProgramTarget target, ProgramProperty pname)
             {
                 int parameters_val;
                 int* parameters = &parameters_val;
@@ -28901,32 +28901,32 @@ namespace OpenTK.Graphics.OpenGL
                     GenTexturesEXT(n, textures_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTargetARB, uint, bool*)"/>
-            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, Span<bool> data)
+            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTarget, uint, bool*)"/>
+            public static unsafe void GetBooleanIndexedvEXT(BufferTarget target, uint index, Span<bool> data)
             {
                 fixed (bool* data_ptr = data)
                 {
                     GetBooleanIndexedvEXT(target, index, data_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTargetARB, uint, bool*)"/>
-            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, bool[] data)
+            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTarget, uint, bool*)"/>
+            public static unsafe void GetBooleanIndexedvEXT(BufferTarget target, uint index, bool[] data)
             {
                 fixed (bool* data_ptr = data)
                 {
                     GetBooleanIndexedvEXT(target, index, data_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTargetARB, uint, bool*)"/>
-            public static unsafe void GetBooleanIndexedvEXT(BufferTargetARB target, uint index, ref bool data)
+            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTarget, uint, bool*)"/>
+            public static unsafe void GetBooleanIndexedvEXT(BufferTarget target, uint index, ref bool data)
             {
                 fixed (bool* data_ptr = &data)
                 {
                     GetBooleanIndexedvEXT(target, index, data_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTargetARB, uint, bool*)"/>
-            public static unsafe bool GetBooleanIndexedvEXT(BufferTargetARB target, uint index)
+            /// <inheritdoc cref="GetBooleanIndexedvEXT(BufferTarget, uint, bool*)"/>
+            public static unsafe bool GetBooleanIndexedvEXT(BufferTarget target, uint index)
             {
                 bool data_val;
                 bool* data = &data_val;
@@ -30213,32 +30213,32 @@ namespace OpenTK.Graphics.OpenGL
                 GetMultiTexParameterivEXT(texunit, target, pname, parameters);
                 return parameters_val;
             }
-            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPNameARB, int*)"/>
-            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, Span<int> parameters)
+            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPName, int*)"/>
+            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPName pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetNamedBufferParameterivEXT(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPNameARB, int*)"/>
-            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, int[] parameters)
+            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPName, int*)"/>
+            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPName pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetNamedBufferParameterivEXT(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPNameARB, int*)"/>
-            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname, ref int parameters)
+            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPName, int*)"/>
+            public static unsafe void GetNamedBufferParameterivEXT(int buffer, BufferPName pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
                     GetNamedBufferParameterivEXT(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPNameARB, int*)"/>
-            public static unsafe int GetNamedBufferParameterivEXT(int buffer, BufferPNameARB pname)
+            /// <inheritdoc cref="GetNamedBufferParameterivEXT(int, BufferPName, int*)"/>
+            public static unsafe int GetNamedBufferParameterivEXT(int buffer, BufferPName pname)
             {
                 int parameters_val;
                 int* parameters = &parameters_val;
@@ -30355,32 +30355,32 @@ namespace OpenTK.Graphics.OpenGL
                 GetNamedFramebufferParameterivEXT(framebuffer, pname, parameters);
                 return parameters_val;
             }
-            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, Span<int> parameters)
+            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramProperty pname, Span<int> parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetNamedProgramivEXT(program, target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, int[] parameters)
+            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramProperty pname, int[] parameters)
             {
                 fixed (int* parameters_ptr = parameters)
                 {
                     GetNamedProgramivEXT(program, target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname, ref int parameters)
+            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe void GetNamedProgramivEXT(int program, ProgramTarget target, ProgramProperty pname, ref int parameters)
             {
                 fixed (int* parameters_ptr = &parameters)
                 {
                     GetNamedProgramivEXT(program, target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramPropertyARB, int*)"/>
-            public static unsafe int GetNamedProgramivEXT(int program, ProgramTarget target, ProgramPropertyARB pname)
+            /// <inheritdoc cref="GetNamedProgramivEXT(int, ProgramTarget, ProgramProperty, int*)"/>
+            public static unsafe int GetNamedProgramivEXT(int program, ProgramTarget target, ProgramProperty pname)
             {
                 int parameters_val;
                 int* parameters = &parameters_val;
@@ -38724,32 +38724,32 @@ namespace OpenTK.Graphics.OpenGL
                     Marshal.FreeCoTaskMem((IntPtr)name_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTargetARB, All, ulong*)"/>
-            public static unsafe void GetBufferParameterui64vNV(BufferTargetARB target, All pname, Span<ulong> parameters)
+            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTarget, All, ulong*)"/>
+            public static unsafe void GetBufferParameterui64vNV(BufferTarget target, All pname, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
                     GetBufferParameterui64vNV(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTargetARB, All, ulong*)"/>
-            public static unsafe void GetBufferParameterui64vNV(BufferTargetARB target, All pname, ulong[] parameters)
+            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTarget, All, ulong*)"/>
+            public static unsafe void GetBufferParameterui64vNV(BufferTarget target, All pname, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
                     GetBufferParameterui64vNV(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTargetARB, All, ulong*)"/>
-            public static unsafe void GetBufferParameterui64vNV(BufferTargetARB target, All pname, ref ulong parameters)
+            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTarget, All, ulong*)"/>
+            public static unsafe void GetBufferParameterui64vNV(BufferTarget target, All pname, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
                     GetBufferParameterui64vNV(target, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTargetARB, All, ulong*)"/>
-            public static unsafe ulong GetBufferParameterui64vNV(BufferTargetARB target, All pname)
+            /// <inheritdoc cref="GetBufferParameterui64vNV(BufferTarget, All, ulong*)"/>
+            public static unsafe ulong GetBufferParameterui64vNV(BufferTarget target, All pname)
             {
                 ulong parameters_val;
                 ulong* parameters = &parameters_val;
@@ -39335,32 +39335,32 @@ namespace OpenTK.Graphics.OpenGL
                 GetMultisamplefvNV(pname, index, val);
                 return val_val;
             }
-            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPNameARB, ulong*)"/>
-            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, Span<ulong> parameters)
+            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPName, ulong*)"/>
+            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPName pname, Span<ulong> parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
                     GetNamedBufferParameterui64vNV(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPNameARB, ulong*)"/>
-            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, ulong[] parameters)
+            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPName, ulong*)"/>
+            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPName pname, ulong[] parameters)
             {
                 fixed (ulong* parameters_ptr = parameters)
                 {
                     GetNamedBufferParameterui64vNV(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPNameARB, ulong*)"/>
-            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname, ref ulong parameters)
+            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPName, ulong*)"/>
+            public static unsafe void GetNamedBufferParameterui64vNV(int buffer, BufferPName pname, ref ulong parameters)
             {
                 fixed (ulong* parameters_ptr = &parameters)
                 {
                     GetNamedBufferParameterui64vNV(buffer, pname, parameters_ptr);
                 }
             }
-            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPNameARB, ulong*)"/>
-            public static unsafe ulong GetNamedBufferParameterui64vNV(int buffer, BufferPNameARB pname)
+            /// <inheritdoc cref="GetNamedBufferParameterui64vNV(int, BufferPName, ulong*)"/>
+            public static unsafe ulong GetNamedBufferParameterui64vNV(int buffer, BufferPName pname)
             {
                 ulong parameters_val;
                 ulong* parameters = &parameters_val;

--- a/src/OpenTK.Graphics/OpenGLES1/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGLES1
@@ -842,7 +842,7 @@ namespace OpenTK.Graphics.OpenGLES1
         ElementArrayBuffer = 34963,
     }
     ///<summary>Used in <see cref="GL.BufferData" /></summary>
-    public enum BufferUsageARB : uint
+    public enum BufferUsage : uint
     {
         StaticDraw = 35044,
         DynamicDraw = 35048,

--- a/src/OpenTK.Graphics/OpenGLES1/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:50 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGLES1
@@ -741,7 +741,7 @@ namespace OpenTK.Graphics.OpenGLES1
         Float = 5126,
     }
     ///<summary>Used in <see cref="GL.EXT.BlendEquationEXT" />, <see cref="GL.OES.BlendEquationOES" />, <see cref="GL.OES.BlendEquationSeparateOES" /></summary>
-    public enum BlendEquationModeEXT : uint
+    public enum BlendEquationMode : uint
     {
         FuncAddExt = 32774,
         MinExt = 32775,
@@ -774,7 +774,7 @@ namespace OpenTK.Graphics.OpenGLES1
         True = 1,
     }
     ///<summary>Used in <see cref="GL.OES.MapBufferOES" /></summary>
-    public enum BufferAccessARB : uint
+    public enum BufferAccess : uint
     {
     }
     ///<summary>Used in <see cref="GL.QCOM.EndTilingQCOM" />, <see cref="GL.QCOM.StartTilingQCOM" /></summary>
@@ -815,7 +815,7 @@ namespace OpenTK.Graphics.OpenGLES1
         MultisampleBufferBit7Qcom = 2147483648,
     }
     ///<summary>Used in <see cref="GL.GetBufferParameteriv" /></summary>
-    public enum BufferPNameARB : uint
+    public enum BufferPName : uint
     {
         BufferSize = 34660,
         BufferUsage = 34661,
@@ -836,7 +836,7 @@ namespace OpenTK.Graphics.OpenGLES1
         ElementArrayBuffer = 34963,
     }
     ///<summary>Used in <see cref="GL.BindBuffer" />, <see cref="GL.BufferData" />, <see cref="GL.BufferSubData" />, ...</summary>
-    public enum BufferTargetARB : uint
+    public enum BufferTarget : uint
     {
         ArrayBuffer = 34962,
         ElementArrayBuffer = 34963,

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;
@@ -51,7 +51,7 @@ namespace OpenTK.Graphics.OpenGLES1
         /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
         /// <param name="usage"> Specifies the expected usage pattern of the data store. The symbolic constant must be GL_STATIC_DRAW or GL_DYNAMIC_DRAW. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glBufferData.xml" /></remarks>
-        public static void BufferData(BufferTarget target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
+        public static void BufferData(BufferTarget target, nint size, void* data, BufferUsage usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glBufferSubData</c>]</b><br/> Updates a subset of a buffer object&apos;s data store.. </summary>
         /// <param name="target"> Specifies the target buffer object. The symbolic constant must be GL_ARRAY_BUFFER or GL_ELEMENT_ARRAY_BUFFER. </param>

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:50 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;
@@ -31,7 +31,7 @@ namespace OpenTK.Graphics.OpenGLES1
         /// <param name="target"> Specifies the target to which the buffer is bound. The symbolic constant must be GL_ARRAY_BUFFER or GL_ELEMENT_ARRAY_BUFFER. </param>
         /// <param name="buffer">Specifies the name of a buffer object.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glBindBuffer.xml" /></remarks>
-        public static void BindBuffer(BufferTargetARB target, int buffer) => GLPointers._glBindBuffer_fnptr((uint)target, buffer);
+        public static void BindBuffer(BufferTarget target, int buffer) => GLPointers._glBindBuffer_fnptr((uint)target, buffer);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glBindTexture</c>]</b><br/> Bind a named texture to a texturing target. </summary>
         /// <param name="target">Specifies the target to which the texture is bound. Must be GL_TEXTURE_2D.</param>
@@ -51,7 +51,7 @@ namespace OpenTK.Graphics.OpenGLES1
         /// <param name="data">Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied.</param>
         /// <param name="usage"> Specifies the expected usage pattern of the data store. The symbolic constant must be GL_STATIC_DRAW or GL_DYNAMIC_DRAW. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glBufferData.xml" /></remarks>
-        public static void BufferData(BufferTargetARB target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
+        public static void BufferData(BufferTarget target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glBufferSubData</c>]</b><br/> Updates a subset of a buffer object&apos;s data store.. </summary>
         /// <param name="target"> Specifies the target buffer object. The symbolic constant must be GL_ARRAY_BUFFER or GL_ELEMENT_ARRAY_BUFFER. </param>
@@ -59,7 +59,7 @@ namespace OpenTK.Graphics.OpenGLES1
         /// <param name="size">Specifies the size in bytes of the data store region being replaced.</param>
         /// <param name="data"> Specifies a pointer to the new data that will be copied into the data store.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glBufferSubData.xml" /></remarks>
-        public static void BufferSubData(BufferTargetARB target, IntPtr offset, nint size, void* data) => GLPointers._glBufferSubData_fnptr((uint)target, offset, size, data);
+        public static void BufferSubData(BufferTarget target, IntPtr offset, nint size, void* data) => GLPointers._glBufferSubData_fnptr((uint)target, offset, size, data);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glClear</c>]</b><br/> Clear buffers to preset values. </summary>
         /// <param name="mask">Bitwise OR of masks that indicate the buffers to be cleared. Valid masks are GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, and GL_STENCIL_BUFFER_BIT.</param>
@@ -351,7 +351,7 @@ namespace OpenTK.Graphics.OpenGLES1
         /// <param name="pname"> Specifies the symbolic name of a buffer object parameter. Accepted values are GL_BUFFER_SIZE or GL_BUFFER_USAGE. </param>
         /// <param name="parameters">Returns the requested parameter.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/glGetBufferParameteriv.xml" /></remarks>
-        public static void GetBufferParameteriv(BufferTargetARB target, BufferPNameARB pname, int* parameters) => GLPointers._glGetBufferParameteriv_fnptr((uint)target, (uint)pname, parameters);
+        public static void GetBufferParameteriv(BufferTarget target, BufferPName pname, int* parameters) => GLPointers._glGetBufferParameteriv_fnptr((uint)target, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glGetClipPlanef</c>]</b><br/> Return the coefficients of the specified clipping    plane. </summary>
         /// <param name="plane">Specifies a clipping plane. The number of clipping planes depends on the implementation, but at least six clipping planes are supported. Symbolic names of the form GL_CLIP_PLANE i, where i is an integer between 0 and GL_MAX_CLIP_PLANES -1 , are accepted.</param>
@@ -951,13 +951,13 @@ namespace OpenTK.Graphics.OpenGLES1
         public static unsafe partial class EXT
         {
             /// <summary> <b>[requires: GL_EXT_blend_minmax]</b> <b>[entry point: <c>glBlendEquationEXT</c>]</b><br/>  </summary>
-            public static void BlendEquationEXT(BlendEquationModeEXT mode) => GLPointers._glBlendEquationEXT_fnptr((uint)mode);
+            public static void BlendEquationEXT(BlendEquationMode mode) => GLPointers._glBlendEquationEXT_fnptr((uint)mode);
             
             /// <summary> <b>[requires: GL_EXT_discard_framebuffer]</b> <b>[entry point: <c>glDiscardFramebufferEXT</c>]</b><br/>  </summary>
             public static void DiscardFramebufferEXT(FramebufferTarget target, int numAttachments, InvalidateFramebufferAttachment* attachments) => GLPointers._glDiscardFramebufferEXT_fnptr((uint)target, numAttachments, (uint*)attachments);
             
             /// <summary> <b>[requires: GL_EXT_map_buffer_range]</b> <b>[entry point: <c>glFlushMappedBufferRangeEXT</c>]</b><br/>  </summary>
-            public static void FlushMappedBufferRangeEXT(BufferTargetARB target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRangeEXT_fnptr((uint)target, offset, length);
+            public static void FlushMappedBufferRangeEXT(BufferTarget target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRangeEXT_fnptr((uint)target, offset, length);
             
             /// <summary> <b>[requires: GL_EXT_multisampled_render_to_texture]</b> <b>[entry point: <c>glFramebufferTexture2DMultisampleEXT</c>]</b><br/>  </summary>
             public static void FramebufferTexture2DMultisampleEXT(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textarget, int texture, int level, int samples) => GLPointers._glFramebufferTexture2DMultisampleEXT_fnptr((uint)target, (uint)attachment, (uint)textarget, texture, level, samples);
@@ -975,7 +975,7 @@ namespace OpenTK.Graphics.OpenGLES1
             public static void InsertEventMarkerEXT(int length, byte* marker) => GLPointers._glInsertEventMarkerEXT_fnptr(length, marker);
             
             /// <summary> <b>[requires: GL_EXT_map_buffer_range]</b> <b>[entry point: <c>glMapBufferRangeEXT</c>]</b><br/>  </summary>
-            public static void* MapBufferRangeEXT(BufferTargetARB target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRangeEXT_fnptr((uint)target, offset, length, (uint)access);
+            public static void* MapBufferRangeEXT(BufferTarget target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRangeEXT_fnptr((uint)target, offset, length, (uint)access);
             
             /// <summary> <b>[requires: GL_EXT_multi_draw_arrays]</b> <b>[entry point: <c>glMultiDrawArraysEXT</c>]</b><br/>  </summary>
             public static void MultiDrawArraysEXT(PrimitiveType mode, int* first, int* count, int primcount) => GLPointers._glMultiDrawArraysEXT_fnptr((uint)mode, first, count, primcount);
@@ -1153,10 +1153,10 @@ namespace OpenTK.Graphics.OpenGLES1
             public static void BlendColorxOES(int red, int green, int blue, int alpha) => GLPointers._glBlendColorxOES_fnptr(red, green, blue, alpha);
             
             /// <summary> <b>[requires: GL_OES_blend_subtract]</b> <b>[entry point: <c>glBlendEquationOES</c>]</b><br/>  </summary>
-            public static void BlendEquationOES(BlendEquationModeEXT mode) => GLPointers._glBlendEquationOES_fnptr((uint)mode);
+            public static void BlendEquationOES(BlendEquationMode mode) => GLPointers._glBlendEquationOES_fnptr((uint)mode);
             
             /// <summary> <b>[requires: GL_OES_blend_equation_separate]</b> <b>[entry point: <c>glBlendEquationSeparateOES</c>]</b><br/>  </summary>
-            public static void BlendEquationSeparateOES(BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparateOES_fnptr((uint)modeRGB, (uint)modeAlpha);
+            public static void BlendEquationSeparateOES(BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparateOES_fnptr((uint)modeRGB, (uint)modeAlpha);
             
             /// <summary> <b>[requires: GL_OES_blend_func_separate]</b> <b>[entry point: <c>glBlendFuncSeparateOES</c>]</b><br/>  </summary>
             public static void BlendFuncSeparateOES(BlendingFactor srcRGB, BlendingFactor dstRGB, BlendingFactor srcAlpha, BlendingFactor dstAlpha) => GLPointers._glBlendFuncSeparateOES_fnptr((uint)srcRGB, (uint)dstRGB, (uint)srcAlpha, (uint)dstAlpha);
@@ -1320,7 +1320,7 @@ namespace OpenTK.Graphics.OpenGLES1
             public static void GenVertexArraysOES(int n, int* arrays) => GLPointers._glGenVertexArraysOES_fnptr(n, arrays);
             
             /// <summary> <b>[requires: GL_OES_mapbuffer]</b> <b>[entry point: <c>glGetBufferPointervOES</c>]</b><br/>  </summary>
-            public static void GetBufferPointervOES_(BufferTargetARB target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointervOES_fnptr((uint)target, (uint)pname, parameters);
+            public static void GetBufferPointervOES_(BufferTarget target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointervOES_fnptr((uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_OES_single_precision]</b> <b>[entry point: <c>glGetClipPlanefOES</c>]</b><br/>  </summary>
             public static void GetClipPlanefOES(ClipPlaneName plane, float* equation) => GLPointers._glGetClipPlanefOES_fnptr((uint)plane, equation);
@@ -1426,7 +1426,7 @@ namespace OpenTK.Graphics.OpenGLES1
             public static void Map2xOES(MapTarget target, int u1, int u2, int ustride, int uorder, int v1, int v2, int vstride, int vorder, int points) => GLPointers._glMap2xOES_fnptr((uint)target, u1, u2, ustride, uorder, v1, v2, vstride, vorder, points);
             
             /// <summary> <b>[requires: GL_OES_mapbuffer]</b> <b>[entry point: <c>glMapBufferOES</c>]</b><br/>  </summary>
-            public static void* MapBufferOES(BufferTargetARB target, BufferAccessARB access) => GLPointers._glMapBufferOES_fnptr((uint)target, (uint)access);
+            public static void* MapBufferOES(BufferTarget target, BufferAccess access) => GLPointers._glMapBufferOES_fnptr((uint)target, (uint)access);
             
             /// <summary> <b>[requires: GL_OES_fixed_point]</b> <b>[entry point: <c>glMapGrid1xOES</c>]</b><br/>  </summary>
             public static void MapGrid1xOES(int n, int u1, int u2) => GLPointers._glMapGrid1xOES_fnptr(n, u1, u2);

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -12,14 +12,14 @@ namespace OpenTK.Graphics.OpenGLES1
 {
     public static unsafe partial class GL
     {
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData(BufferTarget target, nint size, IntPtr data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData(BufferTarget target, nint size, IntPtr data, BufferUsage usage)
         {
             void* data_vptr = (void*)data;
             BufferData(target, size, data_vptr, usage);
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsage usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -28,8 +28,8 @@ namespace OpenTK.Graphics.OpenGLES1
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTarget target, T1[] data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, T1[] data, BufferUsage usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -38,8 +38,8 @@ namespace OpenTK.Graphics.OpenGLES1
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTarget target, nint size, in T1 data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, nint size, in T1 data, BufferUsage usage)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:50 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -12,14 +12,14 @@ namespace OpenTK.Graphics.OpenGLES1
 {
     public static unsafe partial class GL
     {
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData(BufferTargetARB target, nint size, IntPtr data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData(BufferTarget target, nint size, IntPtr data, BufferUsageARB usage)
         {
             void* data_vptr = (void*)data;
             BufferData(target, size, data_vptr, usage);
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTargetARB target, ReadOnlySpan<T1> data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsageARB usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -28,8 +28,8 @@ namespace OpenTK.Graphics.OpenGLES1
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTargetARB target, T1[] data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, T1[] data, BufferUsageARB usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -38,8 +38,8 @@ namespace OpenTK.Graphics.OpenGLES1
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTargetARB target, nint size, in T1 data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, nint size, in T1 data, BufferUsageARB usage)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -47,14 +47,14 @@ namespace OpenTK.Graphics.OpenGLES1
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData(BufferTargetARB target, IntPtr offset, nint size, IntPtr data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData(BufferTarget target, IntPtr offset, nint size, IntPtr data)
         {
             void* data_vptr = (void*)data;
             BufferSubData(target, offset, size, data_vptr);
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData<T1>(BufferTargetARB target, IntPtr offset, ReadOnlySpan<T1> data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData<T1>(BufferTarget target, IntPtr offset, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -63,8 +63,8 @@ namespace OpenTK.Graphics.OpenGLES1
                 BufferSubData(target, offset, size, data_ptr);
             }
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData<T1>(BufferTargetARB target, IntPtr offset, T1[] data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData<T1>(BufferTarget target, IntPtr offset, T1[] data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -73,8 +73,8 @@ namespace OpenTK.Graphics.OpenGLES1
                 BufferSubData(target, offset, size, data_ptr);
             }
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData<T1>(BufferTargetARB target, IntPtr offset, nint size, in T1 data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData<T1>(BufferTarget target, IntPtr offset, nint size, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -514,32 +514,32 @@ namespace OpenTK.Graphics.OpenGLES1
             GetBooleanv(pname, data);
             return data_val;
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe void GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname, Span<int> parameters)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe void GetBufferParameteri(BufferTarget target, BufferPName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetBufferParameteriv(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe void GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname, int[] parameters)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe void GetBufferParameteri(BufferTarget target, BufferPName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetBufferParameteriv(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe void GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname, ref int parameters)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe void GetBufferParameteri(BufferTarget target, BufferPName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
                 GetBufferParameteriv(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe int GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe int GetBufferParameteri(BufferTarget target, BufferPName pname)
         {
             int parameters_val;
             int* parameters = &parameters_val;
@@ -3337,13 +3337,13 @@ namespace OpenTK.Graphics.OpenGLES1
                     GenVertexArraysOES(n, arrays_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferPointervOES(BufferTargetARB, BufferPointerNameARB, void**)"/>
-            public static unsafe void GetBufferPointervOES(BufferTargetARB target, BufferPointerNameARB pname, void** parameters)
+            /// <inheritdoc cref="GetBufferPointervOES(BufferTarget, BufferPointerNameARB, void**)"/>
+            public static unsafe void GetBufferPointervOES(BufferTarget target, BufferPointerNameARB pname, void** parameters)
             {
                 GetBufferPointervOES_(target, pname, parameters);
             }
-            /// <inheritdoc cref="GetBufferPointervOES(BufferTargetARB, BufferPointerNameARB, void**)"/>
-            public static unsafe void* GetBufferPointervOES(BufferTargetARB target, BufferPointerNameARB pname)
+            /// <inheritdoc cref="GetBufferPointervOES(BufferTarget, BufferPointerNameARB, void**)"/>
+            public static unsafe void* GetBufferPointervOES(BufferTarget target, BufferPointerNameARB pname)
             {
                 void* parameters_val;
                 void** parameters = &parameters_val;

--- a/src/OpenTK.Graphics/OpenGLES2/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGLES2/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGLES2
@@ -2684,7 +2684,7 @@ namespace OpenTK.Graphics.OpenGLES2
         AtomicCounterBuffer = 37568,
     }
     ///<summary>Used in <see cref="GL.BufferData" /></summary>
-    public enum BufferUsageARB : uint
+    public enum BufferUsage : uint
     {
         StreamDraw = 35040,
         StreamRead = 35041,

--- a/src/OpenTK.Graphics/OpenGLES2/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGLES2/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:50 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGLES2
@@ -2529,7 +2529,7 @@ namespace OpenTK.Graphics.OpenGLES2
         Float = 5126,
     }
     ///<summary>Used in <see cref="GL.BlendEquation" />, <see cref="GL.BlendEquationi" />, <see cref="GL.BlendEquationSeparate" />, ...</summary>
-    public enum BlendEquationModeEXT : uint
+    public enum BlendEquationMode : uint
     {
         FuncAdd = 32774,
         FuncAddExt = 32774,
@@ -2578,7 +2578,7 @@ namespace OpenTK.Graphics.OpenGLES2
         Stencil = 6146,
     }
     ///<summary>Used in <see cref="GL.BindImageTexture" />, <see cref="GL.OES.MapBufferOES" /></summary>
-    public enum BufferAccessARB : uint
+    public enum BufferAccess : uint
     {
         ReadOnly = 35000,
         WriteOnly = 35001,
@@ -2622,7 +2622,7 @@ namespace OpenTK.Graphics.OpenGLES2
         MultisampleBufferBit7Qcom = 2147483648,
     }
     ///<summary>Used in <see cref="GL.GetBufferParameteri64v" />, <see cref="GL.GetBufferParameteriv" /></summary>
-    public enum BufferPNameARB : uint
+    public enum BufferPName : uint
     {
         BufferSize = 34660,
         BufferUsage = 34661,
@@ -2667,7 +2667,7 @@ namespace OpenTK.Graphics.OpenGLES2
         AtomicCounterBuffer = 37568,
     }
     ///<summary>Used in <see cref="GL.BindBuffer" />, <see cref="GL.BindBufferBase" />, <see cref="GL.BindBufferRange" />, ...</summary>
-    public enum BufferTargetARB : uint
+    public enum BufferTarget : uint
     {
         ArrayBuffer = 34962,
         ElementArrayBuffer = 34963,
@@ -4354,7 +4354,7 @@ namespace OpenTK.Graphics.OpenGLES2
         ProgramSeparable = 33368,
     }
     ///<summary>Used in <see cref="GL.GetProgramiv" /></summary>
-    public enum ProgramPropertyARB : uint
+    public enum ProgramProperty : uint
     {
         ComputeWorkGroupSize = 33383,
         ProgramBinaryLength = 34625,

--- a/src/OpenTK.Graphics/OpenGLES2/GL.Manual.cs
+++ b/src/OpenTK.Graphics/OpenGLES2/GL.Manual.cs
@@ -47,12 +47,12 @@ namespace OpenTK.Graphics.OpenGLES2
         }
 
         /// <summary>
-        /// This is a convenience function that calls <see cref="GL.GetProgrami(int, ProgramPropertyARB, ref int)"/> followed by <see cref="GL.GetProgramInfoLog(int, int, ref int, out string)"/>.
+        /// This is a convenience function that calls <see cref="GL.GetProgrami(int, ProgramProperty, ref int)"/> followed by <see cref="GL.GetProgramInfoLog(int, int, ref int, out string)"/>.
         /// </summary>
         public static void GetProgramInfoLog(int program, out string info)
         {
             int length = default;
-            GL.GetProgrami(program, ProgramPropertyARB.InfoLogLength, ref length);
+            GL.GetProgrami(program, ProgramProperty.InfoLogLength, ref length);
             if (length == 0)
             {
                 info = string.Empty;

--- a/src/OpenTK.Graphics/OpenGLES2/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGLES2/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;
@@ -212,7 +212,7 @@ namespace OpenTK.Graphics.OpenGLES2
         /// <param name="data"> Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied. </param>
         /// <param name="usage"> Specifies the expected usage pattern of the data store. The symbolic constant must be GL_STREAM_DRAW, GL_STREAM_READ, GL_STREAM_COPY, GL_STATIC_DRAW, GL_STATIC_READ, GL_STATIC_COPY, GL_DYNAMIC_DRAW, GL_DYNAMIC_READ, or GL_DYNAMIC_COPY. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glBufferData.xhtml" /></remarks>
-        public static void BufferData(BufferTarget target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
+        public static void BufferData(BufferTarget target, nint size, void* data, BufferUsage usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
         
         /// <summary> <b>[requires: v2.0]</b> <b>[entry point: <c>glBufferSubData</c>]</b><br/> Updates a subset of a buffer object&apos;s data store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glBufferSubData, which must be one of the buffer binding targets in the following table: </param>

--- a/src/OpenTK.Graphics/OpenGLES2/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGLES2/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:50 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;
@@ -49,14 +49,14 @@ namespace OpenTK.Graphics.OpenGLES2
         /// <param name="target"> Specifies the target to which the buffer object is bound, which must be one of the buffer binding targets in the following table: </param>
         /// <param name="buffer"> Specifies the name of a buffer object. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glBindBuffer.xhtml" /></remarks>
-        public static void BindBuffer(BufferTargetARB target, int buffer) => GLPointers._glBindBuffer_fnptr((uint)target, buffer);
+        public static void BindBuffer(BufferTarget target, int buffer) => GLPointers._glBindBuffer_fnptr((uint)target, buffer);
         
         /// <summary> <b>[requires: v3.0]</b> <b>[entry point: <c>glBindBufferBase</c>]</b><br/> Bind a buffer object to an indexed buffer target. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_SHADER_STORAGE_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER or GL_UNIFORM_BUFFER. </param>
         /// <param name="index"> Specify the index of the binding point within the array specified by target. </param>
         /// <param name="buffer"> The name of a buffer object to bind to the specified binding point. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glBindBufferBase.xhtml" /></remarks>
-        public static void BindBufferBase(BufferTargetARB target, uint index, int buffer) => GLPointers._glBindBufferBase_fnptr((uint)target, index, buffer);
+        public static void BindBufferBase(BufferTarget target, uint index, int buffer) => GLPointers._glBindBufferBase_fnptr((uint)target, index, buffer);
         
         /// <summary> <b>[requires: v3.0]</b> <b>[entry point: <c>glBindBufferRange</c>]</b><br/> Bind a range within a buffer object to an indexed buffer target. </summary>
         /// <param name="target"> Specify the target of the bind operation. target must be one of GL_ATOMIC_COUNTER_BUFFER, GL_SHADER_STORAGE_BUFFER, GL_TRANSFORM_FEEDBACK_BUFFER or GL_UNIFORM_BUFFER. </param>
@@ -65,7 +65,7 @@ namespace OpenTK.Graphics.OpenGLES2
         /// <param name="offset"> The starting offset in basic machine units into the buffer object buffer. </param>
         /// <param name="size"> The amount of data in machine units that can be read from the buffet object while used as an indexed target. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glBindBufferRange.xhtml" /></remarks>
-        public static void BindBufferRange(BufferTargetARB target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRange_fnptr((uint)target, index, buffer, offset, size);
+        public static void BindBufferRange(BufferTarget target, uint index, int buffer, IntPtr offset, nint size) => GLPointers._glBindBufferRange_fnptr((uint)target, index, buffer, offset, size);
         
         /// <summary> <b>[requires: v2.0]</b> <b>[entry point: <c>glBindFramebuffer</c>]</b><br/> Bind a framebuffer to a framebuffer target. </summary>
         /// <param name="target"> Specifies the framebuffer target of the binding operation. </param>
@@ -82,7 +82,7 @@ namespace OpenTK.Graphics.OpenGLES2
         /// <param name="access"> Specifies a token indicating the type of access that will be performed on the image. </param>
         /// <param name="format"> Specifies the format that the elements of the image will be treated as for the purposes of formatted loads and stores. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glBindImageTexture.xhtml" /></remarks>
-        public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccessARB access, InternalFormat format) => GLPointers._glBindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
+        public static void BindImageTexture(uint unit, int texture, int level, bool layered, int layer, BufferAccess access, InternalFormat format) => GLPointers._glBindImageTexture_fnptr(unit, texture, level, (byte)(layered ? 1 : 0), layer, (uint)access, (uint)format);
         
         /// <summary> <b>[requires: v3.1]</b> <b>[entry point: <c>glBindProgramPipeline</c>]</b><br/> Bind a program pipeline to the current context. </summary>
         /// <param name="pipeline"> Specifies the name of the pipeline object to bind to the context. </param>
@@ -141,26 +141,26 @@ namespace OpenTK.Graphics.OpenGLES2
         /// <summary> <b>[requires: v2.0]</b> <b>[entry point: <c>glBlendEquation</c>]</b><br/> Specify the equation used for both the RGB blend equation and the Alpha blend equation. </summary>
         /// <param name="mode"> specifies how source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glBlendEquation.xhtml" /></remarks>
-        public static void BlendEquation(BlendEquationModeEXT mode) => GLPointers._glBlendEquation_fnptr((uint)mode);
+        public static void BlendEquation(BlendEquationMode mode) => GLPointers._glBlendEquation_fnptr((uint)mode);
         
         /// <summary> <b>[requires: v3.2]</b> <b>[entry point: <c>glBlendEquationi</c>]</b><br/> Specify the equation used for both the RGB blend equation and the Alpha blend equation. </summary>
         /// <param name="buf"> for glBlendEquationi, specifies the index of the draw buffer for which to set the blend equation. </param>
         /// <param name="mode"> specifies how source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glBlendEquation.xhtml" /></remarks>
-        public static void BlendEquationi(uint buf, BlendEquationModeEXT mode) => GLPointers._glBlendEquationi_fnptr(buf, (uint)mode);
+        public static void BlendEquationi(uint buf, BlendEquationMode mode) => GLPointers._glBlendEquationi_fnptr(buf, (uint)mode);
         
         /// <summary> <b>[requires: v2.0]</b> <b>[entry point: <c>glBlendEquationSeparate</c>]</b><br/> Set the RGB blend equation and the alpha blend equation separately. </summary>
         /// <param name="modeRGB"> specifies the RGB blend equation, how the red, green, and blue components of the source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <param name="modeAlpha"> specifies the alpha blend equation, how the alpha component of the source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glBlendEquationSeparate.xhtml" /></remarks>
-        public static void BlendEquationSeparate(BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparate_fnptr((uint)modeRGB, (uint)modeAlpha);
+        public static void BlendEquationSeparate(BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparate_fnptr((uint)modeRGB, (uint)modeAlpha);
         
         /// <summary> <b>[requires: v3.2]</b> <b>[entry point: <c>glBlendEquationSeparatei</c>]</b><br/> Set the RGB blend equation and the alpha blend equation separately. </summary>
         /// <param name="buf"> for glBlendEquationSeparatei, specifies the index of the draw buffer for which to set the blend equations. </param>
         /// <param name="modeRGB"> specifies the RGB blend equation, how the red, green, and blue components of the source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <param name="modeAlpha"> specifies the alpha blend equation, how the alpha component of the source and destination colors are combined. It must be GL_FUNC_ADD, GL_FUNC_SUBTRACT, GL_FUNC_REVERSE_SUBTRACT, GL_MIN, GL_MAX. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glBlendEquationSeparate.xhtml" /></remarks>
-        public static void BlendEquationSeparatei(uint buf, BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparatei_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
+        public static void BlendEquationSeparatei(uint buf, BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparatei_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
         
         /// <summary> <b>[requires: v2.0]</b> <b>[entry point: <c>glBlendFunc</c>]</b><br/> Specify pixel arithmetic. </summary>
         /// <param name="sfactor"> Specifies how the red, green, blue, and alpha source blending factors are computed. The initial value is GL_ONE. </param>
@@ -212,7 +212,7 @@ namespace OpenTK.Graphics.OpenGLES2
         /// <param name="data"> Specifies a pointer to data that will be copied into the data store for initialization, or NULL if no data is to be copied. </param>
         /// <param name="usage"> Specifies the expected usage pattern of the data store. The symbolic constant must be GL_STREAM_DRAW, GL_STREAM_READ, GL_STREAM_COPY, GL_STATIC_DRAW, GL_STATIC_READ, GL_STATIC_COPY, GL_DYNAMIC_DRAW, GL_DYNAMIC_READ, or GL_DYNAMIC_COPY. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glBufferData.xhtml" /></remarks>
-        public static void BufferData(BufferTargetARB target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
+        public static void BufferData(BufferTarget target, nint size, void* data, BufferUsageARB usage) => GLPointers._glBufferData_fnptr((uint)target, size, data, (uint)usage);
         
         /// <summary> <b>[requires: v2.0]</b> <b>[entry point: <c>glBufferSubData</c>]</b><br/> Updates a subset of a buffer object&apos;s data store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glBufferSubData, which must be one of the buffer binding targets in the following table: </param>
@@ -220,7 +220,7 @@ namespace OpenTK.Graphics.OpenGLES2
         /// <param name="size"> Specifies the size in bytes of the data store region being replaced. </param>
         /// <param name="data"> Specifies a pointer to the new data that will be copied into the data store. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glBufferSubData.xhtml" /></remarks>
-        public static void BufferSubData(BufferTargetARB target, IntPtr offset, nint size, void* data) => GLPointers._glBufferSubData_fnptr((uint)target, offset, size, data);
+        public static void BufferSubData(BufferTarget target, IntPtr offset, nint size, void* data) => GLPointers._glBufferSubData_fnptr((uint)target, offset, size, data);
         
         /// <summary> <b>[requires: v2.0]</b> <b>[entry point: <c>glCheckFramebufferStatus</c>]</b><br/> Check the completeness status of a framebuffer. </summary>
         /// <param name="target"> Specify the target of the framebuffer completeness check. </param>
@@ -727,7 +727,7 @@ namespace OpenTK.Graphics.OpenGLES2
         /// <param name="offset"> Specifies the start of the buffer subrange, in basic machine units. </param>
         /// <param name="length"> Specifies the length of the buffer subrange, in basic machine units. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glFlushMappedBufferRange.xhtml" /></remarks>
-        public static void FlushMappedBufferRange(BufferTargetARB target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRange_fnptr((uint)target, offset, length);
+        public static void FlushMappedBufferRange(BufferTarget target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRange_fnptr((uint)target, offset, length);
         
         /// <summary> <b>[requires: v3.1]</b> <b>[entry point: <c>glFramebufferParameteri</c>]</b><br/> Set a named parameter of a framebuffer. </summary>
         /// <param name="target"> The target of the operation, which must be GL_READ_FRAMEBUFFER, GL_DRAW_FRAMEBUFFER or GL_FRAMEBUFFER. </param>
@@ -901,7 +901,7 @@ namespace OpenTK.Graphics.OpenGLES2
         /// <param name="index"> Specifies the index of the particular element being queried. </param>
         /// <param name="data"> Returns the value or values of the specified parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glGet.xhtml" /></remarks>
-        public static void GetBooleani_v(BufferTargetARB target, uint index, bool* data) => GLPointers._glGetBooleani_v_fnptr((uint)target, index, (byte*)data);
+        public static void GetBooleani_v(BufferTarget target, uint index, bool* data) => GLPointers._glGetBooleani_v_fnptr((uint)target, index, (byte*)data);
         
         /// <summary> <b>[requires: v2.0]</b> <b>[entry point: <c>glGetBooleanv</c>]</b><br/> Return the value or values of a selected parameter. </summary>
         /// <param name="pname"> Specifies the parameter value to be returned. The symbolic constants in the list below are accepted. </param>
@@ -914,21 +914,21 @@ namespace OpenTK.Graphics.OpenGLES2
         /// <param name="value"> Specifies the symbolic name of a buffer object parameter. Accepted values are GL_BUFFER_ACCESS_FLAGS, GL_BUFFER_MAPPED, GL_BUFFER_MAP_LENGTH, GL_BUFFER_MAP_OFFSET, GL_BUFFER_SIZE, or GL_BUFFER_USAGE. </param>
         /// <param name="data"> Returns the requested parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetBufferParameteri64v(BufferTargetARB target, BufferPNameARB pname, long* parameters) => GLPointers._glGetBufferParameteri64v_fnptr((uint)target, (uint)pname, parameters);
+        public static void GetBufferParameteri64v(BufferTarget target, BufferPName pname, long* parameters) => GLPointers._glGetBufferParameteri64v_fnptr((uint)target, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v2.0]</b> <b>[entry point: <c>glGetBufferParameteriv</c>]</b><br/> Return parameters of a buffer object. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glGetBufferParameteriv and glGetBufferParameteri64v. Must be one of the buffer binding targets in the following table: </param>
         /// <param name="value"> Specifies the symbolic name of a buffer object parameter. Accepted values are GL_BUFFER_ACCESS_FLAGS, GL_BUFFER_MAPPED, GL_BUFFER_MAP_LENGTH, GL_BUFFER_MAP_OFFSET, GL_BUFFER_SIZE, or GL_BUFFER_USAGE. </param>
         /// <param name="data"> Returns the requested parameter. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glGetBufferParameter.xhtml" /></remarks>
-        public static void GetBufferParameteriv(BufferTargetARB target, BufferPNameARB pname, int* parameters) => GLPointers._glGetBufferParameteriv_fnptr((uint)target, (uint)pname, parameters);
+        public static void GetBufferParameteriv(BufferTarget target, BufferPName pname, int* parameters) => GLPointers._glGetBufferParameteriv_fnptr((uint)target, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.0]</b> <b>[entry point: <c>glGetBufferPointerv</c>]</b><br/> Return the pointer to a mapped buffer object&apos;s data store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glGetBufferPointerv, which must be one of the buffer binding targets in the following table: </param>
         /// <param name="pname"> Specifies the pointer to be returned. The symbolic constant must be GL_BUFFER_MAP_POINTER. </param>
         /// <param name="parameters"> Returns the pointer value specified by pname. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glGetBufferPointerv.xhtml" /></remarks>
-        public static void GetBufferPointerv(BufferTargetARB target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointerv_fnptr((uint)target, (uint)pname, parameters);
+        public static void GetBufferPointerv(BufferTarget target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointerv_fnptr((uint)target, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.2 | GL_KHR_debug]</b> <b>[entry point: <c>glGetDebugMessageLog</c>]</b><br/> Retrieve messages from the debug message log. </summary>
         /// <param name="count"> The number of debug messages to retrieve from the log. </param>
@@ -1096,7 +1096,7 @@ namespace OpenTK.Graphics.OpenGLES2
         /// <param name="pname">Specifies the object parameter. Accepted symbolic names are GL_ACTIVE_ATOMIC_COUNTER_BUFFERS, GL_ACTIVE_ATTRIBUTES, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, GL_ACTIVE_UNIFORMS, GL_ACTIVE_UNIFORM_BLOCKS, GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH, GL_ACTIVE_UNIFORM_MAX_LENGTH, GL_ATTACHED_SHADERS, GL_COMPUTE_WORK_GROUP_SIZE, GL_DELETE_STATUS, GL_GEOMETRY_LINKED_INPUT_TYPE, GL_GEOMETRY_LINKED_OUTPUT_TYPE, GL_GEOMETRY_LINKED_VERTICES_OUT, GL_GEOMETRY_SHADER_INVOCATIONS, GL_INFO_LOG_LENGTH, GL_LINK_STATUS, GL_PROGRAM_BINARY_RETRIEVABLE_HINT, GL_PROGRAM_SEPARABLE, GL_TESS_CONTROL_OUTPUT_VERTICES, GL_TESS_GEN_MODE, GL_TESS_GEN_POINT_MODE, GL_TESS_GEN_SPACING, GL_TESS_GEN_VERTEX_ORDER, GL_TRANSFORM_FEEDBACK_BUFFER_MODE, GL_TRANSFORM_FEEDBACK_VARYINGS, GL_TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH and GL_VALIDATE_STATUS.</param>
         /// <param name="parameters">Returns the requested object parameter.</param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glGetProgramiv.xhtml" /></remarks>
-        public static void GetProgramiv(int program, ProgramPropertyARB pname, int* parameters) => GLPointers._glGetProgramiv_fnptr(program, (uint)pname, parameters);
+        public static void GetProgramiv(int program, ProgramProperty pname, int* parameters) => GLPointers._glGetProgramiv_fnptr(program, (uint)pname, parameters);
         
         /// <summary> <b>[requires: v3.1]</b> <b>[entry point: <c>glGetProgramPipelineInfoLog</c>]</b><br/> Retrieve the info log string from a program pipeline object. </summary>
         /// <param name="pipeline"> Specifies the name of a program pipeline object from which to retrieve the info log. </param>
@@ -1491,7 +1491,7 @@ namespace OpenTK.Graphics.OpenGLES2
         /// <param name="length"> Specifies the length of the range to be mapped. </param>
         /// <param name="access"> Specifies a combination of access flags indicating the desired access to the range. </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glMapBufferRange.xhtml" /></remarks>
-        public static void* MapBufferRange(BufferTargetARB target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRange_fnptr((uint)target, offset, length, (uint)access);
+        public static void* MapBufferRange(BufferTarget target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRange_fnptr((uint)target, offset, length, (uint)access);
         
         /// <summary> <b>[requires: v3.1]</b> <b>[entry point: <c>glMemoryBarrier</c>]</b><br/> Defines a barrier ordering memory transactions. </summary>
         /// <param name="barriers"> Specifies the barriers to insert. Must be a bitwise combination of GL_VERTEX_ATTRIB_ARRAY_BARRIER_BIT, GL_ELEMENT_ARRAY_BARRIER_BIT, GL_UNIFORM_BARRIER_BIT, GL_TEXTURE_FETCH_BARRIER_BIT, GL_SHADER_IMAGE_ACCESS_BARRIER_BIT, GL_COMMAND_BARRIER_BIT, GL_PIXEL_BUFFER_BARRIER_BIT, GL_TEXTURE_UPDATE_BARRIER_BIT, GL_BUFFER_UPDATE_BARRIER_BIT, GL_FRAMEBUFFER_BARRIER_BIT, GL_TRANSFORM_FEEDBACK_BARRIER_BIT, GL_ATOMIC_COUNTER_BARRIER_BIT, or GL_SHADER_STORAGE_BARRIER_BIT. If the special value GL_ALL_BARRIER_BITS is specified, all supported barriers will be inserted. </param>
@@ -2453,7 +2453,7 @@ namespace OpenTK.Graphics.OpenGLES2
         /// <summary> <b>[requires: v3.0]</b> <b>[entry point: <c>glUnmapBuffer</c>]</b><br/> Map a section of a buffer object&apos;s data store. </summary>
         /// <param name="target"> Specifies the target to which the buffer object is bound for glMapBufferRange, which must be one of the buffer binding targets in the following table: </param>
         /// <remarks><see href="https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glMapBufferRange.xhtml" /></remarks>
-        public static bool UnmapBuffer(BufferTargetARB target) => GLPointers._glUnmapBuffer_fnptr((uint)target) != 0;
+        public static bool UnmapBuffer(BufferTarget target) => GLPointers._glUnmapBuffer_fnptr((uint)target) != 0;
         
         /// <summary> <b>[requires: v2.0]</b> <b>[entry point: <c>glUseProgram</c>]</b><br/> Installs a program object as part of current rendering state. </summary>
         /// <param name="program">Specifies the handle of the program object whose executables are to be used as part of current rendering state.</param>
@@ -2754,13 +2754,13 @@ namespace OpenTK.Graphics.OpenGLES2
             public static void BindProgramPipelineEXT(int pipeline) => GLPointers._glBindProgramPipelineEXT_fnptr(pipeline);
             
             /// <summary> <b>[requires: GL_EXT_blend_minmax]</b> <b>[entry point: <c>glBlendEquationEXT</c>]</b><br/>  </summary>
-            public static void BlendEquationEXT(BlendEquationModeEXT mode) => GLPointers._glBlendEquationEXT_fnptr((uint)mode);
+            public static void BlendEquationEXT(BlendEquationMode mode) => GLPointers._glBlendEquationEXT_fnptr((uint)mode);
             
             /// <summary> <b>[requires: GL_EXT_draw_buffers_indexed]</b> <b>[entry point: <c>glBlendEquationiEXT</c>]</b><br/>  </summary>
-            public static void BlendEquationiEXT(uint buf, BlendEquationModeEXT mode) => GLPointers._glBlendEquationiEXT_fnptr(buf, (uint)mode);
+            public static void BlendEquationiEXT(uint buf, BlendEquationMode mode) => GLPointers._glBlendEquationiEXT_fnptr(buf, (uint)mode);
             
             /// <summary> <b>[requires: GL_EXT_draw_buffers_indexed]</b> <b>[entry point: <c>glBlendEquationSeparateiEXT</c>]</b><br/>  </summary>
-            public static void BlendEquationSeparateiEXT(uint buf, BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparateiEXT_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
+            public static void BlendEquationSeparateiEXT(uint buf, BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparateiEXT_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
             
             /// <summary> <b>[requires: GL_EXT_draw_buffers_indexed]</b> <b>[entry point: <c>glBlendFunciEXT</c>]</b><br/>  </summary>
             public static void BlendFunciEXT(uint buf, BlendingFactor src, BlendingFactor dst) => GLPointers._glBlendFunciEXT_fnptr(buf, (uint)src, (uint)dst);
@@ -2781,7 +2781,7 @@ namespace OpenTK.Graphics.OpenGLES2
             public static void BufferStorageExternalEXT(All target, IntPtr offset, nint size, void* clientBuffer, BufferStorageMask flags) => GLPointers._glBufferStorageExternalEXT_fnptr((uint)target, offset, size, clientBuffer, (uint)flags);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b> <b>[entry point: <c>glBufferStorageMemEXT</c>]</b><br/>  </summary>
-            public static void BufferStorageMemEXT(BufferTargetARB target, nint size, uint memory, ulong offset) => GLPointers._glBufferStorageMemEXT_fnptr((uint)target, size, memory, offset);
+            public static void BufferStorageMemEXT(BufferTarget target, nint size, uint memory, ulong offset) => GLPointers._glBufferStorageMemEXT_fnptr((uint)target, size, memory, offset);
             
             /// <summary> <b>[requires: GL_EXT_shader_pixel_local_storage2]</b> <b>[entry point: <c>glClearPixelLocalStorageuiEXT</c>]</b><br/>  </summary>
             public static void ClearPixelLocalStorageuiEXT(int offset, int n, uint* values) => GLPointers._glClearPixelLocalStorageuiEXT_fnptr(offset, n, values);
@@ -2877,7 +2877,7 @@ namespace OpenTK.Graphics.OpenGLES2
             public static void EndQueryEXT(QueryTarget target) => GLPointers._glEndQueryEXT_fnptr((uint)target);
             
             /// <summary> <b>[requires: GL_EXT_map_buffer_range]</b> <b>[entry point: <c>glFlushMappedBufferRangeEXT</c>]</b><br/>  </summary>
-            public static void FlushMappedBufferRangeEXT(BufferTargetARB target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRangeEXT_fnptr((uint)target, offset, length);
+            public static void FlushMappedBufferRangeEXT(BufferTarget target, IntPtr offset, nint length) => GLPointers._glFlushMappedBufferRangeEXT_fnptr((uint)target, offset, length);
             
             /// <summary> <b>[requires: GL_EXT_shader_framebuffer_fetch_non_coherent]</b> <b>[entry point: <c>glFramebufferFetchBarrierEXT</c>]</b><br/>  </summary>
             public static void FramebufferFetchBarrierEXT() => GLPointers._glFramebufferFetchBarrierEXT_fnptr();
@@ -3018,7 +3018,7 @@ namespace OpenTK.Graphics.OpenGLES2
             public static void LabelObjectEXT(All type, uint obj, int length, byte* label) => GLPointers._glLabelObjectEXT_fnptr((uint)type, obj, length, label);
             
             /// <summary> <b>[requires: GL_EXT_map_buffer_range]</b> <b>[entry point: <c>glMapBufferRangeEXT</c>]</b><br/>  </summary>
-            public static void* MapBufferRangeEXT(BufferTargetARB target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRangeEXT_fnptr((uint)target, offset, length, (uint)access);
+            public static void* MapBufferRangeEXT(BufferTarget target, IntPtr offset, nint length, MapBufferAccessMask access) => GLPointers._glMapBufferRangeEXT_fnptr((uint)target, offset, length, (uint)access);
             
             /// <summary> <b>[requires: GL_EXT_memory_object]</b> <b>[entry point: <c>glMemoryObjectParameterivEXT</c>]</b><br/>  </summary>
             public static void MemoryObjectParameterivEXT(uint memoryObject, MemoryObjectParameterName pname, int* parameters) => GLPointers._glMemoryObjectParameterivEXT_fnptr(memoryObject, (uint)pname, parameters);
@@ -3574,7 +3574,7 @@ namespace OpenTK.Graphics.OpenGLES2
             public static void BlitFramebufferNV(int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter) => GLPointers._glBlitFramebufferNV_fnptr(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, (uint)mask, (uint)filter);
             
             /// <summary> <b>[requires: GL_NV_memory_attachment]</b> <b>[entry point: <c>glBufferAttachMemoryNV</c>]</b><br/>  </summary>
-            public static void BufferAttachMemoryNV(BufferTargetARB target, uint memory, ulong offset) => GLPointers._glBufferAttachMemoryNV_fnptr((uint)target, memory, offset);
+            public static void BufferAttachMemoryNV(BufferTarget target, uint memory, ulong offset) => GLPointers._glBufferAttachMemoryNV_fnptr((uint)target, memory, offset);
             
             /// <summary> <b>[requires: GL_NV_memory_object_sparse]</b> <b>[entry point: <c>glBufferPageCommitmentMemNV</c>]</b><br/>  </summary>
             public static void BufferPageCommitmentMemNV(BufferStorageTarget target, IntPtr offset, nint size, uint memory, ulong memOffset, bool commit) => GLPointers._glBufferPageCommitmentMemNV_fnptr((uint)target, offset, size, memory, memOffset, (byte)(commit ? 1 : 0));
@@ -4205,10 +4205,10 @@ namespace OpenTK.Graphics.OpenGLES2
             public static void BindVertexArrayOES(int array) => GLPointers._glBindVertexArrayOES_fnptr(array);
             
             /// <summary> <b>[requires: GL_OES_draw_buffers_indexed]</b> <b>[entry point: <c>glBlendEquationiOES</c>]</b><br/>  </summary>
-            public static void BlendEquationiOES(uint buf, BlendEquationModeEXT mode) => GLPointers._glBlendEquationiOES_fnptr(buf, (uint)mode);
+            public static void BlendEquationiOES(uint buf, BlendEquationMode mode) => GLPointers._glBlendEquationiOES_fnptr(buf, (uint)mode);
             
             /// <summary> <b>[requires: GL_OES_draw_buffers_indexed]</b> <b>[entry point: <c>glBlendEquationSeparateiOES</c>]</b><br/>  </summary>
-            public static void BlendEquationSeparateiOES(uint buf, BlendEquationModeEXT modeRGB, BlendEquationModeEXT modeAlpha) => GLPointers._glBlendEquationSeparateiOES_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
+            public static void BlendEquationSeparateiOES(uint buf, BlendEquationMode modeRGB, BlendEquationMode modeAlpha) => GLPointers._glBlendEquationSeparateiOES_fnptr(buf, (uint)modeRGB, (uint)modeAlpha);
             
             /// <summary> <b>[requires: GL_OES_draw_buffers_indexed]</b> <b>[entry point: <c>glBlendFunciOES</c>]</b><br/>  </summary>
             public static void BlendFunciOES(uint buf, BlendingFactor src, BlendingFactor dst) => GLPointers._glBlendFunciOES_fnptr(buf, (uint)src, (uint)dst);
@@ -4271,7 +4271,7 @@ namespace OpenTK.Graphics.OpenGLES2
             public static void GenVertexArraysOES(int n, int* arrays) => GLPointers._glGenVertexArraysOES_fnptr(n, arrays);
             
             /// <summary> <b>[requires: GL_OES_mapbuffer]</b> <b>[entry point: <c>glGetBufferPointervOES</c>]</b><br/>  </summary>
-            public static void GetBufferPointervOES_(BufferTargetARB target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointervOES_fnptr((uint)target, (uint)pname, parameters);
+            public static void GetBufferPointervOES_(BufferTarget target, BufferPointerNameARB pname, void** parameters) => GLPointers._glGetBufferPointervOES_fnptr((uint)target, (uint)pname, parameters);
             
             /// <summary> <b>[requires: GL_OES_viewport_array]</b> <b>[entry point: <c>glGetFloati_vOES</c>]</b><br/>  </summary>
             public static void GetFloati_vOES(GetPName target, uint index, float* data) => GLPointers._glGetFloati_vOES_fnptr((uint)target, index, data);
@@ -4298,7 +4298,7 @@ namespace OpenTK.Graphics.OpenGLES2
             public static bool IsVertexArrayOES(int array) => GLPointers._glIsVertexArrayOES_fnptr(array) != 0;
             
             /// <summary> <b>[requires: GL_OES_mapbuffer]</b> <b>[entry point: <c>glMapBufferOES</c>]</b><br/>  </summary>
-            public static void* MapBufferOES(BufferTargetARB target, BufferAccessARB access) => GLPointers._glMapBufferOES_fnptr((uint)target, (uint)access);
+            public static void* MapBufferOES(BufferTarget target, BufferAccess access) => GLPointers._glMapBufferOES_fnptr((uint)target, (uint)access);
             
             /// <summary> <b>[requires: GL_OES_sample_shading]</b> <b>[entry point: <c>glMinSampleShadingOES</c>]</b><br/>  </summary>
             public static void MinSampleShadingOES(float value) => GLPointers._glMinSampleShadingOES_fnptr(value);

--- a/src/OpenTK.Graphics/OpenGLES2/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES2/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -19,14 +19,14 @@ namespace OpenTK.Graphics.OpenGLES2
             BindAttribLocation(program, index, name_ptr);
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData(BufferTarget target, nint size, IntPtr data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData(BufferTarget target, nint size, IntPtr data, BufferUsage usage)
         {
             void* data_vptr = (void*)data;
             BufferData(target, size, data_vptr, usage);
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsage usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -35,8 +35,8 @@ namespace OpenTK.Graphics.OpenGLES2
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTarget target, T1[] data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, T1[] data, BufferUsage usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -45,8 +45,8 @@ namespace OpenTK.Graphics.OpenGLES2
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTarget target, nint size, in T1 data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsage)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, nint size, in T1 data, BufferUsage usage)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)

--- a/src/OpenTK.Graphics/OpenGLES2/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES2/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:50 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -19,14 +19,14 @@ namespace OpenTK.Graphics.OpenGLES2
             BindAttribLocation(program, index, name_ptr);
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData(BufferTargetARB target, nint size, IntPtr data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData(BufferTarget target, nint size, IntPtr data, BufferUsageARB usage)
         {
             void* data_vptr = (void*)data;
             BufferData(target, size, data_vptr, usage);
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTargetARB target, ReadOnlySpan<T1> data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, ReadOnlySpan<T1> data, BufferUsageARB usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -35,8 +35,8 @@ namespace OpenTK.Graphics.OpenGLES2
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTargetARB target, T1[] data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, T1[] data, BufferUsageARB usage)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -45,8 +45,8 @@ namespace OpenTK.Graphics.OpenGLES2
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferData(BufferTargetARB, nint, void*, BufferUsageARB)"/>
-        public static unsafe void BufferData<T1>(BufferTargetARB target, nint size, in T1 data, BufferUsageARB usage)
+        /// <inheritdoc cref="BufferData(BufferTarget, nint, void*, BufferUsageARB)"/>
+        public static unsafe void BufferData<T1>(BufferTarget target, nint size, in T1 data, BufferUsageARB usage)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -54,14 +54,14 @@ namespace OpenTK.Graphics.OpenGLES2
                 BufferData(target, size, data_ptr, usage);
             }
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData(BufferTargetARB target, IntPtr offset, nint size, IntPtr data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData(BufferTarget target, IntPtr offset, nint size, IntPtr data)
         {
             void* data_vptr = (void*)data;
             BufferSubData(target, offset, size, data_vptr);
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData<T1>(BufferTargetARB target, IntPtr offset, ReadOnlySpan<T1> data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData<T1>(BufferTarget target, IntPtr offset, ReadOnlySpan<T1> data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -70,8 +70,8 @@ namespace OpenTK.Graphics.OpenGLES2
                 BufferSubData(target, offset, size, data_ptr);
             }
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData<T1>(BufferTargetARB target, IntPtr offset, T1[] data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData<T1>(BufferTarget target, IntPtr offset, T1[] data)
             where T1 : unmanaged
         {
             nint size = (nint)(data.Length * sizeof(T1));
@@ -80,8 +80,8 @@ namespace OpenTK.Graphics.OpenGLES2
                 BufferSubData(target, offset, size, data_ptr);
             }
         }
-        /// <inheritdoc cref="BufferSubData(BufferTargetARB, IntPtr, nint, void*)"/>
-        public static unsafe void BufferSubData<T1>(BufferTargetARB target, IntPtr offset, nint size, in T1 data)
+        /// <inheritdoc cref="BufferSubData(BufferTarget, IntPtr, nint, void*)"/>
+        public static unsafe void BufferSubData<T1>(BufferTarget target, IntPtr offset, nint size, in T1 data)
             where T1 : unmanaged
         {
             fixed (void* data_ptr = &data)
@@ -1757,32 +1757,32 @@ namespace OpenTK.Graphics.OpenGLES2
             Marshal.FreeCoTaskMem((IntPtr)name_ptr);
             return returnValue;
         }
-        /// <inheritdoc cref="GetBooleani_v(BufferTargetARB, uint, bool*)"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, Span<bool> data)
+        /// <inheritdoc cref="GetBooleani_v(BufferTarget, uint, bool*)"/>
+        public static unsafe void GetBoolean(BufferTarget target, uint index, Span<bool> data)
         {
             fixed (bool* data_ptr = data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
-        /// <inheritdoc cref="GetBooleani_v(BufferTargetARB, uint, bool*)"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, bool[] data)
+        /// <inheritdoc cref="GetBooleani_v(BufferTarget, uint, bool*)"/>
+        public static unsafe void GetBoolean(BufferTarget target, uint index, bool[] data)
         {
             fixed (bool* data_ptr = data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
-        /// <inheritdoc cref="GetBooleani_v(BufferTargetARB, uint, bool*)"/>
-        public static unsafe void GetBoolean(BufferTargetARB target, uint index, ref bool data)
+        /// <inheritdoc cref="GetBooleani_v(BufferTarget, uint, bool*)"/>
+        public static unsafe void GetBoolean(BufferTarget target, uint index, ref bool data)
         {
             fixed (bool* data_ptr = &data)
             {
                 GetBooleani_v(target, index, data_ptr);
             }
         }
-        /// <inheritdoc cref="GetBooleani_v(BufferTargetARB, uint, bool*)"/>
-        public static unsafe bool GetBoolean(BufferTargetARB target, uint index)
+        /// <inheritdoc cref="GetBooleani_v(BufferTarget, uint, bool*)"/>
+        public static unsafe bool GetBoolean(BufferTarget target, uint index)
         {
             bool data_val;
             bool* data = &data_val;
@@ -1821,77 +1821,77 @@ namespace OpenTK.Graphics.OpenGLES2
             GetBooleanv(pname, data);
             return data_val;
         }
-        /// <inheritdoc cref="GetBufferParameteri64v(BufferTargetARB, BufferPNameARB, long*)"/>
-        public static unsafe void GetBufferParameteri64(BufferTargetARB target, BufferPNameARB pname, Span<long> parameters)
+        /// <inheritdoc cref="GetBufferParameteri64v(BufferTarget, BufferPName, long*)"/>
+        public static unsafe void GetBufferParameteri64(BufferTarget target, BufferPName pname, Span<long> parameters)
         {
             fixed (long* parameters_ptr = parameters)
             {
                 GetBufferParameteri64v(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteri64v(BufferTargetARB, BufferPNameARB, long*)"/>
-        public static unsafe void GetBufferParameteri64(BufferTargetARB target, BufferPNameARB pname, long[] parameters)
+        /// <inheritdoc cref="GetBufferParameteri64v(BufferTarget, BufferPName, long*)"/>
+        public static unsafe void GetBufferParameteri64(BufferTarget target, BufferPName pname, long[] parameters)
         {
             fixed (long* parameters_ptr = parameters)
             {
                 GetBufferParameteri64v(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteri64v(BufferTargetARB, BufferPNameARB, long*)"/>
-        public static unsafe void GetBufferParameteri64(BufferTargetARB target, BufferPNameARB pname, ref long parameters)
+        /// <inheritdoc cref="GetBufferParameteri64v(BufferTarget, BufferPName, long*)"/>
+        public static unsafe void GetBufferParameteri64(BufferTarget target, BufferPName pname, ref long parameters)
         {
             fixed (long* parameters_ptr = &parameters)
             {
                 GetBufferParameteri64v(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteri64v(BufferTargetARB, BufferPNameARB, long*)"/>
-        public static unsafe long GetBufferParameteri64(BufferTargetARB target, BufferPNameARB pname)
+        /// <inheritdoc cref="GetBufferParameteri64v(BufferTarget, BufferPName, long*)"/>
+        public static unsafe long GetBufferParameteri64(BufferTarget target, BufferPName pname)
         {
             long parameters_val;
             long* parameters = &parameters_val;
             GetBufferParameteri64v(target, pname, parameters);
             return parameters_val;
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe void GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname, Span<int> parameters)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe void GetBufferParameteri(BufferTarget target, BufferPName pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetBufferParameteriv(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe void GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname, int[] parameters)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe void GetBufferParameteri(BufferTarget target, BufferPName pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetBufferParameteriv(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe void GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname, ref int parameters)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe void GetBufferParameteri(BufferTarget target, BufferPName pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
                 GetBufferParameteriv(target, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetBufferParameteriv(BufferTargetARB, BufferPNameARB, int*)"/>
-        public static unsafe int GetBufferParameteri(BufferTargetARB target, BufferPNameARB pname)
+        /// <inheritdoc cref="GetBufferParameteriv(BufferTarget, BufferPName, int*)"/>
+        public static unsafe int GetBufferParameteri(BufferTarget target, BufferPName pname)
         {
             int parameters_val;
             int* parameters = &parameters_val;
             GetBufferParameteriv(target, pname, parameters);
             return parameters_val;
         }
-        /// <inheritdoc cref="GetBufferPointerv(BufferTargetARB, BufferPointerNameARB, void**)"/>
-        public static unsafe void GetBufferPointer(BufferTargetARB target, BufferPointerNameARB pname, void** parameters)
+        /// <inheritdoc cref="GetBufferPointerv(BufferTarget, BufferPointerNameARB, void**)"/>
+        public static unsafe void GetBufferPointer(BufferTarget target, BufferPointerNameARB pname, void** parameters)
         {
             GetBufferPointerv(target, pname, parameters);
         }
-        /// <inheritdoc cref="GetBufferPointerv(BufferTargetARB, BufferPointerNameARB, void**)"/>
-        public static unsafe void* GetBufferPointer(BufferTargetARB target, BufferPointerNameARB pname)
+        /// <inheritdoc cref="GetBufferPointerv(BufferTarget, BufferPointerNameARB, void**)"/>
+        public static unsafe void* GetBufferPointer(BufferTarget target, BufferPointerNameARB pname)
         {
             void* parameters_val;
             void** parameters = &parameters_val;
@@ -2802,32 +2802,32 @@ namespace OpenTK.Graphics.OpenGLES2
             GetProgramInterfaceiv(program, programInterface, pname, parameters);
             return parameters_val;
         }
-        /// <inheritdoc cref="GetProgramiv(int, ProgramPropertyARB, int*)"/>
-        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, Span<int> parameters)
+        /// <inheritdoc cref="GetProgramiv(int, ProgramProperty, int*)"/>
+        public static unsafe void GetProgrami(int program, ProgramProperty pname, Span<int> parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetProgramiv(program, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetProgramiv(int, ProgramPropertyARB, int*)"/>
-        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, int[] parameters)
+        /// <inheritdoc cref="GetProgramiv(int, ProgramProperty, int*)"/>
+        public static unsafe void GetProgrami(int program, ProgramProperty pname, int[] parameters)
         {
             fixed (int* parameters_ptr = parameters)
             {
                 GetProgramiv(program, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetProgramiv(int, ProgramPropertyARB, int*)"/>
-        public static unsafe void GetProgrami(int program, ProgramPropertyARB pname, ref int parameters)
+        /// <inheritdoc cref="GetProgramiv(int, ProgramProperty, int*)"/>
+        public static unsafe void GetProgrami(int program, ProgramProperty pname, ref int parameters)
         {
             fixed (int* parameters_ptr = &parameters)
             {
                 GetProgramiv(program, pname, parameters_ptr);
             }
         }
-        /// <inheritdoc cref="GetProgramiv(int, ProgramPropertyARB, int*)"/>
-        public static unsafe int GetProgrami(int program, ProgramPropertyARB pname)
+        /// <inheritdoc cref="GetProgramiv(int, ProgramProperty, int*)"/>
+        public static unsafe int GetProgrami(int program, ProgramProperty pname)
         {
             int parameters_val;
             int* parameters = &parameters_val;
@@ -14288,13 +14288,13 @@ namespace OpenTK.Graphics.OpenGLES2
                     GenVertexArraysOES(n, arrays_ptr);
                 }
             }
-            /// <inheritdoc cref="GetBufferPointervOES(BufferTargetARB, BufferPointerNameARB, void**)"/>
-            public static unsafe void GetBufferPointervOES(BufferTargetARB target, BufferPointerNameARB pname, void** parameters)
+            /// <inheritdoc cref="GetBufferPointervOES(BufferTarget, BufferPointerNameARB, void**)"/>
+            public static unsafe void GetBufferPointervOES(BufferTarget target, BufferPointerNameARB pname, void** parameters)
             {
                 GetBufferPointervOES_(target, pname, parameters);
             }
-            /// <inheritdoc cref="GetBufferPointervOES(BufferTargetARB, BufferPointerNameARB, void**)"/>
-            public static unsafe void* GetBufferPointervOES(BufferTargetARB target, BufferPointerNameARB pname)
+            /// <inheritdoc cref="GetBufferPointervOES(BufferTarget, BufferPointerNameARB, void**)"/>
+            public static unsafe void* GetBufferPointervOES(BufferTarget target, BufferPointerNameARB pname)
             {
                 void* parameters_val;
                 void** parameters = &parameters_val;

--- a/src/OpenTK.Graphics/WGL.Pointers.cs
+++ b/src/OpenTK.Graphics/WGL.Pointers.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:43 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/WGL.Pointers.cs
+++ b/src/OpenTK.Graphics/WGL.Pointers.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:49 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:43 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/Wgl/Enums.cs
+++ b/src/OpenTK.Graphics/Wgl/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.Wgl

--- a/src/OpenTK.Graphics/Wgl/Enums.cs
+++ b/src/OpenTK.Graphics/Wgl/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:50 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.Wgl

--- a/src/OpenTK.Graphics/Wgl/WGL.Native.cs
+++ b/src/OpenTK.Graphics/Wgl/WGL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/Wgl/WGL.Native.cs
+++ b/src/OpenTK.Graphics/Wgl/WGL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:50 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/Wgl/WGL.Overloads.cs
+++ b/src/OpenTK.Graphics/Wgl/WGL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/OpenTK.Graphics/Wgl/WGL.Overloads.cs
+++ b/src/OpenTK.Graphics/Wgl/WGL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2023-10-16 17:21:50 GMT+02:00
+// This file is auto generated, do not edit. Generated: 2023-11-22 16:45:44 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;


### PR DESCRIPTION
### Purpose of this PR

Adds the ability for the generator to rename enum groups. 
This allows us to more easily be backwards compatible and allows us to rename some groups to make OpenTK 4 to OpenTK 5 migrations easier.

Currently this PR only contains some easy renamings from groups containing a `ARB` or `EXT` prefix so that do not do that.
But the goal is to add some easy wins to make OpenTK 4 to OpenTK 5 migrations simpler.

### Testing status

Tested locally, the generated code compiles.