### PR TITLE
Add AutoIconify property (exposes GLFW_AUTO_ICONIFY)

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -139,6 +139,25 @@ namespace OpenTK.Windowing.Desktop
             }
         }
 
+        private bool _fullscreenMinimizeOnFocusChange;
+
+        /// <summary>
+        /// <inheritdoc cref="NativeWindow.FullscreenMinimizeOnFocusChange"/>
+        /// </summary>
+        public unsafe bool FullscreenMinimizeOnFocusChange
+        {
+            get => _fullscreenMinimizeOnFocusChange;
+
+            set
+            {
+                if (_fullscreenMinimizeOnFocusChange != value)
+                {
+                    _fullscreenMinimizeOnFocusChange = value;
+                    GLFW.SetWindowAttrib(WindowPtr, WindowAttribute.AutoIconify, value);
+                }
+            }
+        }
+
         private WindowIcon _icon;
 
         /// <summary>
@@ -822,6 +841,9 @@ namespace OpenTK.Windowing.Desktop
             {
                 GLFW.WindowHint(WindowHintBool.TransparentFramebuffer, transparent);
             }
+
+            _fullscreenMinimizeOnFocusChange = settings.FullscreenMinimizeOnFocusChange;
+            GLFW.WindowHint(WindowHintBool.AutoIconify, settings.FullscreenMinimizeOnFocusChange);
 
             var monitor = settings.CurrentMonitor.ToUnsafePtr<GraphicsLibraryFramework.Monitor>();
             var modePtr = GLFW.GetVideoMode(monitor);

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -139,20 +139,20 @@ namespace OpenTK.Windowing.Desktop
             }
         }
 
-        private bool _fullscreenMinimizeOnFocusChange;
+        private bool _autoIconify;
 
         /// <summary>
-        /// <inheritdoc cref="NativeWindow.FullscreenMinimizeOnFocusChange"/>
+        /// <inheritdoc cref="NativeWindowSettings.AutoIconify"/>
         /// </summary>
-        public unsafe bool FullscreenMinimizeOnFocusChange
+        public unsafe bool AutoIconify
         {
-            get => _fullscreenMinimizeOnFocusChange;
+            get => _autoIconify;
 
             set
             {
-                if (_fullscreenMinimizeOnFocusChange != value)
+                if (_autoIconify != value)
                 {
-                    _fullscreenMinimizeOnFocusChange = value;
+                    _autoIconify = value;
                     GLFW.SetWindowAttrib(WindowPtr, WindowAttribute.AutoIconify, value);
                 }
             }
@@ -842,8 +842,8 @@ namespace OpenTK.Windowing.Desktop
                 GLFW.WindowHint(WindowHintBool.TransparentFramebuffer, transparent);
             }
 
-            _fullscreenMinimizeOnFocusChange = settings.FullscreenMinimizeOnFocusChange;
-            GLFW.WindowHint(WindowHintBool.AutoIconify, settings.FullscreenMinimizeOnFocusChange);
+            _autoIconify = settings.AutoIconify;
+            GLFW.WindowHint(WindowHintBool.AutoIconify, settings.AutoIconify);
 
             var monitor = settings.CurrentMonitor.ToUnsafePtr<GraphicsLibraryFramework.Monitor>();
             var modePtr = GLFW.GetVideoMode(monitor);

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -142,7 +142,8 @@ namespace OpenTK.Windowing.Desktop
         private bool _autoIconify;
 
         /// <summary>
-        /// <inheritdoc cref="NativeWindowSettings.AutoIconify"/>
+        /// Gets or sets a value indicating whether the application window will be minimized if the
+        /// focus changes while the window is in fullscreen mode. The default value is <c>true</c>.
         /// </summary>
         public unsafe bool AutoIconify
         {

--- a/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
@@ -8,6 +8,7 @@
 //
 
 using System;
+using System.Diagnostics;
 using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Common.Input;
@@ -267,5 +268,13 @@ namespace OpenTK.Windowing.Desktop
         /// if you are not using <see cref="GameWindow"/> you will have to handle adaptive vsync yourself.
         /// </summary>
         public VSyncMode Vsync { get; set; } = VSyncMode.Off;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the application window will be minimized if the
+        /// focus changes while the window is in fullscreen mode. Set this to false to allow use of windows
+        /// located on other monitors. The default value is true, except when a debugger is attached (such
+        /// as running in debug mode within Visual Studio).
+        /// </summary>
+        public bool FullscreenMinimizeOnFocusChange { get; set; } //= !Debugger.IsAttached;
     }
 }

--- a/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
@@ -8,6 +8,7 @@
 //
 
 using System;
+using System.Data.SqlTypes;
 using System.Diagnostics;
 using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
@@ -271,10 +272,8 @@ namespace OpenTK.Windowing.Desktop
 
         /// <summary>
         /// Gets or sets a value indicating whether the application window will be minimized if the
-        /// focus changes while the window is in fullscreen mode. Set this to false to allow use of windows
-        /// located on other monitors. The default value is true, except when a debugger is attached (such
-        /// as running in debug mode within Visual Studio).
+        /// focus changes while the window is in fullscreen mode. The default value is true.
         /// </summary>
-        public bool FullscreenMinimizeOnFocusChange { get; set; } //= !Debugger.IsAttached;
+        public bool AutoIconify { get; set; } = true;
     }
 }

--- a/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
@@ -8,8 +8,6 @@
 //
 
 using System;
-using System.Data.SqlTypes;
-using System.Diagnostics;
 using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Common.Input;
@@ -272,10 +270,7 @@ namespace OpenTK.Windowing.Desktop
 
         /// <summary>
         /// Gets or sets a value indicating whether the application window will be minimized if the
-        /// focus changes while the window is in fullscreen mode. The default value is <c>true</c>. Note that
-        /// <see cref="WindowState.Fullscreen"/> implies exclusive fullscreen mode, which means other normal windows on
-        /// the same monitor will not overdraw the application window. If overdraw is required, the library consumer must
-        /// define and manage a non-exclusive "borderless" window, sized and positioned to cover the entire display area.
+        /// focus changes while the window is in fullscreen mode. The default value is <c>true</c>.
         /// </summary>
         public bool AutoIconify { get; set; } = true;
     }

--- a/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
@@ -272,7 +272,10 @@ namespace OpenTK.Windowing.Desktop
 
         /// <summary>
         /// Gets or sets a value indicating whether the application window will be minimized if the
-        /// focus changes while the window is in fullscreen mode. The default value is true.
+        /// focus changes while the window is in fullscreen mode. The default value is <c>true</c>. Note that
+        /// <see cref="WindowState.Fullscreen"/> implies exclusive fullscreen mode, which means other normal windows on
+        /// the same monitor will not overdraw the application window. If overdraw is required, the library consumer must
+        /// define and manage a non-exclusive "borderless" window, sized and positioned to cover the entire display area.
         /// </summary>
         public bool AutoIconify { get; set; } = true;
     }

--- a/tests/LocalTest/Program.cs
+++ b/tests/LocalTest/Program.cs
@@ -78,6 +78,31 @@ namespace LocalTest
         protected override void OnUpdateFrame(FrameEventArgs args)
         {
             base.OnUpdateFrame(args);
+
+            var input = KeyboardState;
+
+            // ESC to quit
+            if (input.IsKeyReleased(Keys.Escape))
+            {
+                Close();
+                return;
+            }
+
+            // Space to toggle fullscreen
+            if (input.IsKeyReleased(Keys.Space))
+            {
+                WindowState = (WindowState == WindowState.Fullscreen) ? WindowState.Normal : WindowState.Fullscreen;
+                Console.WriteLine($"WindowState {WindowState}");
+                return;
+            }
+
+            // Enter to toggle FullscreenMinimizeOnFocusChange
+            if (input.IsKeyReleased(Keys.Enter))
+            {
+                FullscreenMinimizeOnFocusChange = !FullscreenMinimizeOnFocusChange;
+                Console.WriteLine($"FullscreenMinimizeOnFocusChange {FullscreenMinimizeOnFocusChange}");
+                return;
+            }
         }
 
         protected override void OnResize(ResizeEventArgs e)

--- a/tests/LocalTest/Program.cs
+++ b/tests/LocalTest/Program.cs
@@ -96,11 +96,11 @@ namespace LocalTest
                 return;
             }
 
-            // Enter to toggle FullscreenMinimizeOnFocusChange
+            // Enter to toggle AutoIconify
             if (input.IsKeyReleased(Keys.Enter))
             {
-                FullscreenMinimizeOnFocusChange = !FullscreenMinimizeOnFocusChange;
-                Console.WriteLine($"FullscreenMinimizeOnFocusChange {FullscreenMinimizeOnFocusChange}");
+                AutoIconify = !AutoIconify;
+                Console.WriteLine($"AutoIconify {AutoIconify}");
                 return;
             }
         }

--- a/tests/LocalTest/Program.cs
+++ b/tests/LocalTest/Program.cs
@@ -78,31 +78,6 @@ namespace LocalTest
         protected override void OnUpdateFrame(FrameEventArgs args)
         {
             base.OnUpdateFrame(args);
-
-            var input = KeyboardState;
-
-            // ESC to quit
-            if (input.IsKeyReleased(Keys.Escape))
-            {
-                Close();
-                return;
-            }
-
-            // Space to toggle fullscreen
-            if (input.IsKeyReleased(Keys.Space))
-            {
-                WindowState = (WindowState == WindowState.Fullscreen) ? WindowState.Normal : WindowState.Fullscreen;
-                Console.WriteLine($"WindowState {WindowState}");
-                return;
-            }
-
-            // Enter to toggle AutoIconify
-            if (input.IsKeyReleased(Keys.Enter))
-            {
-                AutoIconify = !AutoIconify;
-                Console.WriteLine($"AutoIconify {AutoIconify}");
-                return;
-            }
         }
 
         protected override void OnResize(ResizeEventArgs e)


### PR DESCRIPTION
Provides a native settings and window `AutoIconify` property to control whether an exclusive-mode fullscreen OpenTK window will minimize when another window gains focus. The default is true to avoid breaking changes (matching GLFW's default behavior). 

Most useful with multiple monitors, as the default exclusive fullscreen mode prevents other windows from overdrawing the GLFW window. The XML doc summary notes that if overdraw is required, the library consumer must "manually" prepare, size, and position a borderless window instead of setting `WindowState.Fullscreen`.

Tested by adding some toggle keys to the LocalTest project (fullscreen toggle is broken in 4.8.1, fixed by PR #1650, but easy enough to validate this without that):

```cs
protected override void OnUpdateFrame(FrameEventArgs args)
{
    base.OnUpdateFrame(args);

    var input = KeyboardState;

    // ESC to quit
    if (input.IsKeyReleased(Keys.Escape))
    {
        Close();
        return;
    }

    // Space to toggle fullscreen
    if (input.IsKeyReleased(Keys.Space))
    {
        WindowState = (WindowState == WindowState.Fullscreen) ? WindowState.Normal : WindowState.Fullscreen;
        Console.WriteLine($"WindowState {WindowState}");
        return;
    }

    // Enter to toggle AutoIconify
    if (input.IsKeyReleased(Keys.Enter))
    {
        AutoIconify = !AutoIconify;
        Console.WriteLine($"AutoIconify {AutoIconify}");
        return;
    }
}
```