### PR TITLE
[5.0] Add separate loaders for WGL and GLX bindings.

### DIFF
--- a/src/Generator/Parsing/SpecificationParser.cs
+++ b/src/Generator/Parsing/SpecificationParser.cs
@@ -603,6 +603,9 @@ namespace Generator.Parsing
                         "DWORD" => CSPrimitive.Uint(@const),
                         "FLOAT" => CSPrimitive.Float(@const),
                         "HANDLE" => CSPrimitive.IntPtr(@const),
+                        // FIXME: Do we want types for types like HDC and HGLRC
+                        // that we could use both here and in PAL2?
+                        // - Noggin_bops 2024-03-06
                         "HDC" => CSPrimitive.IntPtr(@const),
                         "HGLRC" => CSPrimitive.IntPtr(@const),
                         "INT" => CSPrimitive.Int(@const),

--- a/src/Generator/Parsing/SpecificationParser.cs
+++ b/src/Generator/Parsing/SpecificationParser.cs
@@ -610,7 +610,7 @@ namespace Generator.Parsing
                         "INT64" => CSPrimitive.Long(@const),
                         "PROC" => new CSFunctionPointer("???", @const),
                         "RECT" => new CSStruct("Rect", @const),
-                        "LPCSTR" => new CSPointer(new CSChar16(true), @const),
+                        "LPCSTR" => new CSPointer(new CSChar8(true), @const),
                         "LPVOID" => CSPrimitive.IntPtr(@const),
                         "UINT" => CSPrimitive.Uint(@const),
                         "USHORT" => CSPrimitive.Ushort(@const),

--- a/src/Generator/Process/OutputData.cs
+++ b/src/Generator/Process/OutputData.cs
@@ -192,6 +192,17 @@ namespace Generator.Writing
         }
     }
 
+    // This struct type is used internally to mark that this struct is opaque and needs to be converted to
+    // a pointer variant before it can be used.
+    // - Noggin_bops 2024-03-07
+    internal record CSOpaqueStruct(string TypeName, bool Constant) : BaseCSType, IConstantCSType
+    {
+        internal override string ToCSString()
+        {
+            throw new InvalidOperationException($"Opaque type '{TypeName}' should never be used directly");
+        }
+    }
+
     internal record CSStruct(string TypeName, bool Constant) : BaseCSType, IConstantCSType
     {
         internal override string ToCSString()

--- a/src/Generator/Writer.cs
+++ b/src/Generator/Writer.cs
@@ -16,7 +16,7 @@ namespace Generator.Writing
         private const string BaseNamespace = "OpenTK";
         private const string GraphicsNamespace = BaseNamespace + ".Graphics";
 
-        internal record FileStrings(string ClassName, string Namespace, string LoaderClass, string LoaderBindingsContext)
+        internal record FileStrings(string FileNamePrefix, string ClassName, string Namespace, string LoaderClass, string LoaderBindingsContext)
         {
             /// <summary>Alias for <see cref="ClassName"/>.</summary>
             public string ApiName => ClassName;
@@ -33,9 +33,9 @@ namespace Generator.Writing
             {
                 FileStrings strings = pointers.File switch
                 {
-                    GLFile.GL => new FileStrings("GL", "OpenGL", "GLLoader", "GLLoader.BindingsContext"),
-                    GLFile.WGL => new FileStrings("Wgl", "Wgl", "WGLLoader", "WGLLoader.BindingsContext"),
-                    GLFile.GLX => new FileStrings("Glx", "Glx", "GLXLoader", "GLXLoader.BindingsContext"),
+                    GLFile.GL => new FileStrings("GL", "GL", "OpenGL", "GLLoader", "GLLoader.BindingsContext"),
+                    GLFile.WGL => new FileStrings("WGL", "Wgl", "Wgl", "WGLLoader", "WGLLoader.BindingsContext"),
+                    GLFile.GLX => new FileStrings("GLX", "Glx", "Glx", "GLXLoader", "GLXLoader.BindingsContext"),
                     _ => throw new Exception(),
                 };
 
@@ -54,19 +54,19 @@ namespace Generator.Writing
             // FIXME: Fix function pointers so we can merge this.
             FileStrings strings = @namespace.Name switch
             {
-                OutputApi.GL => new FileStrings("GL", "OpenGL", "GLLoader", "GLLoader.BindingsContext"),
-                OutputApi.GLCompat => new FileStrings("GL", "OpenGL.Compatibility", "GLLoader", "GLLoader.BindingsContext"),
-                OutputApi.GLES1 => new FileStrings("GL", "OpenGLES1", "GLLoader", "GLLoader.BindingsContext"),
-                OutputApi.GLES2 => new FileStrings("GL", "OpenGLES2", "GLLoader", "GLLoader.BindingsContext"),
-                OutputApi.WGL => new FileStrings("Wgl", "Wgl", "WGLLoader", "WGLLoader.BindingsContext"),
-                OutputApi.GLX => new FileStrings("Glx", "Glx", "GLXLoader", "GLXLoader.BindingsContext"),
+                OutputApi.GL => new FileStrings("GL", "GL", "OpenGL", "GLLoader", "GLLoader.BindingsContext"),
+                OutputApi.GLCompat => new FileStrings("GL", "GL", "OpenGL.Compatibility", "GLLoader", "GLLoader.BindingsContext"),
+                OutputApi.GLES1 => new FileStrings("GL", "GL", "OpenGLES1", "GLLoader", "GLLoader.BindingsContext"),
+                OutputApi.GLES2 => new FileStrings("GL", "GL", "OpenGLES2", "GLLoader", "GLLoader.BindingsContext"),
+                OutputApi.WGL => new FileStrings("WGL", "Wgl", "Wgl", "WGLLoader", "WGLLoader.BindingsContext"),
+                OutputApi.GLX => new FileStrings("GLX", "Glx", "Glx", "GLXLoader", "GLXLoader.BindingsContext"),
                 _ => throw new Exception($"This is not a valid output API ({@namespace.Name})"),
             };
 
             string directoryPath = Path.Combine(outputProjectPath, Path.Combine(strings.Namespace.Split('.')));
             if (Directory.Exists(directoryPath) == false) Directory.CreateDirectory(directoryPath);
             var files = Directory.GetFiles(directoryPath, "*.cs", SearchOption.TopDirectoryOnly);
-            foreach (var file in files.Where(file => Path.GetFileName(file) != $"{strings.ClassName}.Manual.cs"))
+            foreach (var file in files.Where(file => Path.GetFileName(file) != $"{strings.FileNamePrefix}.Manual.cs"))
             {
                 File.Delete(file);
             }
@@ -80,7 +80,7 @@ namespace Generator.Writing
         // FIXME: Maybe we should nest this 
         private static void WriteFunctionPointers(string directoryPath, FileStrings strings, List<NativeFunction> nativeFunctions)
         {
-            using StreamWriter stream = File.CreateText(Path.Combine(directoryPath, $"{strings.ClassName}.Pointers.cs"));
+            using StreamWriter stream = File.CreateText(Path.Combine(directoryPath, $"{strings.FileNamePrefix}.Pointers.cs"));
             using IndentedTextWriter writer = new IndentedTextWriter(stream);
 
             // FIXME: using OpenTK.Graphics.OpenGL if we are wgl or glx...
@@ -231,7 +231,7 @@ namespace Generator.Writing
             SortedDictionary<string, GLVendorFunctions> groups,
             Dictionary<NativeFunction, FunctionDocumentation> documentation)
         {
-            using StreamWriter stream = File.CreateText(Path.Combine(directoryPath, $"{strings.ApiName}.Native.cs"));
+            using StreamWriter stream = File.CreateText(Path.Combine(directoryPath, $"{strings.FileNamePrefix}.Native.cs"));
             using IndentedTextWriter writer = new IndentedTextWriter(stream);
             writer.WriteLine($"// This file is auto generated, do not edit. Generated: {DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss \"GMT\"zzz")}");
             writer.WriteLine("using System;");
@@ -322,7 +322,7 @@ namespace Generator.Writing
             FileStrings strings,
             SortedDictionary<string, GLVendorFunctions> groups)
         {
-            using StreamWriter stream = File.CreateText(Path.Combine(directoryPath, $"{strings.ApiName}.Overloads.cs"));
+            using StreamWriter stream = File.CreateText(Path.Combine(directoryPath, $"{strings.FileNamePrefix}.Overloads.cs"));
             using IndentedTextWriter writer = new IndentedTextWriter(stream);
             writer.WriteLine($"// This file is auto generated, do not edit. Generated: {DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss \"GMT\"zzz")}");
             writer.WriteLine("using System;");

--- a/src/OpenTK.Graphics/GL.Pointers.cs
+++ b/src/OpenTK.Graphics/GL.Pointers.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:58 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/GL.Pointers.cs
+++ b/src/OpenTK.Graphics/GL.Pointers.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/GLX.Pointers.cs
+++ b/src/OpenTK.Graphics/GLX.Pointers.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;
@@ -9,74 +9,74 @@ namespace OpenTK.Graphics.Glx
     public static unsafe partial class GlxPointers
     {
         /// <summary><b>[entry point: <c>glXBindChannelToWindowSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int, nuint, int> _glXBindChannelToWindowSGIX_fnptr = &glXBindChannelToWindowSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int, nuint, int> _glXBindChannelToWindowSGIX_fnptr = &glXBindChannelToWindowSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXBindChannelToWindowSGIX_Lazy(Display* display, int screen, int channel, nuint window)
+        private static int glXBindChannelToWindowSGIX_Lazy(IntPtr display, int screen, int channel, nuint window)
         {
-            _glXBindChannelToWindowSGIX_fnptr = (delegate* unmanaged<Display*, int, int, nuint, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindChannelToWindowSGIX");
+            _glXBindChannelToWindowSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int, nuint, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindChannelToWindowSGIX");
             return _glXBindChannelToWindowSGIX_fnptr(display, screen, channel, window);
         }
         
         /// <summary><b>[entry point: <c>glXBindHyperpipeSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int> _glXBindHyperpipeSGIX_fnptr = &glXBindHyperpipeSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int> _glXBindHyperpipeSGIX_fnptr = &glXBindHyperpipeSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXBindHyperpipeSGIX_Lazy(Display* dpy, int hpId)
+        private static int glXBindHyperpipeSGIX_Lazy(IntPtr dpy, int hpId)
         {
-            _glXBindHyperpipeSGIX_fnptr = (delegate* unmanaged<Display*, int, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindHyperpipeSGIX");
+            _glXBindHyperpipeSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindHyperpipeSGIX");
             return _glXBindHyperpipeSGIX_fnptr(dpy, hpId);
         }
         
         /// <summary><b>[entry point: <c>glXBindSwapBarrierNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, uint, uint, byte> _glXBindSwapBarrierNV_fnptr = &glXBindSwapBarrierNV_Lazy;
+        public static delegate* unmanaged<IntPtr, uint, uint, byte> _glXBindSwapBarrierNV_fnptr = &glXBindSwapBarrierNV_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXBindSwapBarrierNV_Lazy(Display* dpy, uint group, uint barrier)
+        private static byte glXBindSwapBarrierNV_Lazy(IntPtr dpy, uint group, uint barrier)
         {
-            _glXBindSwapBarrierNV_fnptr = (delegate* unmanaged<Display*, uint, uint, byte>)GLXLoader.BindingsContext.GetProcAddress("glXBindSwapBarrierNV");
+            _glXBindSwapBarrierNV_fnptr = (delegate* unmanaged<IntPtr, uint, uint, byte>)GLXLoader.BindingsContext.GetProcAddress("glXBindSwapBarrierNV");
             return _glXBindSwapBarrierNV_fnptr(dpy, group, barrier);
         }
         
         /// <summary><b>[entry point: <c>glXBindSwapBarrierSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, int, void> _glXBindSwapBarrierSGIX_fnptr = &glXBindSwapBarrierSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, int, void> _glXBindSwapBarrierSGIX_fnptr = &glXBindSwapBarrierSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXBindSwapBarrierSGIX_Lazy(Display* dpy, nuint drawable, int barrier)
+        private static void glXBindSwapBarrierSGIX_Lazy(IntPtr dpy, nuint drawable, int barrier)
         {
-            _glXBindSwapBarrierSGIX_fnptr = (delegate* unmanaged<Display*, nuint, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXBindSwapBarrierSGIX");
+            _glXBindSwapBarrierSGIX_fnptr = (delegate* unmanaged<IntPtr, nuint, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXBindSwapBarrierSGIX");
             _glXBindSwapBarrierSGIX_fnptr(dpy, drawable, barrier);
         }
         
         /// <summary><b>[entry point: <c>glXBindTexImageEXT</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, int, int*, void> _glXBindTexImageEXT_fnptr = &glXBindTexImageEXT_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, int, int*, void> _glXBindTexImageEXT_fnptr = &glXBindTexImageEXT_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXBindTexImageEXT_Lazy(Display* dpy, nuint drawable, int buffer, int* attrib_list)
+        private static void glXBindTexImageEXT_Lazy(IntPtr dpy, nuint drawable, int buffer, int* attrib_list)
         {
-            _glXBindTexImageEXT_fnptr = (delegate* unmanaged<Display*, nuint, int, int*, void>)GLXLoader.BindingsContext.GetProcAddress("glXBindTexImageEXT");
+            _glXBindTexImageEXT_fnptr = (delegate* unmanaged<IntPtr, nuint, int, int*, void>)GLXLoader.BindingsContext.GetProcAddress("glXBindTexImageEXT");
             _glXBindTexImageEXT_fnptr(dpy, drawable, buffer, attrib_list);
         }
         
         /// <summary><b>[entry point: <c>glXBindVideoCaptureDeviceNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, uint, nuint, int> _glXBindVideoCaptureDeviceNV_fnptr = &glXBindVideoCaptureDeviceNV_Lazy;
+        public static delegate* unmanaged<IntPtr, uint, nuint, int> _glXBindVideoCaptureDeviceNV_fnptr = &glXBindVideoCaptureDeviceNV_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXBindVideoCaptureDeviceNV_Lazy(Display* dpy, uint video_capture_slot, nuint device)
+        private static int glXBindVideoCaptureDeviceNV_Lazy(IntPtr dpy, uint video_capture_slot, nuint device)
         {
-            _glXBindVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<Display*, uint, nuint, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindVideoCaptureDeviceNV");
+            _glXBindVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<IntPtr, uint, nuint, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindVideoCaptureDeviceNV");
             return _glXBindVideoCaptureDeviceNV_fnptr(dpy, video_capture_slot, device);
         }
         
         /// <summary><b>[entry point: <c>glXBindVideoDeviceNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, uint, uint, int*, int> _glXBindVideoDeviceNV_fnptr = &glXBindVideoDeviceNV_Lazy;
+        public static delegate* unmanaged<IntPtr, uint, uint, int*, int> _glXBindVideoDeviceNV_fnptr = &glXBindVideoDeviceNV_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXBindVideoDeviceNV_Lazy(Display* dpy, uint video_slot, uint video_device, int* attrib_list)
+        private static int glXBindVideoDeviceNV_Lazy(IntPtr dpy, uint video_slot, uint video_device, int* attrib_list)
         {
-            _glXBindVideoDeviceNV_fnptr = (delegate* unmanaged<Display*, uint, uint, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindVideoDeviceNV");
+            _glXBindVideoDeviceNV_fnptr = (delegate* unmanaged<IntPtr, uint, uint, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindVideoDeviceNV");
             return _glXBindVideoDeviceNV_fnptr(dpy, video_slot, video_device, attrib_list);
         }
         
         /// <summary><b>[entry point: <c>glXBindVideoImageNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, uint, nuint, int, int> _glXBindVideoImageNV_fnptr = &glXBindVideoImageNV_Lazy;
+        public static delegate* unmanaged<IntPtr, uint, nuint, int, int> _glXBindVideoImageNV_fnptr = &glXBindVideoImageNV_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXBindVideoImageNV_Lazy(Display* dpy, uint VideoDevice, nuint pbuf, int iVideoBuffer)
+        private static int glXBindVideoImageNV_Lazy(IntPtr dpy, uint VideoDevice, nuint pbuf, int iVideoBuffer)
         {
-            _glXBindVideoImageNV_fnptr = (delegate* unmanaged<Display*, uint, nuint, int, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindVideoImageNV");
+            _glXBindVideoImageNV_fnptr = (delegate* unmanaged<IntPtr, uint, nuint, int, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindVideoImageNV");
             return _glXBindVideoImageNV_fnptr(dpy, VideoDevice, pbuf, iVideoBuffer);
         }
         
@@ -90,83 +90,83 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXChannelRectSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int, int, int, int, int, int> _glXChannelRectSGIX_fnptr = &glXChannelRectSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int, int, int, int, int, int> _glXChannelRectSGIX_fnptr = &glXChannelRectSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXChannelRectSGIX_Lazy(Display* display, int screen, int channel, int x, int y, int w, int h)
+        private static int glXChannelRectSGIX_Lazy(IntPtr display, int screen, int channel, int x, int y, int w, int h)
         {
-            _glXChannelRectSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int, int, int, int, int>)GLXLoader.BindingsContext.GetProcAddress("glXChannelRectSGIX");
+            _glXChannelRectSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int, int, int, int, int, int>)GLXLoader.BindingsContext.GetProcAddress("glXChannelRectSGIX");
             return _glXChannelRectSGIX_fnptr(display, screen, channel, x, y, w, h);
         }
         
         /// <summary><b>[entry point: <c>glXChannelRectSyncSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int, uint, int> _glXChannelRectSyncSGIX_fnptr = &glXChannelRectSyncSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int, uint, int> _glXChannelRectSyncSGIX_fnptr = &glXChannelRectSyncSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXChannelRectSyncSGIX_Lazy(Display* display, int screen, int channel, uint synctype)
+        private static int glXChannelRectSyncSGIX_Lazy(IntPtr display, int screen, int channel, uint synctype)
         {
-            _glXChannelRectSyncSGIX_fnptr = (delegate* unmanaged<Display*, int, int, uint, int>)GLXLoader.BindingsContext.GetProcAddress("glXChannelRectSyncSGIX");
+            _glXChannelRectSyncSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int, uint, int>)GLXLoader.BindingsContext.GetProcAddress("glXChannelRectSyncSGIX");
             return _glXChannelRectSyncSGIX_fnptr(display, screen, channel, synctype);
         }
         
         /// <summary><b>[entry point: <c>glXChooseFBConfig</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int*, int*, IntPtr*> _glXChooseFBConfig_fnptr = &glXChooseFBConfig_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int*, int*, IntPtr*> _glXChooseFBConfig_fnptr = &glXChooseFBConfig_Lazy;
         [UnmanagedCallersOnly]
-        private static IntPtr* glXChooseFBConfig_Lazy(Display* dpy, int screen, int* attrib_list, int* nelements)
+        private static IntPtr* glXChooseFBConfig_Lazy(IntPtr dpy, int screen, int* attrib_list, int* nelements)
         {
-            _glXChooseFBConfig_fnptr = (delegate* unmanaged<Display*, int, int*, int*, IntPtr*>)GLXLoader.BindingsContext.GetProcAddress("glXChooseFBConfig");
+            _glXChooseFBConfig_fnptr = (delegate* unmanaged<IntPtr, int, int*, int*, IntPtr*>)GLXLoader.BindingsContext.GetProcAddress("glXChooseFBConfig");
             return _glXChooseFBConfig_fnptr(dpy, screen, attrib_list, nelements);
         }
         
         /// <summary><b>[entry point: <c>glXChooseFBConfigSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int*, int*, IntPtr*> _glXChooseFBConfigSGIX_fnptr = &glXChooseFBConfigSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int*, int*, IntPtr*> _glXChooseFBConfigSGIX_fnptr = &glXChooseFBConfigSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static IntPtr* glXChooseFBConfigSGIX_Lazy(Display* dpy, int screen, int* attrib_list, int* nelements)
+        private static IntPtr* glXChooseFBConfigSGIX_Lazy(IntPtr dpy, int screen, int* attrib_list, int* nelements)
         {
-            _glXChooseFBConfigSGIX_fnptr = (delegate* unmanaged<Display*, int, int*, int*, IntPtr*>)GLXLoader.BindingsContext.GetProcAddress("glXChooseFBConfigSGIX");
+            _glXChooseFBConfigSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int*, int*, IntPtr*>)GLXLoader.BindingsContext.GetProcAddress("glXChooseFBConfigSGIX");
             return _glXChooseFBConfigSGIX_fnptr(dpy, screen, attrib_list, nelements);
         }
         
         /// <summary><b>[entry point: <c>glXChooseVisual</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int*, XVisualInfo*> _glXChooseVisual_fnptr = &glXChooseVisual_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int*, IntPtr> _glXChooseVisual_fnptr = &glXChooseVisual_Lazy;
         [UnmanagedCallersOnly]
-        private static XVisualInfo* glXChooseVisual_Lazy(Display* dpy, int screen, int* attribList)
+        private static IntPtr glXChooseVisual_Lazy(IntPtr dpy, int screen, int* attribList)
         {
-            _glXChooseVisual_fnptr = (delegate* unmanaged<Display*, int, int*, XVisualInfo*>)GLXLoader.BindingsContext.GetProcAddress("glXChooseVisual");
+            _glXChooseVisual_fnptr = (delegate* unmanaged<IntPtr, int, int*, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXChooseVisual");
             return _glXChooseVisual_fnptr(dpy, screen, attribList);
         }
         
         /// <summary><b>[entry point: <c>glXCopyBufferSubDataNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, IntPtr, uint, uint, IntPtr, IntPtr, nint, void> _glXCopyBufferSubDataNV_fnptr = &glXCopyBufferSubDataNV_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, IntPtr, uint, uint, IntPtr, IntPtr, nint, void> _glXCopyBufferSubDataNV_fnptr = &glXCopyBufferSubDataNV_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXCopyBufferSubDataNV_Lazy(Display* dpy, IntPtr readCtx, IntPtr writeCtx, uint readTarget, uint writeTarget, IntPtr readOffset, IntPtr writeOffset, nint size)
+        private static void glXCopyBufferSubDataNV_Lazy(IntPtr dpy, IntPtr readCtx, IntPtr writeCtx, uint readTarget, uint writeTarget, IntPtr readOffset, IntPtr writeOffset, nint size)
         {
-            _glXCopyBufferSubDataNV_fnptr = (delegate* unmanaged<Display*, IntPtr, IntPtr, uint, uint, IntPtr, IntPtr, nint, void>)GLXLoader.BindingsContext.GetProcAddress("glXCopyBufferSubDataNV");
+            _glXCopyBufferSubDataNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr, IntPtr, uint, uint, IntPtr, IntPtr, nint, void>)GLXLoader.BindingsContext.GetProcAddress("glXCopyBufferSubDataNV");
             _glXCopyBufferSubDataNV_fnptr(dpy, readCtx, writeCtx, readTarget, writeTarget, readOffset, writeOffset, size);
         }
         
         /// <summary><b>[entry point: <c>glXCopyContext</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, IntPtr, ulong, void> _glXCopyContext_fnptr = &glXCopyContext_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, IntPtr, ulong, void> _glXCopyContext_fnptr = &glXCopyContext_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXCopyContext_Lazy(Display* dpy, IntPtr src, IntPtr dst, ulong mask)
+        private static void glXCopyContext_Lazy(IntPtr dpy, IntPtr src, IntPtr dst, ulong mask)
         {
-            _glXCopyContext_fnptr = (delegate* unmanaged<Display*, IntPtr, IntPtr, ulong, void>)GLXLoader.BindingsContext.GetProcAddress("glXCopyContext");
+            _glXCopyContext_fnptr = (delegate* unmanaged<IntPtr, IntPtr, IntPtr, ulong, void>)GLXLoader.BindingsContext.GetProcAddress("glXCopyContext");
             _glXCopyContext_fnptr(dpy, src, dst, mask);
         }
         
         /// <summary><b>[entry point: <c>glXCopyImageSubDataNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, uint, uint, int, int, int, int, IntPtr, uint, uint, int, int, int, int, int, int, int, void> _glXCopyImageSubDataNV_fnptr = &glXCopyImageSubDataNV_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, uint, uint, int, int, int, int, IntPtr, uint, uint, int, int, int, int, int, int, int, void> _glXCopyImageSubDataNV_fnptr = &glXCopyImageSubDataNV_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXCopyImageSubDataNV_Lazy(Display* dpy, IntPtr srcCtx, uint srcName, uint srcTarget, int srcLevel, int srcX, int srcY, int srcZ, IntPtr dstCtx, uint dstName, uint dstTarget, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth)
+        private static void glXCopyImageSubDataNV_Lazy(IntPtr dpy, IntPtr srcCtx, uint srcName, uint srcTarget, int srcLevel, int srcX, int srcY, int srcZ, IntPtr dstCtx, uint dstName, uint dstTarget, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth)
         {
-            _glXCopyImageSubDataNV_fnptr = (delegate* unmanaged<Display*, IntPtr, uint, uint, int, int, int, int, IntPtr, uint, uint, int, int, int, int, int, int, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXCopyImageSubDataNV");
+            _glXCopyImageSubDataNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr, uint, uint, int, int, int, int, IntPtr, uint, uint, int, int, int, int, int, int, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXCopyImageSubDataNV");
             _glXCopyImageSubDataNV_fnptr(dpy, srcCtx, srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstCtx, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
         }
         
         /// <summary><b>[entry point: <c>glXCopySubBufferMESA</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, int, int, int, int, void> _glXCopySubBufferMESA_fnptr = &glXCopySubBufferMESA_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, int, int, int, int, void> _glXCopySubBufferMESA_fnptr = &glXCopySubBufferMESA_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXCopySubBufferMESA_Lazy(Display* dpy, nuint drawable, int x, int y, int width, int height)
+        private static void glXCopySubBufferMESA_Lazy(IntPtr dpy, nuint drawable, int x, int y, int width, int height)
         {
-            _glXCopySubBufferMESA_fnptr = (delegate* unmanaged<Display*, nuint, int, int, int, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXCopySubBufferMESA");
+            _glXCopySubBufferMESA_fnptr = (delegate* unmanaged<IntPtr, nuint, int, int, int, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXCopySubBufferMESA");
             _glXCopySubBufferMESA_fnptr(dpy, drawable, x, y, width, height);
         }
         
@@ -189,119 +189,119 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXCreateContext</c>]</b></summary>
-        public static delegate* unmanaged<Display*, XVisualInfo*, IntPtr, byte, IntPtr> _glXCreateContext_fnptr = &glXCreateContext_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, IntPtr, byte, IntPtr> _glXCreateContext_fnptr = &glXCreateContext_Lazy;
         [UnmanagedCallersOnly]
-        private static IntPtr glXCreateContext_Lazy(Display* dpy, XVisualInfo* vis, IntPtr shareList, byte direct)
+        private static IntPtr glXCreateContext_Lazy(IntPtr dpy, IntPtr vis, IntPtr shareList, byte direct)
         {
-            _glXCreateContext_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, IntPtr, byte, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateContext");
+            _glXCreateContext_fnptr = (delegate* unmanaged<IntPtr, IntPtr, IntPtr, byte, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateContext");
             return _glXCreateContext_fnptr(dpy, vis, shareList, direct);
         }
         
         /// <summary><b>[entry point: <c>glXCreateContextAttribsARB</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, IntPtr, byte, int*, IntPtr> _glXCreateContextAttribsARB_fnptr = &glXCreateContextAttribsARB_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, IntPtr, byte, int*, IntPtr> _glXCreateContextAttribsARB_fnptr = &glXCreateContextAttribsARB_Lazy;
         [UnmanagedCallersOnly]
-        private static IntPtr glXCreateContextAttribsARB_Lazy(Display* dpy, IntPtr config, IntPtr share_context, byte direct, int* attrib_list)
+        private static IntPtr glXCreateContextAttribsARB_Lazy(IntPtr dpy, IntPtr config, IntPtr share_context, byte direct, int* attrib_list)
         {
-            _glXCreateContextAttribsARB_fnptr = (delegate* unmanaged<Display*, IntPtr, IntPtr, byte, int*, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateContextAttribsARB");
+            _glXCreateContextAttribsARB_fnptr = (delegate* unmanaged<IntPtr, IntPtr, IntPtr, byte, int*, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateContextAttribsARB");
             return _glXCreateContextAttribsARB_fnptr(dpy, config, share_context, direct, attrib_list);
         }
         
         /// <summary><b>[entry point: <c>glXCreateContextWithConfigSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, int, IntPtr, byte, IntPtr> _glXCreateContextWithConfigSGIX_fnptr = &glXCreateContextWithConfigSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, int, IntPtr, byte, IntPtr> _glXCreateContextWithConfigSGIX_fnptr = &glXCreateContextWithConfigSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static IntPtr glXCreateContextWithConfigSGIX_Lazy(Display* dpy, IntPtr config, int render_type, IntPtr share_list, byte direct)
+        private static IntPtr glXCreateContextWithConfigSGIX_Lazy(IntPtr dpy, IntPtr config, int render_type, IntPtr share_list, byte direct)
         {
-            _glXCreateContextWithConfigSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, int, IntPtr, byte, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateContextWithConfigSGIX");
+            _glXCreateContextWithConfigSGIX_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int, IntPtr, byte, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateContextWithConfigSGIX");
             return _glXCreateContextWithConfigSGIX_fnptr(dpy, config, render_type, share_list, direct);
         }
         
         /// <summary><b>[entry point: <c>glXCreateGLXPbufferSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, uint, uint, int*, nuint> _glXCreateGLXPbufferSGIX_fnptr = &glXCreateGLXPbufferSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, uint, uint, int*, nuint> _glXCreateGLXPbufferSGIX_fnptr = &glXCreateGLXPbufferSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static nuint glXCreateGLXPbufferSGIX_Lazy(Display* dpy, IntPtr config, uint width, uint height, int* attrib_list)
+        private static nuint glXCreateGLXPbufferSGIX_Lazy(IntPtr dpy, IntPtr config, uint width, uint height, int* attrib_list)
         {
-            _glXCreateGLXPbufferSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, uint, uint, int*, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateGLXPbufferSGIX");
+            _glXCreateGLXPbufferSGIX_fnptr = (delegate* unmanaged<IntPtr, IntPtr, uint, uint, int*, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateGLXPbufferSGIX");
             return _glXCreateGLXPbufferSGIX_fnptr(dpy, config, width, height, attrib_list);
         }
         
         /// <summary><b>[entry point: <c>glXCreateGLXPixmap</c>]</b></summary>
-        public static delegate* unmanaged<Display*, XVisualInfo*, nuint, nuint> _glXCreateGLXPixmap_fnptr = &glXCreateGLXPixmap_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, nuint, nuint> _glXCreateGLXPixmap_fnptr = &glXCreateGLXPixmap_Lazy;
         [UnmanagedCallersOnly]
-        private static nuint glXCreateGLXPixmap_Lazy(Display* dpy, XVisualInfo* visual, nuint pixmap)
+        private static nuint glXCreateGLXPixmap_Lazy(IntPtr dpy, IntPtr visual, nuint pixmap)
         {
-            _glXCreateGLXPixmap_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, nuint, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateGLXPixmap");
+            _glXCreateGLXPixmap_fnptr = (delegate* unmanaged<IntPtr, IntPtr, nuint, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateGLXPixmap");
             return _glXCreateGLXPixmap_fnptr(dpy, visual, pixmap);
         }
         
         /// <summary><b>[entry point: <c>glXCreateGLXPixmapMESA</c>]</b></summary>
-        public static delegate* unmanaged<Display*, XVisualInfo*, nuint, nuint, nuint> _glXCreateGLXPixmapMESA_fnptr = &glXCreateGLXPixmapMESA_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, nuint, nuint, nuint> _glXCreateGLXPixmapMESA_fnptr = &glXCreateGLXPixmapMESA_Lazy;
         [UnmanagedCallersOnly]
-        private static nuint glXCreateGLXPixmapMESA_Lazy(Display* dpy, XVisualInfo* visual, nuint pixmap, nuint cmap)
+        private static nuint glXCreateGLXPixmapMESA_Lazy(IntPtr dpy, IntPtr visual, nuint pixmap, nuint cmap)
         {
-            _glXCreateGLXPixmapMESA_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, nuint, nuint, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateGLXPixmapMESA");
+            _glXCreateGLXPixmapMESA_fnptr = (delegate* unmanaged<IntPtr, IntPtr, nuint, nuint, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateGLXPixmapMESA");
             return _glXCreateGLXPixmapMESA_fnptr(dpy, visual, pixmap, cmap);
         }
         
         /// <summary><b>[entry point: <c>glXCreateGLXPixmapWithConfigSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, nuint, nuint> _glXCreateGLXPixmapWithConfigSGIX_fnptr = &glXCreateGLXPixmapWithConfigSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, nuint, nuint> _glXCreateGLXPixmapWithConfigSGIX_fnptr = &glXCreateGLXPixmapWithConfigSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static nuint glXCreateGLXPixmapWithConfigSGIX_Lazy(Display* dpy, IntPtr config, nuint pixmap)
+        private static nuint glXCreateGLXPixmapWithConfigSGIX_Lazy(IntPtr dpy, IntPtr config, nuint pixmap)
         {
-            _glXCreateGLXPixmapWithConfigSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, nuint, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateGLXPixmapWithConfigSGIX");
+            _glXCreateGLXPixmapWithConfigSGIX_fnptr = (delegate* unmanaged<IntPtr, IntPtr, nuint, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateGLXPixmapWithConfigSGIX");
             return _glXCreateGLXPixmapWithConfigSGIX_fnptr(dpy, config, pixmap);
         }
         
         /// <summary><b>[entry point: <c>glXCreateNewContext</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, int, IntPtr, byte, IntPtr> _glXCreateNewContext_fnptr = &glXCreateNewContext_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, int, IntPtr, byte, IntPtr> _glXCreateNewContext_fnptr = &glXCreateNewContext_Lazy;
         [UnmanagedCallersOnly]
-        private static IntPtr glXCreateNewContext_Lazy(Display* dpy, IntPtr config, int render_type, IntPtr share_list, byte direct)
+        private static IntPtr glXCreateNewContext_Lazy(IntPtr dpy, IntPtr config, int render_type, IntPtr share_list, byte direct)
         {
-            _glXCreateNewContext_fnptr = (delegate* unmanaged<Display*, IntPtr, int, IntPtr, byte, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateNewContext");
+            _glXCreateNewContext_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int, IntPtr, byte, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateNewContext");
             return _glXCreateNewContext_fnptr(dpy, config, render_type, share_list, direct);
         }
         
         /// <summary><b>[entry point: <c>glXCreatePbuffer</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, int*, nuint> _glXCreatePbuffer_fnptr = &glXCreatePbuffer_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, int*, nuint> _glXCreatePbuffer_fnptr = &glXCreatePbuffer_Lazy;
         [UnmanagedCallersOnly]
-        private static nuint glXCreatePbuffer_Lazy(Display* dpy, IntPtr config, int* attrib_list)
+        private static nuint glXCreatePbuffer_Lazy(IntPtr dpy, IntPtr config, int* attrib_list)
         {
-            _glXCreatePbuffer_fnptr = (delegate* unmanaged<Display*, IntPtr, int*, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreatePbuffer");
+            _glXCreatePbuffer_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int*, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreatePbuffer");
             return _glXCreatePbuffer_fnptr(dpy, config, attrib_list);
         }
         
         /// <summary><b>[entry point: <c>glXCreatePixmap</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, nuint, int*, nuint> _glXCreatePixmap_fnptr = &glXCreatePixmap_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, nuint, int*, nuint> _glXCreatePixmap_fnptr = &glXCreatePixmap_Lazy;
         [UnmanagedCallersOnly]
-        private static nuint glXCreatePixmap_Lazy(Display* dpy, IntPtr config, nuint pixmap, int* attrib_list)
+        private static nuint glXCreatePixmap_Lazy(IntPtr dpy, IntPtr config, nuint pixmap, int* attrib_list)
         {
-            _glXCreatePixmap_fnptr = (delegate* unmanaged<Display*, IntPtr, nuint, int*, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreatePixmap");
+            _glXCreatePixmap_fnptr = (delegate* unmanaged<IntPtr, IntPtr, nuint, int*, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreatePixmap");
             return _glXCreatePixmap_fnptr(dpy, config, pixmap, attrib_list);
         }
         
         /// <summary><b>[entry point: <c>glXCreateWindow</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, nuint, int*, nuint> _glXCreateWindow_fnptr = &glXCreateWindow_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, nuint, int*, nuint> _glXCreateWindow_fnptr = &glXCreateWindow_Lazy;
         [UnmanagedCallersOnly]
-        private static nuint glXCreateWindow_Lazy(Display* dpy, IntPtr config, nuint win, int* attrib_list)
+        private static nuint glXCreateWindow_Lazy(IntPtr dpy, IntPtr config, nuint win, int* attrib_list)
         {
-            _glXCreateWindow_fnptr = (delegate* unmanaged<Display*, IntPtr, nuint, int*, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateWindow");
+            _glXCreateWindow_fnptr = (delegate* unmanaged<IntPtr, IntPtr, nuint, int*, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateWindow");
             return _glXCreateWindow_fnptr(dpy, config, win, attrib_list);
         }
         
         /// <summary><b>[entry point: <c>glXCushionSGI</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, float, void> _glXCushionSGI_fnptr = &glXCushionSGI_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, float, void> _glXCushionSGI_fnptr = &glXCushionSGI_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXCushionSGI_Lazy(Display* dpy, nuint window, float cushion)
+        private static void glXCushionSGI_Lazy(IntPtr dpy, nuint window, float cushion)
         {
-            _glXCushionSGI_fnptr = (delegate* unmanaged<Display*, nuint, float, void>)GLXLoader.BindingsContext.GetProcAddress("glXCushionSGI");
+            _glXCushionSGI_fnptr = (delegate* unmanaged<IntPtr, nuint, float, void>)GLXLoader.BindingsContext.GetProcAddress("glXCushionSGI");
             _glXCushionSGI_fnptr(dpy, window, cushion);
         }
         
         /// <summary><b>[entry point: <c>glXDelayBeforeSwapNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, float, byte> _glXDelayBeforeSwapNV_fnptr = &glXDelayBeforeSwapNV_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, float, byte> _glXDelayBeforeSwapNV_fnptr = &glXDelayBeforeSwapNV_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXDelayBeforeSwapNV_Lazy(Display* dpy, nuint drawable, float seconds)
+        private static byte glXDelayBeforeSwapNV_Lazy(IntPtr dpy, nuint drawable, float seconds)
         {
-            _glXDelayBeforeSwapNV_fnptr = (delegate* unmanaged<Display*, nuint, float, byte>)GLXLoader.BindingsContext.GetProcAddress("glXDelayBeforeSwapNV");
+            _glXDelayBeforeSwapNV_fnptr = (delegate* unmanaged<IntPtr, nuint, float, byte>)GLXLoader.BindingsContext.GetProcAddress("glXDelayBeforeSwapNV");
             return _glXDelayBeforeSwapNV_fnptr(dpy, drawable, seconds);
         }
         
@@ -315,92 +315,92 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXDestroyContext</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, void> _glXDestroyContext_fnptr = &glXDestroyContext_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, void> _glXDestroyContext_fnptr = &glXDestroyContext_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXDestroyContext_Lazy(Display* dpy, IntPtr ctx)
+        private static void glXDestroyContext_Lazy(IntPtr dpy, IntPtr ctx)
         {
-            _glXDestroyContext_fnptr = (delegate* unmanaged<Display*, IntPtr, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyContext");
+            _glXDestroyContext_fnptr = (delegate* unmanaged<IntPtr, IntPtr, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyContext");
             _glXDestroyContext_fnptr(dpy, ctx);
         }
         
         /// <summary><b>[entry point: <c>glXDestroyGLXPbufferSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, void> _glXDestroyGLXPbufferSGIX_fnptr = &glXDestroyGLXPbufferSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, void> _glXDestroyGLXPbufferSGIX_fnptr = &glXDestroyGLXPbufferSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXDestroyGLXPbufferSGIX_Lazy(Display* dpy, nuint pbuf)
+        private static void glXDestroyGLXPbufferSGIX_Lazy(IntPtr dpy, nuint pbuf)
         {
-            _glXDestroyGLXPbufferSGIX_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyGLXPbufferSGIX");
+            _glXDestroyGLXPbufferSGIX_fnptr = (delegate* unmanaged<IntPtr, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyGLXPbufferSGIX");
             _glXDestroyGLXPbufferSGIX_fnptr(dpy, pbuf);
         }
         
         /// <summary><b>[entry point: <c>glXDestroyGLXPixmap</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, void> _glXDestroyGLXPixmap_fnptr = &glXDestroyGLXPixmap_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, void> _glXDestroyGLXPixmap_fnptr = &glXDestroyGLXPixmap_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXDestroyGLXPixmap_Lazy(Display* dpy, nuint pixmap)
+        private static void glXDestroyGLXPixmap_Lazy(IntPtr dpy, nuint pixmap)
         {
-            _glXDestroyGLXPixmap_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyGLXPixmap");
+            _glXDestroyGLXPixmap_fnptr = (delegate* unmanaged<IntPtr, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyGLXPixmap");
             _glXDestroyGLXPixmap_fnptr(dpy, pixmap);
         }
         
         /// <summary><b>[entry point: <c>glXDestroyHyperpipeConfigSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int> _glXDestroyHyperpipeConfigSGIX_fnptr = &glXDestroyHyperpipeConfigSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int> _glXDestroyHyperpipeConfigSGIX_fnptr = &glXDestroyHyperpipeConfigSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXDestroyHyperpipeConfigSGIX_Lazy(Display* dpy, int hpId)
+        private static int glXDestroyHyperpipeConfigSGIX_Lazy(IntPtr dpy, int hpId)
         {
-            _glXDestroyHyperpipeConfigSGIX_fnptr = (delegate* unmanaged<Display*, int, int>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyHyperpipeConfigSGIX");
+            _glXDestroyHyperpipeConfigSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyHyperpipeConfigSGIX");
             return _glXDestroyHyperpipeConfigSGIX_fnptr(dpy, hpId);
         }
         
         /// <summary><b>[entry point: <c>glXDestroyPbuffer</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, void> _glXDestroyPbuffer_fnptr = &glXDestroyPbuffer_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, void> _glXDestroyPbuffer_fnptr = &glXDestroyPbuffer_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXDestroyPbuffer_Lazy(Display* dpy, nuint pbuf)
+        private static void glXDestroyPbuffer_Lazy(IntPtr dpy, nuint pbuf)
         {
-            _glXDestroyPbuffer_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyPbuffer");
+            _glXDestroyPbuffer_fnptr = (delegate* unmanaged<IntPtr, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyPbuffer");
             _glXDestroyPbuffer_fnptr(dpy, pbuf);
         }
         
         /// <summary><b>[entry point: <c>glXDestroyPixmap</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, void> _glXDestroyPixmap_fnptr = &glXDestroyPixmap_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, void> _glXDestroyPixmap_fnptr = &glXDestroyPixmap_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXDestroyPixmap_Lazy(Display* dpy, nuint pixmap)
+        private static void glXDestroyPixmap_Lazy(IntPtr dpy, nuint pixmap)
         {
-            _glXDestroyPixmap_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyPixmap");
+            _glXDestroyPixmap_fnptr = (delegate* unmanaged<IntPtr, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyPixmap");
             _glXDestroyPixmap_fnptr(dpy, pixmap);
         }
         
         /// <summary><b>[entry point: <c>glXDestroyWindow</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, void> _glXDestroyWindow_fnptr = &glXDestroyWindow_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, void> _glXDestroyWindow_fnptr = &glXDestroyWindow_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXDestroyWindow_Lazy(Display* dpy, nuint win)
+        private static void glXDestroyWindow_Lazy(IntPtr dpy, nuint win)
         {
-            _glXDestroyWindow_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyWindow");
+            _glXDestroyWindow_fnptr = (delegate* unmanaged<IntPtr, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyWindow");
             _glXDestroyWindow_fnptr(dpy, win);
         }
         
         /// <summary><b>[entry point: <c>glXEnumerateVideoCaptureDevicesNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int*, nuint*> _glXEnumerateVideoCaptureDevicesNV_fnptr = &glXEnumerateVideoCaptureDevicesNV_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int*, nuint*> _glXEnumerateVideoCaptureDevicesNV_fnptr = &glXEnumerateVideoCaptureDevicesNV_Lazy;
         [UnmanagedCallersOnly]
-        private static nuint* glXEnumerateVideoCaptureDevicesNV_Lazy(Display* dpy, int screen, int* nelements)
+        private static nuint* glXEnumerateVideoCaptureDevicesNV_Lazy(IntPtr dpy, int screen, int* nelements)
         {
-            _glXEnumerateVideoCaptureDevicesNV_fnptr = (delegate* unmanaged<Display*, int, int*, nuint*>)GLXLoader.BindingsContext.GetProcAddress("glXEnumerateVideoCaptureDevicesNV");
+            _glXEnumerateVideoCaptureDevicesNV_fnptr = (delegate* unmanaged<IntPtr, int, int*, nuint*>)GLXLoader.BindingsContext.GetProcAddress("glXEnumerateVideoCaptureDevicesNV");
             return _glXEnumerateVideoCaptureDevicesNV_fnptr(dpy, screen, nelements);
         }
         
         /// <summary><b>[entry point: <c>glXEnumerateVideoDevicesNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int*, uint*> _glXEnumerateVideoDevicesNV_fnptr = &glXEnumerateVideoDevicesNV_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int*, uint*> _glXEnumerateVideoDevicesNV_fnptr = &glXEnumerateVideoDevicesNV_Lazy;
         [UnmanagedCallersOnly]
-        private static uint* glXEnumerateVideoDevicesNV_Lazy(Display* dpy, int screen, int* nelements)
+        private static uint* glXEnumerateVideoDevicesNV_Lazy(IntPtr dpy, int screen, int* nelements)
         {
-            _glXEnumerateVideoDevicesNV_fnptr = (delegate* unmanaged<Display*, int, int*, uint*>)GLXLoader.BindingsContext.GetProcAddress("glXEnumerateVideoDevicesNV");
+            _glXEnumerateVideoDevicesNV_fnptr = (delegate* unmanaged<IntPtr, int, int*, uint*>)GLXLoader.BindingsContext.GetProcAddress("glXEnumerateVideoDevicesNV");
             return _glXEnumerateVideoDevicesNV_fnptr(dpy, screen, nelements);
         }
         
         /// <summary><b>[entry point: <c>glXFreeContextEXT</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, void> _glXFreeContextEXT_fnptr = &glXFreeContextEXT_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, void> _glXFreeContextEXT_fnptr = &glXFreeContextEXT_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXFreeContextEXT_Lazy(Display* dpy, IntPtr context)
+        private static void glXFreeContextEXT_Lazy(IntPtr dpy, IntPtr context)
         {
-            _glXFreeContextEXT_fnptr = (delegate* unmanaged<Display*, IntPtr, void>)GLXLoader.BindingsContext.GetProcAddress("glXFreeContextEXT");
+            _glXFreeContextEXT_fnptr = (delegate* unmanaged<IntPtr, IntPtr, void>)GLXLoader.BindingsContext.GetProcAddress("glXFreeContextEXT");
             _glXFreeContextEXT_fnptr(dpy, context);
         }
         
@@ -414,20 +414,20 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXGetClientString</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, byte*> _glXGetClientString_fnptr = &glXGetClientString_Lazy;
+        public static delegate* unmanaged<IntPtr, int, byte*> _glXGetClientString_fnptr = &glXGetClientString_Lazy;
         [UnmanagedCallersOnly]
-        private static byte* glXGetClientString_Lazy(Display* dpy, int name)
+        private static byte* glXGetClientString_Lazy(IntPtr dpy, int name)
         {
-            _glXGetClientString_fnptr = (delegate* unmanaged<Display*, int, byte*>)GLXLoader.BindingsContext.GetProcAddress("glXGetClientString");
+            _glXGetClientString_fnptr = (delegate* unmanaged<IntPtr, int, byte*>)GLXLoader.BindingsContext.GetProcAddress("glXGetClientString");
             return _glXGetClientString_fnptr(dpy, name);
         }
         
         /// <summary><b>[entry point: <c>glXGetConfig</c>]</b></summary>
-        public static delegate* unmanaged<Display*, XVisualInfo*, int, int*, int> _glXGetConfig_fnptr = &glXGetConfig_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, int, int*, int> _glXGetConfig_fnptr = &glXGetConfig_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXGetConfig_Lazy(Display* dpy, XVisualInfo* visual, int attrib, int* value)
+        private static int glXGetConfig_Lazy(IntPtr dpy, IntPtr visual, int attrib, int* value)
         {
-            _glXGetConfig_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetConfig");
+            _glXGetConfig_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetConfig");
             return _glXGetConfig_fnptr(dpy, visual, attrib, value);
         }
         
@@ -468,20 +468,20 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXGetCurrentDisplay</c>]</b></summary>
-        public static delegate* unmanaged<Display*> _glXGetCurrentDisplay_fnptr = &glXGetCurrentDisplay_Lazy;
+        public static delegate* unmanaged<IntPtr> _glXGetCurrentDisplay_fnptr = &glXGetCurrentDisplay_Lazy;
         [UnmanagedCallersOnly]
-        private static Display* glXGetCurrentDisplay_Lazy()
+        private static IntPtr glXGetCurrentDisplay_Lazy()
         {
-            _glXGetCurrentDisplay_fnptr = (delegate* unmanaged<Display*>)GLXLoader.BindingsContext.GetProcAddress("glXGetCurrentDisplay");
+            _glXGetCurrentDisplay_fnptr = (delegate* unmanaged<IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXGetCurrentDisplay");
             return _glXGetCurrentDisplay_fnptr();
         }
         
         /// <summary><b>[entry point: <c>glXGetCurrentDisplayEXT</c>]</b></summary>
-        public static delegate* unmanaged<Display*> _glXGetCurrentDisplayEXT_fnptr = &glXGetCurrentDisplayEXT_Lazy;
+        public static delegate* unmanaged<IntPtr> _glXGetCurrentDisplayEXT_fnptr = &glXGetCurrentDisplayEXT_Lazy;
         [UnmanagedCallersOnly]
-        private static Display* glXGetCurrentDisplayEXT_Lazy()
+        private static IntPtr glXGetCurrentDisplayEXT_Lazy()
         {
-            _glXGetCurrentDisplayEXT_fnptr = (delegate* unmanaged<Display*>)GLXLoader.BindingsContext.GetProcAddress("glXGetCurrentDisplayEXT");
+            _glXGetCurrentDisplayEXT_fnptr = (delegate* unmanaged<IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXGetCurrentDisplayEXT");
             return _glXGetCurrentDisplayEXT_fnptr();
         }
         
@@ -513,38 +513,38 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXGetFBConfigAttrib</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, int, int*, int> _glXGetFBConfigAttrib_fnptr = &glXGetFBConfigAttrib_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, int, int*, int> _glXGetFBConfigAttrib_fnptr = &glXGetFBConfigAttrib_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXGetFBConfigAttrib_Lazy(Display* dpy, IntPtr config, int attribute, int* value)
+        private static int glXGetFBConfigAttrib_Lazy(IntPtr dpy, IntPtr config, int attribute, int* value)
         {
-            _glXGetFBConfigAttrib_fnptr = (delegate* unmanaged<Display*, IntPtr, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetFBConfigAttrib");
+            _glXGetFBConfigAttrib_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetFBConfigAttrib");
             return _glXGetFBConfigAttrib_fnptr(dpy, config, attribute, value);
         }
         
         /// <summary><b>[entry point: <c>glXGetFBConfigAttribSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, int, int*, int> _glXGetFBConfigAttribSGIX_fnptr = &glXGetFBConfigAttribSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, int, int*, int> _glXGetFBConfigAttribSGIX_fnptr = &glXGetFBConfigAttribSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXGetFBConfigAttribSGIX_Lazy(Display* dpy, IntPtr config, int attribute, int* value)
+        private static int glXGetFBConfigAttribSGIX_Lazy(IntPtr dpy, IntPtr config, int attribute, int* value)
         {
-            _glXGetFBConfigAttribSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetFBConfigAttribSGIX");
+            _glXGetFBConfigAttribSGIX_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetFBConfigAttribSGIX");
             return _glXGetFBConfigAttribSGIX_fnptr(dpy, config, attribute, value);
         }
         
         /// <summary><b>[entry point: <c>glXGetFBConfigFromVisualSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, XVisualInfo*, IntPtr> _glXGetFBConfigFromVisualSGIX_fnptr = &glXGetFBConfigFromVisualSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, IntPtr> _glXGetFBConfigFromVisualSGIX_fnptr = &glXGetFBConfigFromVisualSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static IntPtr glXGetFBConfigFromVisualSGIX_Lazy(Display* dpy, XVisualInfo* vis)
+        private static IntPtr glXGetFBConfigFromVisualSGIX_Lazy(IntPtr dpy, IntPtr vis)
         {
-            _glXGetFBConfigFromVisualSGIX_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXGetFBConfigFromVisualSGIX");
+            _glXGetFBConfigFromVisualSGIX_fnptr = (delegate* unmanaged<IntPtr, IntPtr, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXGetFBConfigFromVisualSGIX");
             return _glXGetFBConfigFromVisualSGIX_fnptr(dpy, vis);
         }
         
         /// <summary><b>[entry point: <c>glXGetFBConfigs</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int*, IntPtr*> _glXGetFBConfigs_fnptr = &glXGetFBConfigs_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int*, IntPtr*> _glXGetFBConfigs_fnptr = &glXGetFBConfigs_Lazy;
         [UnmanagedCallersOnly]
-        private static IntPtr* glXGetFBConfigs_Lazy(Display* dpy, int screen, int* nelements)
+        private static IntPtr* glXGetFBConfigs_Lazy(IntPtr dpy, int screen, int* nelements)
         {
-            _glXGetFBConfigs_fnptr = (delegate* unmanaged<Display*, int, int*, IntPtr*>)GLXLoader.BindingsContext.GetProcAddress("glXGetFBConfigs");
+            _glXGetFBConfigs_fnptr = (delegate* unmanaged<IntPtr, int, int*, IntPtr*>)GLXLoader.BindingsContext.GetProcAddress("glXGetFBConfigs");
             return _glXGetFBConfigs_fnptr(dpy, screen, nelements);
         }
         
@@ -567,11 +567,11 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXGetMscRateOML</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, int*, int*, byte> _glXGetMscRateOML_fnptr = &glXGetMscRateOML_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, int*, int*, byte> _glXGetMscRateOML_fnptr = &glXGetMscRateOML_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXGetMscRateOML_Lazy(Display* dpy, nuint drawable, int* numerator, int* denominator)
+        private static byte glXGetMscRateOML_Lazy(IntPtr dpy, nuint drawable, int* numerator, int* denominator)
         {
-            _glXGetMscRateOML_fnptr = (delegate* unmanaged<Display*, nuint, int*, int*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXGetMscRateOML");
+            _glXGetMscRateOML_fnptr = (delegate* unmanaged<IntPtr, nuint, int*, int*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXGetMscRateOML");
             return _glXGetMscRateOML_fnptr(dpy, drawable, numerator, denominator);
         }
         
@@ -594,20 +594,20 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXGetSelectedEvent</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, ulong*, void> _glXGetSelectedEvent_fnptr = &glXGetSelectedEvent_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, ulong*, void> _glXGetSelectedEvent_fnptr = &glXGetSelectedEvent_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXGetSelectedEvent_Lazy(Display* dpy, nuint draw, ulong* event_mask)
+        private static void glXGetSelectedEvent_Lazy(IntPtr dpy, nuint draw, ulong* event_mask)
         {
-            _glXGetSelectedEvent_fnptr = (delegate* unmanaged<Display*, nuint, ulong*, void>)GLXLoader.BindingsContext.GetProcAddress("glXGetSelectedEvent");
+            _glXGetSelectedEvent_fnptr = (delegate* unmanaged<IntPtr, nuint, ulong*, void>)GLXLoader.BindingsContext.GetProcAddress("glXGetSelectedEvent");
             _glXGetSelectedEvent_fnptr(dpy, draw, event_mask);
         }
         
         /// <summary><b>[entry point: <c>glXGetSelectedEventSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, ulong*, void> _glXGetSelectedEventSGIX_fnptr = &glXGetSelectedEventSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, ulong*, void> _glXGetSelectedEventSGIX_fnptr = &glXGetSelectedEventSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXGetSelectedEventSGIX_Lazy(Display* dpy, nuint drawable, ulong* mask)
+        private static void glXGetSelectedEventSGIX_Lazy(IntPtr dpy, nuint drawable, ulong* mask)
         {
-            _glXGetSelectedEventSGIX_fnptr = (delegate* unmanaged<Display*, nuint, ulong*, void>)GLXLoader.BindingsContext.GetProcAddress("glXGetSelectedEventSGIX");
+            _glXGetSelectedEventSGIX_fnptr = (delegate* unmanaged<IntPtr, nuint, ulong*, void>)GLXLoader.BindingsContext.GetProcAddress("glXGetSelectedEventSGIX");
             _glXGetSelectedEventSGIX_fnptr(dpy, drawable, mask);
         }
         
@@ -621,38 +621,38 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXGetSyncValuesOML</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, long*, long*, long*, byte> _glXGetSyncValuesOML_fnptr = &glXGetSyncValuesOML_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, long*, long*, long*, byte> _glXGetSyncValuesOML_fnptr = &glXGetSyncValuesOML_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXGetSyncValuesOML_Lazy(Display* dpy, nuint drawable, long* ust, long* msc, long* sbc)
+        private static byte glXGetSyncValuesOML_Lazy(IntPtr dpy, nuint drawable, long* ust, long* msc, long* sbc)
         {
-            _glXGetSyncValuesOML_fnptr = (delegate* unmanaged<Display*, nuint, long*, long*, long*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXGetSyncValuesOML");
+            _glXGetSyncValuesOML_fnptr = (delegate* unmanaged<IntPtr, nuint, long*, long*, long*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXGetSyncValuesOML");
             return _glXGetSyncValuesOML_fnptr(dpy, drawable, ust, msc, sbc);
         }
         
         /// <summary><b>[entry point: <c>glXGetTransparentIndexSUN</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, nuint, ulong*, int> _glXGetTransparentIndexSUN_fnptr = &glXGetTransparentIndexSUN_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, nuint, ulong*, int> _glXGetTransparentIndexSUN_fnptr = &glXGetTransparentIndexSUN_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXGetTransparentIndexSUN_Lazy(Display* dpy, nuint overlay, nuint underlay, ulong* pTransparentIndex)
+        private static int glXGetTransparentIndexSUN_Lazy(IntPtr dpy, nuint overlay, nuint underlay, ulong* pTransparentIndex)
         {
-            _glXGetTransparentIndexSUN_fnptr = (delegate* unmanaged<Display*, nuint, nuint, ulong*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetTransparentIndexSUN");
+            _glXGetTransparentIndexSUN_fnptr = (delegate* unmanaged<IntPtr, nuint, nuint, ulong*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetTransparentIndexSUN");
             return _glXGetTransparentIndexSUN_fnptr(dpy, overlay, underlay, pTransparentIndex);
         }
         
         /// <summary><b>[entry point: <c>glXGetVideoDeviceNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int, uint*, int> _glXGetVideoDeviceNV_fnptr = &glXGetVideoDeviceNV_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int, uint*, int> _glXGetVideoDeviceNV_fnptr = &glXGetVideoDeviceNV_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXGetVideoDeviceNV_Lazy(Display* dpy, int screen, int numVideoDevices, uint* pVideoDevice)
+        private static int glXGetVideoDeviceNV_Lazy(IntPtr dpy, int screen, int numVideoDevices, uint* pVideoDevice)
         {
-            _glXGetVideoDeviceNV_fnptr = (delegate* unmanaged<Display*, int, int, uint*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetVideoDeviceNV");
+            _glXGetVideoDeviceNV_fnptr = (delegate* unmanaged<IntPtr, int, int, uint*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetVideoDeviceNV");
             return _glXGetVideoDeviceNV_fnptr(dpy, screen, numVideoDevices, pVideoDevice);
         }
         
         /// <summary><b>[entry point: <c>glXGetVideoInfoNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, uint, ulong*, ulong*, int> _glXGetVideoInfoNV_fnptr = &glXGetVideoInfoNV_Lazy;
+        public static delegate* unmanaged<IntPtr, int, uint, ulong*, ulong*, int> _glXGetVideoInfoNV_fnptr = &glXGetVideoInfoNV_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXGetVideoInfoNV_Lazy(Display* dpy, int screen, uint VideoDevice, ulong* pulCounterOutputPbuffer, ulong* pulCounterOutputVideo)
+        private static int glXGetVideoInfoNV_Lazy(IntPtr dpy, int screen, uint VideoDevice, ulong* pulCounterOutputPbuffer, ulong* pulCounterOutputVideo)
         {
-            _glXGetVideoInfoNV_fnptr = (delegate* unmanaged<Display*, int, uint, ulong*, ulong*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetVideoInfoNV");
+            _glXGetVideoInfoNV_fnptr = (delegate* unmanaged<IntPtr, int, uint, ulong*, ulong*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetVideoInfoNV");
             return _glXGetVideoInfoNV_fnptr(dpy, screen, VideoDevice, pulCounterOutputPbuffer, pulCounterOutputVideo);
         }
         
@@ -666,83 +666,83 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXGetVisualFromFBConfig</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, XVisualInfo*> _glXGetVisualFromFBConfig_fnptr = &glXGetVisualFromFBConfig_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, IntPtr> _glXGetVisualFromFBConfig_fnptr = &glXGetVisualFromFBConfig_Lazy;
         [UnmanagedCallersOnly]
-        private static XVisualInfo* glXGetVisualFromFBConfig_Lazy(Display* dpy, IntPtr config)
+        private static IntPtr glXGetVisualFromFBConfig_Lazy(IntPtr dpy, IntPtr config)
         {
-            _glXGetVisualFromFBConfig_fnptr = (delegate* unmanaged<Display*, IntPtr, XVisualInfo*>)GLXLoader.BindingsContext.GetProcAddress("glXGetVisualFromFBConfig");
+            _glXGetVisualFromFBConfig_fnptr = (delegate* unmanaged<IntPtr, IntPtr, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXGetVisualFromFBConfig");
             return _glXGetVisualFromFBConfig_fnptr(dpy, config);
         }
         
         /// <summary><b>[entry point: <c>glXGetVisualFromFBConfigSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, XVisualInfo*> _glXGetVisualFromFBConfigSGIX_fnptr = &glXGetVisualFromFBConfigSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, IntPtr> _glXGetVisualFromFBConfigSGIX_fnptr = &glXGetVisualFromFBConfigSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static XVisualInfo* glXGetVisualFromFBConfigSGIX_Lazy(Display* dpy, IntPtr config)
+        private static IntPtr glXGetVisualFromFBConfigSGIX_Lazy(IntPtr dpy, IntPtr config)
         {
-            _glXGetVisualFromFBConfigSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, XVisualInfo*>)GLXLoader.BindingsContext.GetProcAddress("glXGetVisualFromFBConfigSGIX");
+            _glXGetVisualFromFBConfigSGIX_fnptr = (delegate* unmanaged<IntPtr, IntPtr, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXGetVisualFromFBConfigSGIX");
             return _glXGetVisualFromFBConfigSGIX_fnptr(dpy, config);
         }
         
         /// <summary><b>[entry point: <c>glXHyperpipeAttribSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int, int, void*, int> _glXHyperpipeAttribSGIX_fnptr = &glXHyperpipeAttribSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int, int, void*, int> _glXHyperpipeAttribSGIX_fnptr = &glXHyperpipeAttribSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXHyperpipeAttribSGIX_Lazy(Display* dpy, int timeSlice, int attrib, int size, void* attribList)
+        private static int glXHyperpipeAttribSGIX_Lazy(IntPtr dpy, int timeSlice, int attrib, int size, void* attribList)
         {
-            _glXHyperpipeAttribSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int, void*, int>)GLXLoader.BindingsContext.GetProcAddress("glXHyperpipeAttribSGIX");
+            _glXHyperpipeAttribSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int, int, void*, int>)GLXLoader.BindingsContext.GetProcAddress("glXHyperpipeAttribSGIX");
             return _glXHyperpipeAttribSGIX_fnptr(dpy, timeSlice, attrib, size, attribList);
         }
         
         /// <summary><b>[entry point: <c>glXHyperpipeConfigSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int, GLXHyperpipeConfigSGIX*, int*, int> _glXHyperpipeConfigSGIX_fnptr = &glXHyperpipeConfigSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int, GLXHyperpipeConfigSGIX*, int*, int> _glXHyperpipeConfigSGIX_fnptr = &glXHyperpipeConfigSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXHyperpipeConfigSGIX_Lazy(Display* dpy, int networkId, int npipes, GLXHyperpipeConfigSGIX* cfg, int* hpId)
+        private static int glXHyperpipeConfigSGIX_Lazy(IntPtr dpy, int networkId, int npipes, GLXHyperpipeConfigSGIX* cfg, int* hpId)
         {
-            _glXHyperpipeConfigSGIX_fnptr = (delegate* unmanaged<Display*, int, int, GLXHyperpipeConfigSGIX*, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXHyperpipeConfigSGIX");
+            _glXHyperpipeConfigSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int, GLXHyperpipeConfigSGIX*, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXHyperpipeConfigSGIX");
             return _glXHyperpipeConfigSGIX_fnptr(dpy, networkId, npipes, cfg, hpId);
         }
         
         /// <summary><b>[entry point: <c>glXImportContextEXT</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, IntPtr> _glXImportContextEXT_fnptr = &glXImportContextEXT_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, IntPtr> _glXImportContextEXT_fnptr = &glXImportContextEXT_Lazy;
         [UnmanagedCallersOnly]
-        private static IntPtr glXImportContextEXT_Lazy(Display* dpy, nuint contextID)
+        private static IntPtr glXImportContextEXT_Lazy(IntPtr dpy, nuint contextID)
         {
-            _glXImportContextEXT_fnptr = (delegate* unmanaged<Display*, nuint, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXImportContextEXT");
+            _glXImportContextEXT_fnptr = (delegate* unmanaged<IntPtr, nuint, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXImportContextEXT");
             return _glXImportContextEXT_fnptr(dpy, contextID);
         }
         
         /// <summary><b>[entry point: <c>glXIsDirect</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, byte> _glXIsDirect_fnptr = &glXIsDirect_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, byte> _glXIsDirect_fnptr = &glXIsDirect_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXIsDirect_Lazy(Display* dpy, IntPtr ctx)
+        private static byte glXIsDirect_Lazy(IntPtr dpy, IntPtr ctx)
         {
-            _glXIsDirect_fnptr = (delegate* unmanaged<Display*, IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXIsDirect");
+            _glXIsDirect_fnptr = (delegate* unmanaged<IntPtr, IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXIsDirect");
             return _glXIsDirect_fnptr(dpy, ctx);
         }
         
         /// <summary><b>[entry point: <c>glXJoinSwapGroupNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, uint, byte> _glXJoinSwapGroupNV_fnptr = &glXJoinSwapGroupNV_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, uint, byte> _glXJoinSwapGroupNV_fnptr = &glXJoinSwapGroupNV_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXJoinSwapGroupNV_Lazy(Display* dpy, nuint drawable, uint group)
+        private static byte glXJoinSwapGroupNV_Lazy(IntPtr dpy, nuint drawable, uint group)
         {
-            _glXJoinSwapGroupNV_fnptr = (delegate* unmanaged<Display*, nuint, uint, byte>)GLXLoader.BindingsContext.GetProcAddress("glXJoinSwapGroupNV");
+            _glXJoinSwapGroupNV_fnptr = (delegate* unmanaged<IntPtr, nuint, uint, byte>)GLXLoader.BindingsContext.GetProcAddress("glXJoinSwapGroupNV");
             return _glXJoinSwapGroupNV_fnptr(dpy, drawable, group);
         }
         
         /// <summary><b>[entry point: <c>glXJoinSwapGroupSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, nuint, void> _glXJoinSwapGroupSGIX_fnptr = &glXJoinSwapGroupSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, nuint, void> _glXJoinSwapGroupSGIX_fnptr = &glXJoinSwapGroupSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXJoinSwapGroupSGIX_Lazy(Display* dpy, nuint drawable, nuint member)
+        private static void glXJoinSwapGroupSGIX_Lazy(IntPtr dpy, nuint drawable, nuint member)
         {
-            _glXJoinSwapGroupSGIX_fnptr = (delegate* unmanaged<Display*, nuint, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXJoinSwapGroupSGIX");
+            _glXJoinSwapGroupSGIX_fnptr = (delegate* unmanaged<IntPtr, nuint, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXJoinSwapGroupSGIX");
             _glXJoinSwapGroupSGIX_fnptr(dpy, drawable, member);
         }
         
         /// <summary><b>[entry point: <c>glXLockVideoCaptureDeviceNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, void> _glXLockVideoCaptureDeviceNV_fnptr = &glXLockVideoCaptureDeviceNV_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, void> _glXLockVideoCaptureDeviceNV_fnptr = &glXLockVideoCaptureDeviceNV_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXLockVideoCaptureDeviceNV_Lazy(Display* dpy, nuint device)
+        private static void glXLockVideoCaptureDeviceNV_Lazy(IntPtr dpy, nuint device)
         {
-            _glXLockVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXLockVideoCaptureDeviceNV");
+            _glXLockVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<IntPtr, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXLockVideoCaptureDeviceNV");
             _glXLockVideoCaptureDeviceNV_fnptr(dpy, device);
         }
         
@@ -756,74 +756,74 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXMakeContextCurrent</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, nuint, IntPtr, byte> _glXMakeContextCurrent_fnptr = &glXMakeContextCurrent_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, nuint, IntPtr, byte> _glXMakeContextCurrent_fnptr = &glXMakeContextCurrent_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXMakeContextCurrent_Lazy(Display* dpy, nuint draw, nuint read, IntPtr ctx)
+        private static byte glXMakeContextCurrent_Lazy(IntPtr dpy, nuint draw, nuint read, IntPtr ctx)
         {
-            _glXMakeContextCurrent_fnptr = (delegate* unmanaged<Display*, nuint, nuint, IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXMakeContextCurrent");
+            _glXMakeContextCurrent_fnptr = (delegate* unmanaged<IntPtr, nuint, nuint, IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXMakeContextCurrent");
             return _glXMakeContextCurrent_fnptr(dpy, draw, read, ctx);
         }
         
         /// <summary><b>[entry point: <c>glXMakeCurrent</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, IntPtr, byte> _glXMakeCurrent_fnptr = &glXMakeCurrent_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, IntPtr, byte> _glXMakeCurrent_fnptr = &glXMakeCurrent_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXMakeCurrent_Lazy(Display* dpy, nuint drawable, IntPtr ctx)
+        private static byte glXMakeCurrent_Lazy(IntPtr dpy, nuint drawable, IntPtr ctx)
         {
-            _glXMakeCurrent_fnptr = (delegate* unmanaged<Display*, nuint, IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXMakeCurrent");
+            _glXMakeCurrent_fnptr = (delegate* unmanaged<IntPtr, nuint, IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXMakeCurrent");
             return _glXMakeCurrent_fnptr(dpy, drawable, ctx);
         }
         
         /// <summary><b>[entry point: <c>glXMakeCurrentReadSGI</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, nuint, IntPtr, byte> _glXMakeCurrentReadSGI_fnptr = &glXMakeCurrentReadSGI_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, nuint, IntPtr, byte> _glXMakeCurrentReadSGI_fnptr = &glXMakeCurrentReadSGI_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXMakeCurrentReadSGI_Lazy(Display* dpy, nuint draw, nuint read, IntPtr ctx)
+        private static byte glXMakeCurrentReadSGI_Lazy(IntPtr dpy, nuint draw, nuint read, IntPtr ctx)
         {
-            _glXMakeCurrentReadSGI_fnptr = (delegate* unmanaged<Display*, nuint, nuint, IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXMakeCurrentReadSGI");
+            _glXMakeCurrentReadSGI_fnptr = (delegate* unmanaged<IntPtr, nuint, nuint, IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXMakeCurrentReadSGI");
             return _glXMakeCurrentReadSGI_fnptr(dpy, draw, read, ctx);
         }
         
         /// <summary><b>[entry point: <c>glXNamedCopyBufferSubDataNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, IntPtr, uint, uint, IntPtr, IntPtr, nint, void> _glXNamedCopyBufferSubDataNV_fnptr = &glXNamedCopyBufferSubDataNV_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, IntPtr, uint, uint, IntPtr, IntPtr, nint, void> _glXNamedCopyBufferSubDataNV_fnptr = &glXNamedCopyBufferSubDataNV_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXNamedCopyBufferSubDataNV_Lazy(Display* dpy, IntPtr readCtx, IntPtr writeCtx, uint readBuffer, uint writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size)
+        private static void glXNamedCopyBufferSubDataNV_Lazy(IntPtr dpy, IntPtr readCtx, IntPtr writeCtx, uint readBuffer, uint writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size)
         {
-            _glXNamedCopyBufferSubDataNV_fnptr = (delegate* unmanaged<Display*, IntPtr, IntPtr, uint, uint, IntPtr, IntPtr, nint, void>)GLXLoader.BindingsContext.GetProcAddress("glXNamedCopyBufferSubDataNV");
+            _glXNamedCopyBufferSubDataNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr, IntPtr, uint, uint, IntPtr, IntPtr, nint, void>)GLXLoader.BindingsContext.GetProcAddress("glXNamedCopyBufferSubDataNV");
             _glXNamedCopyBufferSubDataNV_fnptr(dpy, readCtx, writeCtx, readBuffer, writeBuffer, readOffset, writeOffset, size);
         }
         
         /// <summary><b>[entry point: <c>glXQueryChannelDeltasSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int, int*, int*, int*, int*, int> _glXQueryChannelDeltasSGIX_fnptr = &glXQueryChannelDeltasSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int, int*, int*, int*, int*, int> _glXQueryChannelDeltasSGIX_fnptr = &glXQueryChannelDeltasSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXQueryChannelDeltasSGIX_Lazy(Display* display, int screen, int channel, int* x, int* y, int* w, int* h)
+        private static int glXQueryChannelDeltasSGIX_Lazy(IntPtr display, int screen, int channel, int* x, int* y, int* w, int* h)
         {
-            _glXQueryChannelDeltasSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int*, int*, int*, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryChannelDeltasSGIX");
+            _glXQueryChannelDeltasSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int, int*, int*, int*, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryChannelDeltasSGIX");
             return _glXQueryChannelDeltasSGIX_fnptr(display, screen, channel, x, y, w, h);
         }
         
         /// <summary><b>[entry point: <c>glXQueryChannelRectSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int, int*, int*, int*, int*, int> _glXQueryChannelRectSGIX_fnptr = &glXQueryChannelRectSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int, int*, int*, int*, int*, int> _glXQueryChannelRectSGIX_fnptr = &glXQueryChannelRectSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXQueryChannelRectSGIX_Lazy(Display* display, int screen, int channel, int* dx, int* dy, int* dw, int* dh)
+        private static int glXQueryChannelRectSGIX_Lazy(IntPtr display, int screen, int channel, int* dx, int* dy, int* dw, int* dh)
         {
-            _glXQueryChannelRectSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int*, int*, int*, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryChannelRectSGIX");
+            _glXQueryChannelRectSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int, int*, int*, int*, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryChannelRectSGIX");
             return _glXQueryChannelRectSGIX_fnptr(display, screen, channel, dx, dy, dw, dh);
         }
         
         /// <summary><b>[entry point: <c>glXQueryContext</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, int, int*, int> _glXQueryContext_fnptr = &glXQueryContext_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, int, int*, int> _glXQueryContext_fnptr = &glXQueryContext_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXQueryContext_Lazy(Display* dpy, IntPtr ctx, int attribute, int* value)
+        private static int glXQueryContext_Lazy(IntPtr dpy, IntPtr ctx, int attribute, int* value)
         {
-            _glXQueryContext_fnptr = (delegate* unmanaged<Display*, IntPtr, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryContext");
+            _glXQueryContext_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryContext");
             return _glXQueryContext_fnptr(dpy, ctx, attribute, value);
         }
         
         /// <summary><b>[entry point: <c>glXQueryContextInfoEXT</c>]</b></summary>
-        public static delegate* unmanaged<Display*, IntPtr, int, int*, int> _glXQueryContextInfoEXT_fnptr = &glXQueryContextInfoEXT_Lazy;
+        public static delegate* unmanaged<IntPtr, IntPtr, int, int*, int> _glXQueryContextInfoEXT_fnptr = &glXQueryContextInfoEXT_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXQueryContextInfoEXT_Lazy(Display* dpy, IntPtr context, int attribute, int* value)
+        private static int glXQueryContextInfoEXT_Lazy(IntPtr dpy, IntPtr context, int attribute, int* value)
         {
-            _glXQueryContextInfoEXT_fnptr = (delegate* unmanaged<Display*, IntPtr, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryContextInfoEXT");
+            _glXQueryContextInfoEXT_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryContextInfoEXT");
             return _glXQueryContextInfoEXT_fnptr(dpy, context, attribute, value);
         }
         
@@ -846,236 +846,236 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXQueryDrawable</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, int, uint*, void> _glXQueryDrawable_fnptr = &glXQueryDrawable_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, int, uint*, void> _glXQueryDrawable_fnptr = &glXQueryDrawable_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXQueryDrawable_Lazy(Display* dpy, nuint draw, int attribute, uint* value)
+        private static void glXQueryDrawable_Lazy(IntPtr dpy, nuint draw, int attribute, uint* value)
         {
-            _glXQueryDrawable_fnptr = (delegate* unmanaged<Display*, nuint, int, uint*, void>)GLXLoader.BindingsContext.GetProcAddress("glXQueryDrawable");
+            _glXQueryDrawable_fnptr = (delegate* unmanaged<IntPtr, nuint, int, uint*, void>)GLXLoader.BindingsContext.GetProcAddress("glXQueryDrawable");
             _glXQueryDrawable_fnptr(dpy, draw, attribute, value);
         }
         
         /// <summary><b>[entry point: <c>glXQueryExtension</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int*, int*, byte> _glXQueryExtension_fnptr = &glXQueryExtension_Lazy;
+        public static delegate* unmanaged<IntPtr, int*, int*, byte> _glXQueryExtension_fnptr = &glXQueryExtension_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXQueryExtension_Lazy(Display* dpy, int* errorb, int* @event)
+        private static byte glXQueryExtension_Lazy(IntPtr dpy, int* errorb, int* @event)
         {
-            _glXQueryExtension_fnptr = (delegate* unmanaged<Display*, int*, int*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryExtension");
+            _glXQueryExtension_fnptr = (delegate* unmanaged<IntPtr, int*, int*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryExtension");
             return _glXQueryExtension_fnptr(dpy, errorb, @event);
         }
         
         /// <summary><b>[entry point: <c>glXQueryExtensionsString</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, byte*> _glXQueryExtensionsString_fnptr = &glXQueryExtensionsString_Lazy;
+        public static delegate* unmanaged<IntPtr, int, byte*> _glXQueryExtensionsString_fnptr = &glXQueryExtensionsString_Lazy;
         [UnmanagedCallersOnly]
-        private static byte* glXQueryExtensionsString_Lazy(Display* dpy, int screen)
+        private static byte* glXQueryExtensionsString_Lazy(IntPtr dpy, int screen)
         {
-            _glXQueryExtensionsString_fnptr = (delegate* unmanaged<Display*, int, byte*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryExtensionsString");
+            _glXQueryExtensionsString_fnptr = (delegate* unmanaged<IntPtr, int, byte*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryExtensionsString");
             return _glXQueryExtensionsString_fnptr(dpy, screen);
         }
         
         /// <summary><b>[entry point: <c>glXQueryFrameCountNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, uint*, byte> _glXQueryFrameCountNV_fnptr = &glXQueryFrameCountNV_Lazy;
+        public static delegate* unmanaged<IntPtr, int, uint*, byte> _glXQueryFrameCountNV_fnptr = &glXQueryFrameCountNV_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXQueryFrameCountNV_Lazy(Display* dpy, int screen, uint* count)
+        private static byte glXQueryFrameCountNV_Lazy(IntPtr dpy, int screen, uint* count)
         {
-            _glXQueryFrameCountNV_fnptr = (delegate* unmanaged<Display*, int, uint*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryFrameCountNV");
+            _glXQueryFrameCountNV_fnptr = (delegate* unmanaged<IntPtr, int, uint*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryFrameCountNV");
             return _glXQueryFrameCountNV_fnptr(dpy, screen, count);
         }
         
         /// <summary><b>[entry point: <c>glXQueryGLXPbufferSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, int, uint*, void> _glXQueryGLXPbufferSGIX_fnptr = &glXQueryGLXPbufferSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, int, uint*, void> _glXQueryGLXPbufferSGIX_fnptr = &glXQueryGLXPbufferSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXQueryGLXPbufferSGIX_Lazy(Display* dpy, nuint pbuf, int attribute, uint* value)
+        private static void glXQueryGLXPbufferSGIX_Lazy(IntPtr dpy, nuint pbuf, int attribute, uint* value)
         {
-            _glXQueryGLXPbufferSGIX_fnptr = (delegate* unmanaged<Display*, nuint, int, uint*, void>)GLXLoader.BindingsContext.GetProcAddress("glXQueryGLXPbufferSGIX");
+            _glXQueryGLXPbufferSGIX_fnptr = (delegate* unmanaged<IntPtr, nuint, int, uint*, void>)GLXLoader.BindingsContext.GetProcAddress("glXQueryGLXPbufferSGIX");
             _glXQueryGLXPbufferSGIX_fnptr(dpy, pbuf, attribute, value);
         }
         
         /// <summary><b>[entry point: <c>glXQueryHyperpipeAttribSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int, int, void*, int> _glXQueryHyperpipeAttribSGIX_fnptr = &glXQueryHyperpipeAttribSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int, int, void*, int> _glXQueryHyperpipeAttribSGIX_fnptr = &glXQueryHyperpipeAttribSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXQueryHyperpipeAttribSGIX_Lazy(Display* dpy, int timeSlice, int attrib, int size, void* returnAttribList)
+        private static int glXQueryHyperpipeAttribSGIX_Lazy(IntPtr dpy, int timeSlice, int attrib, int size, void* returnAttribList)
         {
-            _glXQueryHyperpipeAttribSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int, void*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeAttribSGIX");
+            _glXQueryHyperpipeAttribSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int, int, void*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeAttribSGIX");
             return _glXQueryHyperpipeAttribSGIX_fnptr(dpy, timeSlice, attrib, size, returnAttribList);
         }
         
         /// <summary><b>[entry point: <c>glXQueryHyperpipeBestAttribSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int, int, void*, void*, int> _glXQueryHyperpipeBestAttribSGIX_fnptr = &glXQueryHyperpipeBestAttribSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int, int, void*, void*, int> _glXQueryHyperpipeBestAttribSGIX_fnptr = &glXQueryHyperpipeBestAttribSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXQueryHyperpipeBestAttribSGIX_Lazy(Display* dpy, int timeSlice, int attrib, int size, void* attribList, void* returnAttribList)
+        private static int glXQueryHyperpipeBestAttribSGIX_Lazy(IntPtr dpy, int timeSlice, int attrib, int size, void* attribList, void* returnAttribList)
         {
-            _glXQueryHyperpipeBestAttribSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int, void*, void*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeBestAttribSGIX");
+            _glXQueryHyperpipeBestAttribSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int, int, void*, void*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeBestAttribSGIX");
             return _glXQueryHyperpipeBestAttribSGIX_fnptr(dpy, timeSlice, attrib, size, attribList, returnAttribList);
         }
         
         /// <summary><b>[entry point: <c>glXQueryHyperpipeConfigSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int*, GLXHyperpipeConfigSGIX*> _glXQueryHyperpipeConfigSGIX_fnptr = &glXQueryHyperpipeConfigSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int*, GLXHyperpipeConfigSGIX*> _glXQueryHyperpipeConfigSGIX_fnptr = &glXQueryHyperpipeConfigSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static GLXHyperpipeConfigSGIX* glXQueryHyperpipeConfigSGIX_Lazy(Display* dpy, int hpId, int* npipes)
+        private static GLXHyperpipeConfigSGIX* glXQueryHyperpipeConfigSGIX_Lazy(IntPtr dpy, int hpId, int* npipes)
         {
-            _glXQueryHyperpipeConfigSGIX_fnptr = (delegate* unmanaged<Display*, int, int*, GLXHyperpipeConfigSGIX*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeConfigSGIX");
+            _glXQueryHyperpipeConfigSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int*, GLXHyperpipeConfigSGIX*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeConfigSGIX");
             return _glXQueryHyperpipeConfigSGIX_fnptr(dpy, hpId, npipes);
         }
         
         /// <summary><b>[entry point: <c>glXQueryHyperpipeNetworkSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int*, GLXHyperpipeNetworkSGIX*> _glXQueryHyperpipeNetworkSGIX_fnptr = &glXQueryHyperpipeNetworkSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int*, GLXHyperpipeNetworkSGIX*> _glXQueryHyperpipeNetworkSGIX_fnptr = &glXQueryHyperpipeNetworkSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static GLXHyperpipeNetworkSGIX* glXQueryHyperpipeNetworkSGIX_Lazy(Display* dpy, int* npipes)
+        private static GLXHyperpipeNetworkSGIX* glXQueryHyperpipeNetworkSGIX_Lazy(IntPtr dpy, int* npipes)
         {
-            _glXQueryHyperpipeNetworkSGIX_fnptr = (delegate* unmanaged<Display*, int*, GLXHyperpipeNetworkSGIX*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeNetworkSGIX");
+            _glXQueryHyperpipeNetworkSGIX_fnptr = (delegate* unmanaged<IntPtr, int*, GLXHyperpipeNetworkSGIX*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeNetworkSGIX");
             return _glXQueryHyperpipeNetworkSGIX_fnptr(dpy, npipes);
         }
         
         /// <summary><b>[entry point: <c>glXQueryMaxSwapBarriersSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int*, byte> _glXQueryMaxSwapBarriersSGIX_fnptr = &glXQueryMaxSwapBarriersSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int*, byte> _glXQueryMaxSwapBarriersSGIX_fnptr = &glXQueryMaxSwapBarriersSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXQueryMaxSwapBarriersSGIX_Lazy(Display* dpy, int screen, int* max)
+        private static byte glXQueryMaxSwapBarriersSGIX_Lazy(IntPtr dpy, int screen, int* max)
         {
-            _glXQueryMaxSwapBarriersSGIX_fnptr = (delegate* unmanaged<Display*, int, int*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryMaxSwapBarriersSGIX");
+            _glXQueryMaxSwapBarriersSGIX_fnptr = (delegate* unmanaged<IntPtr, int, int*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryMaxSwapBarriersSGIX");
             return _glXQueryMaxSwapBarriersSGIX_fnptr(dpy, screen, max);
         }
         
         /// <summary><b>[entry point: <c>glXQueryMaxSwapGroupsNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, uint*, uint*, byte> _glXQueryMaxSwapGroupsNV_fnptr = &glXQueryMaxSwapGroupsNV_Lazy;
+        public static delegate* unmanaged<IntPtr, int, uint*, uint*, byte> _glXQueryMaxSwapGroupsNV_fnptr = &glXQueryMaxSwapGroupsNV_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXQueryMaxSwapGroupsNV_Lazy(Display* dpy, int screen, uint* maxGroups, uint* maxBarriers)
+        private static byte glXQueryMaxSwapGroupsNV_Lazy(IntPtr dpy, int screen, uint* maxGroups, uint* maxBarriers)
         {
-            _glXQueryMaxSwapGroupsNV_fnptr = (delegate* unmanaged<Display*, int, uint*, uint*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryMaxSwapGroupsNV");
+            _glXQueryMaxSwapGroupsNV_fnptr = (delegate* unmanaged<IntPtr, int, uint*, uint*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryMaxSwapGroupsNV");
             return _glXQueryMaxSwapGroupsNV_fnptr(dpy, screen, maxGroups, maxBarriers);
         }
         
         /// <summary><b>[entry point: <c>glXQueryRendererIntegerMESA</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int, int, uint*, byte> _glXQueryRendererIntegerMESA_fnptr = &glXQueryRendererIntegerMESA_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int, int, uint*, byte> _glXQueryRendererIntegerMESA_fnptr = &glXQueryRendererIntegerMESA_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXQueryRendererIntegerMESA_Lazy(Display* dpy, int screen, int renderer, int attribute, uint* value)
+        private static byte glXQueryRendererIntegerMESA_Lazy(IntPtr dpy, int screen, int renderer, int attribute, uint* value)
         {
-            _glXQueryRendererIntegerMESA_fnptr = (delegate* unmanaged<Display*, int, int, int, uint*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryRendererIntegerMESA");
+            _glXQueryRendererIntegerMESA_fnptr = (delegate* unmanaged<IntPtr, int, int, int, uint*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryRendererIntegerMESA");
             return _glXQueryRendererIntegerMESA_fnptr(dpy, screen, renderer, attribute, value);
         }
         
         /// <summary><b>[entry point: <c>glXQueryRendererStringMESA</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int, int, byte*> _glXQueryRendererStringMESA_fnptr = &glXQueryRendererStringMESA_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int, int, byte*> _glXQueryRendererStringMESA_fnptr = &glXQueryRendererStringMESA_Lazy;
         [UnmanagedCallersOnly]
-        private static byte* glXQueryRendererStringMESA_Lazy(Display* dpy, int screen, int renderer, int attribute)
+        private static byte* glXQueryRendererStringMESA_Lazy(IntPtr dpy, int screen, int renderer, int attribute)
         {
-            _glXQueryRendererStringMESA_fnptr = (delegate* unmanaged<Display*, int, int, int, byte*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryRendererStringMESA");
+            _glXQueryRendererStringMESA_fnptr = (delegate* unmanaged<IntPtr, int, int, int, byte*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryRendererStringMESA");
             return _glXQueryRendererStringMESA_fnptr(dpy, screen, renderer, attribute);
         }
         
         /// <summary><b>[entry point: <c>glXQueryServerString</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, int, byte*> _glXQueryServerString_fnptr = &glXQueryServerString_Lazy;
+        public static delegate* unmanaged<IntPtr, int, int, byte*> _glXQueryServerString_fnptr = &glXQueryServerString_Lazy;
         [UnmanagedCallersOnly]
-        private static byte* glXQueryServerString_Lazy(Display* dpy, int screen, int name)
+        private static byte* glXQueryServerString_Lazy(IntPtr dpy, int screen, int name)
         {
-            _glXQueryServerString_fnptr = (delegate* unmanaged<Display*, int, int, byte*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryServerString");
+            _glXQueryServerString_fnptr = (delegate* unmanaged<IntPtr, int, int, byte*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryServerString");
             return _glXQueryServerString_fnptr(dpy, screen, name);
         }
         
         /// <summary><b>[entry point: <c>glXQuerySwapGroupNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, uint*, uint*, byte> _glXQuerySwapGroupNV_fnptr = &glXQuerySwapGroupNV_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, uint*, uint*, byte> _glXQuerySwapGroupNV_fnptr = &glXQuerySwapGroupNV_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXQuerySwapGroupNV_Lazy(Display* dpy, nuint drawable, uint* group, uint* barrier)
+        private static byte glXQuerySwapGroupNV_Lazy(IntPtr dpy, nuint drawable, uint* group, uint* barrier)
         {
-            _glXQuerySwapGroupNV_fnptr = (delegate* unmanaged<Display*, nuint, uint*, uint*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQuerySwapGroupNV");
+            _glXQuerySwapGroupNV_fnptr = (delegate* unmanaged<IntPtr, nuint, uint*, uint*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQuerySwapGroupNV");
             return _glXQuerySwapGroupNV_fnptr(dpy, drawable, group, barrier);
         }
         
         /// <summary><b>[entry point: <c>glXQueryVersion</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int*, int*, byte> _glXQueryVersion_fnptr = &glXQueryVersion_Lazy;
+        public static delegate* unmanaged<IntPtr, int*, int*, byte> _glXQueryVersion_fnptr = &glXQueryVersion_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXQueryVersion_Lazy(Display* dpy, int* maj, int* min)
+        private static byte glXQueryVersion_Lazy(IntPtr dpy, int* maj, int* min)
         {
-            _glXQueryVersion_fnptr = (delegate* unmanaged<Display*, int*, int*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryVersion");
+            _glXQueryVersion_fnptr = (delegate* unmanaged<IntPtr, int*, int*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryVersion");
             return _glXQueryVersion_fnptr(dpy, maj, min);
         }
         
         /// <summary><b>[entry point: <c>glXQueryVideoCaptureDeviceNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, int, int*, int> _glXQueryVideoCaptureDeviceNV_fnptr = &glXQueryVideoCaptureDeviceNV_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, int, int*, int> _glXQueryVideoCaptureDeviceNV_fnptr = &glXQueryVideoCaptureDeviceNV_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXQueryVideoCaptureDeviceNV_Lazy(Display* dpy, nuint device, int attribute, int* value)
+        private static int glXQueryVideoCaptureDeviceNV_Lazy(IntPtr dpy, nuint device, int attribute, int* value)
         {
-            _glXQueryVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<Display*, nuint, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryVideoCaptureDeviceNV");
+            _glXQueryVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<IntPtr, nuint, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryVideoCaptureDeviceNV");
             return _glXQueryVideoCaptureDeviceNV_fnptr(dpy, device, attribute, value);
         }
         
         /// <summary><b>[entry point: <c>glXReleaseBuffersMESA</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, byte> _glXReleaseBuffersMESA_fnptr = &glXReleaseBuffersMESA_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, byte> _glXReleaseBuffersMESA_fnptr = &glXReleaseBuffersMESA_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXReleaseBuffersMESA_Lazy(Display* dpy, nuint drawable)
+        private static byte glXReleaseBuffersMESA_Lazy(IntPtr dpy, nuint drawable)
         {
-            _glXReleaseBuffersMESA_fnptr = (delegate* unmanaged<Display*, nuint, byte>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseBuffersMESA");
+            _glXReleaseBuffersMESA_fnptr = (delegate* unmanaged<IntPtr, nuint, byte>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseBuffersMESA");
             return _glXReleaseBuffersMESA_fnptr(dpy, drawable);
         }
         
         /// <summary><b>[entry point: <c>glXReleaseTexImageEXT</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, int, void> _glXReleaseTexImageEXT_fnptr = &glXReleaseTexImageEXT_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, int, void> _glXReleaseTexImageEXT_fnptr = &glXReleaseTexImageEXT_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXReleaseTexImageEXT_Lazy(Display* dpy, nuint drawable, int buffer)
+        private static void glXReleaseTexImageEXT_Lazy(IntPtr dpy, nuint drawable, int buffer)
         {
-            _glXReleaseTexImageEXT_fnptr = (delegate* unmanaged<Display*, nuint, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseTexImageEXT");
+            _glXReleaseTexImageEXT_fnptr = (delegate* unmanaged<IntPtr, nuint, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseTexImageEXT");
             _glXReleaseTexImageEXT_fnptr(dpy, drawable, buffer);
         }
         
         /// <summary><b>[entry point: <c>glXReleaseVideoCaptureDeviceNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, void> _glXReleaseVideoCaptureDeviceNV_fnptr = &glXReleaseVideoCaptureDeviceNV_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, void> _glXReleaseVideoCaptureDeviceNV_fnptr = &glXReleaseVideoCaptureDeviceNV_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXReleaseVideoCaptureDeviceNV_Lazy(Display* dpy, nuint device)
+        private static void glXReleaseVideoCaptureDeviceNV_Lazy(IntPtr dpy, nuint device)
         {
-            _glXReleaseVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseVideoCaptureDeviceNV");
+            _glXReleaseVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<IntPtr, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseVideoCaptureDeviceNV");
             _glXReleaseVideoCaptureDeviceNV_fnptr(dpy, device);
         }
         
         /// <summary><b>[entry point: <c>glXReleaseVideoDeviceNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, uint, int> _glXReleaseVideoDeviceNV_fnptr = &glXReleaseVideoDeviceNV_Lazy;
+        public static delegate* unmanaged<IntPtr, int, uint, int> _glXReleaseVideoDeviceNV_fnptr = &glXReleaseVideoDeviceNV_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXReleaseVideoDeviceNV_Lazy(Display* dpy, int screen, uint VideoDevice)
+        private static int glXReleaseVideoDeviceNV_Lazy(IntPtr dpy, int screen, uint VideoDevice)
         {
-            _glXReleaseVideoDeviceNV_fnptr = (delegate* unmanaged<Display*, int, uint, int>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseVideoDeviceNV");
+            _glXReleaseVideoDeviceNV_fnptr = (delegate* unmanaged<IntPtr, int, uint, int>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseVideoDeviceNV");
             return _glXReleaseVideoDeviceNV_fnptr(dpy, screen, VideoDevice);
         }
         
         /// <summary><b>[entry point: <c>glXReleaseVideoImageNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, int> _glXReleaseVideoImageNV_fnptr = &glXReleaseVideoImageNV_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, int> _glXReleaseVideoImageNV_fnptr = &glXReleaseVideoImageNV_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXReleaseVideoImageNV_Lazy(Display* dpy, nuint pbuf)
+        private static int glXReleaseVideoImageNV_Lazy(IntPtr dpy, nuint pbuf)
         {
-            _glXReleaseVideoImageNV_fnptr = (delegate* unmanaged<Display*, nuint, int>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseVideoImageNV");
+            _glXReleaseVideoImageNV_fnptr = (delegate* unmanaged<IntPtr, nuint, int>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseVideoImageNV");
             return _glXReleaseVideoImageNV_fnptr(dpy, pbuf);
         }
         
         /// <summary><b>[entry point: <c>glXResetFrameCountNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, int, byte> _glXResetFrameCountNV_fnptr = &glXResetFrameCountNV_Lazy;
+        public static delegate* unmanaged<IntPtr, int, byte> _glXResetFrameCountNV_fnptr = &glXResetFrameCountNV_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXResetFrameCountNV_Lazy(Display* dpy, int screen)
+        private static byte glXResetFrameCountNV_Lazy(IntPtr dpy, int screen)
         {
-            _glXResetFrameCountNV_fnptr = (delegate* unmanaged<Display*, int, byte>)GLXLoader.BindingsContext.GetProcAddress("glXResetFrameCountNV");
+            _glXResetFrameCountNV_fnptr = (delegate* unmanaged<IntPtr, int, byte>)GLXLoader.BindingsContext.GetProcAddress("glXResetFrameCountNV");
             return _glXResetFrameCountNV_fnptr(dpy, screen);
         }
         
         /// <summary><b>[entry point: <c>glXSelectEvent</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, ulong, void> _glXSelectEvent_fnptr = &glXSelectEvent_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, ulong, void> _glXSelectEvent_fnptr = &glXSelectEvent_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXSelectEvent_Lazy(Display* dpy, nuint draw, ulong event_mask)
+        private static void glXSelectEvent_Lazy(IntPtr dpy, nuint draw, ulong event_mask)
         {
-            _glXSelectEvent_fnptr = (delegate* unmanaged<Display*, nuint, ulong, void>)GLXLoader.BindingsContext.GetProcAddress("glXSelectEvent");
+            _glXSelectEvent_fnptr = (delegate* unmanaged<IntPtr, nuint, ulong, void>)GLXLoader.BindingsContext.GetProcAddress("glXSelectEvent");
             _glXSelectEvent_fnptr(dpy, draw, event_mask);
         }
         
         /// <summary><b>[entry point: <c>glXSelectEventSGIX</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, ulong, void> _glXSelectEventSGIX_fnptr = &glXSelectEventSGIX_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, ulong, void> _glXSelectEventSGIX_fnptr = &glXSelectEventSGIX_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXSelectEventSGIX_Lazy(Display* dpy, nuint drawable, ulong mask)
+        private static void glXSelectEventSGIX_Lazy(IntPtr dpy, nuint drawable, ulong mask)
         {
-            _glXSelectEventSGIX_fnptr = (delegate* unmanaged<Display*, nuint, ulong, void>)GLXLoader.BindingsContext.GetProcAddress("glXSelectEventSGIX");
+            _glXSelectEventSGIX_fnptr = (delegate* unmanaged<IntPtr, nuint, ulong, void>)GLXLoader.BindingsContext.GetProcAddress("glXSelectEventSGIX");
             _glXSelectEventSGIX_fnptr(dpy, drawable, mask);
         }
         
         /// <summary><b>[entry point: <c>glXSendPbufferToVideoNV</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, int, ulong*, byte, int> _glXSendPbufferToVideoNV_fnptr = &glXSendPbufferToVideoNV_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, int, ulong*, byte, int> _glXSendPbufferToVideoNV_fnptr = &glXSendPbufferToVideoNV_Lazy;
         [UnmanagedCallersOnly]
-        private static int glXSendPbufferToVideoNV_Lazy(Display* dpy, nuint pbuf, int iBufferType, ulong* pulCounterPbuffer, byte bBlock)
+        private static int glXSendPbufferToVideoNV_Lazy(IntPtr dpy, nuint pbuf, int iBufferType, ulong* pulCounterPbuffer, byte bBlock)
         {
-            _glXSendPbufferToVideoNV_fnptr = (delegate* unmanaged<Display*, nuint, int, ulong*, byte, int>)GLXLoader.BindingsContext.GetProcAddress("glXSendPbufferToVideoNV");
+            _glXSendPbufferToVideoNV_fnptr = (delegate* unmanaged<IntPtr, nuint, int, ulong*, byte, int>)GLXLoader.BindingsContext.GetProcAddress("glXSendPbufferToVideoNV");
             return _glXSendPbufferToVideoNV_fnptr(dpy, pbuf, iBufferType, pulCounterPbuffer, bBlock);
         }
         
@@ -1089,29 +1089,29 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXSwapBuffers</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, void> _glXSwapBuffers_fnptr = &glXSwapBuffers_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, void> _glXSwapBuffers_fnptr = &glXSwapBuffers_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXSwapBuffers_Lazy(Display* dpy, nuint drawable)
+        private static void glXSwapBuffers_Lazy(IntPtr dpy, nuint drawable)
         {
-            _glXSwapBuffers_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXSwapBuffers");
+            _glXSwapBuffers_fnptr = (delegate* unmanaged<IntPtr, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXSwapBuffers");
             _glXSwapBuffers_fnptr(dpy, drawable);
         }
         
         /// <summary><b>[entry point: <c>glXSwapBuffersMscOML</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, long, long, long, long> _glXSwapBuffersMscOML_fnptr = &glXSwapBuffersMscOML_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, long, long, long, long> _glXSwapBuffersMscOML_fnptr = &glXSwapBuffersMscOML_Lazy;
         [UnmanagedCallersOnly]
-        private static long glXSwapBuffersMscOML_Lazy(Display* dpy, nuint drawable, long target_msc, long divisor, long remainder)
+        private static long glXSwapBuffersMscOML_Lazy(IntPtr dpy, nuint drawable, long target_msc, long divisor, long remainder)
         {
-            _glXSwapBuffersMscOML_fnptr = (delegate* unmanaged<Display*, nuint, long, long, long, long>)GLXLoader.BindingsContext.GetProcAddress("glXSwapBuffersMscOML");
+            _glXSwapBuffersMscOML_fnptr = (delegate* unmanaged<IntPtr, nuint, long, long, long, long>)GLXLoader.BindingsContext.GetProcAddress("glXSwapBuffersMscOML");
             return _glXSwapBuffersMscOML_fnptr(dpy, drawable, target_msc, divisor, remainder);
         }
         
         /// <summary><b>[entry point: <c>glXSwapIntervalEXT</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, int, void> _glXSwapIntervalEXT_fnptr = &glXSwapIntervalEXT_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, int, void> _glXSwapIntervalEXT_fnptr = &glXSwapIntervalEXT_Lazy;
         [UnmanagedCallersOnly]
-        private static void glXSwapIntervalEXT_Lazy(Display* dpy, nuint drawable, int interval)
+        private static void glXSwapIntervalEXT_Lazy(IntPtr dpy, nuint drawable, int interval)
         {
-            _glXSwapIntervalEXT_fnptr = (delegate* unmanaged<Display*, nuint, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXSwapIntervalEXT");
+            _glXSwapIntervalEXT_fnptr = (delegate* unmanaged<IntPtr, nuint, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXSwapIntervalEXT");
             _glXSwapIntervalEXT_fnptr(dpy, drawable, interval);
         }
         
@@ -1143,20 +1143,20 @@ namespace OpenTK.Graphics.Glx
         }
         
         /// <summary><b>[entry point: <c>glXWaitForMscOML</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, long, long, long, long*, long*, long*, byte> _glXWaitForMscOML_fnptr = &glXWaitForMscOML_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, long, long, long, long*, long*, long*, byte> _glXWaitForMscOML_fnptr = &glXWaitForMscOML_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXWaitForMscOML_Lazy(Display* dpy, nuint drawable, long target_msc, long divisor, long remainder, long* ust, long* msc, long* sbc)
+        private static byte glXWaitForMscOML_Lazy(IntPtr dpy, nuint drawable, long target_msc, long divisor, long remainder, long* ust, long* msc, long* sbc)
         {
-            _glXWaitForMscOML_fnptr = (delegate* unmanaged<Display*, nuint, long, long, long, long*, long*, long*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXWaitForMscOML");
+            _glXWaitForMscOML_fnptr = (delegate* unmanaged<IntPtr, nuint, long, long, long, long*, long*, long*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXWaitForMscOML");
             return _glXWaitForMscOML_fnptr(dpy, drawable, target_msc, divisor, remainder, ust, msc, sbc);
         }
         
         /// <summary><b>[entry point: <c>glXWaitForSbcOML</c>]</b></summary>
-        public static delegate* unmanaged<Display*, nuint, long, long*, long*, long*, byte> _glXWaitForSbcOML_fnptr = &glXWaitForSbcOML_Lazy;
+        public static delegate* unmanaged<IntPtr, nuint, long, long*, long*, long*, byte> _glXWaitForSbcOML_fnptr = &glXWaitForSbcOML_Lazy;
         [UnmanagedCallersOnly]
-        private static byte glXWaitForSbcOML_Lazy(Display* dpy, nuint drawable, long target_sbc, long* ust, long* msc, long* sbc)
+        private static byte glXWaitForSbcOML_Lazy(IntPtr dpy, nuint drawable, long target_sbc, long* ust, long* msc, long* sbc)
         {
-            _glXWaitForSbcOML_fnptr = (delegate* unmanaged<Display*, nuint, long, long*, long*, long*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXWaitForSbcOML");
+            _glXWaitForSbcOML_fnptr = (delegate* unmanaged<IntPtr, nuint, long, long*, long*, long*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXWaitForSbcOML");
             return _glXWaitForSbcOML_fnptr(dpy, drawable, target_sbc, ust, msc, sbc);
         }
         

--- a/src/OpenTK.Graphics/GLX.Pointers.cs
+++ b/src/OpenTK.Graphics/GLX.Pointers.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;
@@ -13,7 +13,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXBindChannelToWindowSGIX_Lazy(Display* display, int screen, int channel, nuint window)
         {
-            _glXBindChannelToWindowSGIX_fnptr = (delegate* unmanaged<Display*, int, int, nuint, int>)GLLoader.BindingsContext.GetProcAddress("glXBindChannelToWindowSGIX");
+            _glXBindChannelToWindowSGIX_fnptr = (delegate* unmanaged<Display*, int, int, nuint, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindChannelToWindowSGIX");
             return _glXBindChannelToWindowSGIX_fnptr(display, screen, channel, window);
         }
         
@@ -22,7 +22,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXBindHyperpipeSGIX_Lazy(Display* dpy, int hpId)
         {
-            _glXBindHyperpipeSGIX_fnptr = (delegate* unmanaged<Display*, int, int>)GLLoader.BindingsContext.GetProcAddress("glXBindHyperpipeSGIX");
+            _glXBindHyperpipeSGIX_fnptr = (delegate* unmanaged<Display*, int, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindHyperpipeSGIX");
             return _glXBindHyperpipeSGIX_fnptr(dpy, hpId);
         }
         
@@ -31,7 +31,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXBindSwapBarrierNV_Lazy(Display* dpy, uint group, uint barrier)
         {
-            _glXBindSwapBarrierNV_fnptr = (delegate* unmanaged<Display*, uint, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glXBindSwapBarrierNV");
+            _glXBindSwapBarrierNV_fnptr = (delegate* unmanaged<Display*, uint, uint, byte>)GLXLoader.BindingsContext.GetProcAddress("glXBindSwapBarrierNV");
             return _glXBindSwapBarrierNV_fnptr(dpy, group, barrier);
         }
         
@@ -40,7 +40,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXBindSwapBarrierSGIX_Lazy(Display* dpy, nuint drawable, int barrier)
         {
-            _glXBindSwapBarrierSGIX_fnptr = (delegate* unmanaged<Display*, nuint, int, void>)GLLoader.BindingsContext.GetProcAddress("glXBindSwapBarrierSGIX");
+            _glXBindSwapBarrierSGIX_fnptr = (delegate* unmanaged<Display*, nuint, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXBindSwapBarrierSGIX");
             _glXBindSwapBarrierSGIX_fnptr(dpy, drawable, barrier);
         }
         
@@ -49,7 +49,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXBindTexImageEXT_Lazy(Display* dpy, nuint drawable, int buffer, int* attrib_list)
         {
-            _glXBindTexImageEXT_fnptr = (delegate* unmanaged<Display*, nuint, int, int*, void>)GLLoader.BindingsContext.GetProcAddress("glXBindTexImageEXT");
+            _glXBindTexImageEXT_fnptr = (delegate* unmanaged<Display*, nuint, int, int*, void>)GLXLoader.BindingsContext.GetProcAddress("glXBindTexImageEXT");
             _glXBindTexImageEXT_fnptr(dpy, drawable, buffer, attrib_list);
         }
         
@@ -58,7 +58,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXBindVideoCaptureDeviceNV_Lazy(Display* dpy, uint video_capture_slot, nuint device)
         {
-            _glXBindVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<Display*, uint, nuint, int>)GLLoader.BindingsContext.GetProcAddress("glXBindVideoCaptureDeviceNV");
+            _glXBindVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<Display*, uint, nuint, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindVideoCaptureDeviceNV");
             return _glXBindVideoCaptureDeviceNV_fnptr(dpy, video_capture_slot, device);
         }
         
@@ -67,7 +67,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXBindVideoDeviceNV_Lazy(Display* dpy, uint video_slot, uint video_device, int* attrib_list)
         {
-            _glXBindVideoDeviceNV_fnptr = (delegate* unmanaged<Display*, uint, uint, int*, int>)GLLoader.BindingsContext.GetProcAddress("glXBindVideoDeviceNV");
+            _glXBindVideoDeviceNV_fnptr = (delegate* unmanaged<Display*, uint, uint, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindVideoDeviceNV");
             return _glXBindVideoDeviceNV_fnptr(dpy, video_slot, video_device, attrib_list);
         }
         
@@ -76,7 +76,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXBindVideoImageNV_Lazy(Display* dpy, uint VideoDevice, nuint pbuf, int iVideoBuffer)
         {
-            _glXBindVideoImageNV_fnptr = (delegate* unmanaged<Display*, uint, nuint, int, int>)GLLoader.BindingsContext.GetProcAddress("glXBindVideoImageNV");
+            _glXBindVideoImageNV_fnptr = (delegate* unmanaged<Display*, uint, nuint, int, int>)GLXLoader.BindingsContext.GetProcAddress("glXBindVideoImageNV");
             return _glXBindVideoImageNV_fnptr(dpy, VideoDevice, pbuf, iVideoBuffer);
         }
         
@@ -85,7 +85,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXBlitContextFramebufferAMD_Lazy(IntPtr dstCtx, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, uint mask, uint filter)
         {
-            _glXBlitContextFramebufferAMD_fnptr = (delegate* unmanaged<IntPtr, int, int, int, int, int, int, int, int, uint, uint, void>)GLLoader.BindingsContext.GetProcAddress("glXBlitContextFramebufferAMD");
+            _glXBlitContextFramebufferAMD_fnptr = (delegate* unmanaged<IntPtr, int, int, int, int, int, int, int, int, uint, uint, void>)GLXLoader.BindingsContext.GetProcAddress("glXBlitContextFramebufferAMD");
             _glXBlitContextFramebufferAMD_fnptr(dstCtx, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
         }
         
@@ -94,7 +94,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXChannelRectSGIX_Lazy(Display* display, int screen, int channel, int x, int y, int w, int h)
         {
-            _glXChannelRectSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int, int, int, int, int>)GLLoader.BindingsContext.GetProcAddress("glXChannelRectSGIX");
+            _glXChannelRectSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int, int, int, int, int>)GLXLoader.BindingsContext.GetProcAddress("glXChannelRectSGIX");
             return _glXChannelRectSGIX_fnptr(display, screen, channel, x, y, w, h);
         }
         
@@ -103,7 +103,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXChannelRectSyncSGIX_Lazy(Display* display, int screen, int channel, uint synctype)
         {
-            _glXChannelRectSyncSGIX_fnptr = (delegate* unmanaged<Display*, int, int, uint, int>)GLLoader.BindingsContext.GetProcAddress("glXChannelRectSyncSGIX");
+            _glXChannelRectSyncSGIX_fnptr = (delegate* unmanaged<Display*, int, int, uint, int>)GLXLoader.BindingsContext.GetProcAddress("glXChannelRectSyncSGIX");
             return _glXChannelRectSyncSGIX_fnptr(display, screen, channel, synctype);
         }
         
@@ -112,7 +112,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr* glXChooseFBConfig_Lazy(Display* dpy, int screen, int* attrib_list, int* nelements)
         {
-            _glXChooseFBConfig_fnptr = (delegate* unmanaged<Display*, int, int*, int*, IntPtr*>)GLLoader.BindingsContext.GetProcAddress("glXChooseFBConfig");
+            _glXChooseFBConfig_fnptr = (delegate* unmanaged<Display*, int, int*, int*, IntPtr*>)GLXLoader.BindingsContext.GetProcAddress("glXChooseFBConfig");
             return _glXChooseFBConfig_fnptr(dpy, screen, attrib_list, nelements);
         }
         
@@ -121,7 +121,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr* glXChooseFBConfigSGIX_Lazy(Display* dpy, int screen, int* attrib_list, int* nelements)
         {
-            _glXChooseFBConfigSGIX_fnptr = (delegate* unmanaged<Display*, int, int*, int*, IntPtr*>)GLLoader.BindingsContext.GetProcAddress("glXChooseFBConfigSGIX");
+            _glXChooseFBConfigSGIX_fnptr = (delegate* unmanaged<Display*, int, int*, int*, IntPtr*>)GLXLoader.BindingsContext.GetProcAddress("glXChooseFBConfigSGIX");
             return _glXChooseFBConfigSGIX_fnptr(dpy, screen, attrib_list, nelements);
         }
         
@@ -130,7 +130,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static XVisualInfo* glXChooseVisual_Lazy(Display* dpy, int screen, int* attribList)
         {
-            _glXChooseVisual_fnptr = (delegate* unmanaged<Display*, int, int*, XVisualInfo*>)GLLoader.BindingsContext.GetProcAddress("glXChooseVisual");
+            _glXChooseVisual_fnptr = (delegate* unmanaged<Display*, int, int*, XVisualInfo*>)GLXLoader.BindingsContext.GetProcAddress("glXChooseVisual");
             return _glXChooseVisual_fnptr(dpy, screen, attribList);
         }
         
@@ -139,7 +139,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXCopyBufferSubDataNV_Lazy(Display* dpy, IntPtr readCtx, IntPtr writeCtx, uint readTarget, uint writeTarget, IntPtr readOffset, IntPtr writeOffset, nint size)
         {
-            _glXCopyBufferSubDataNV_fnptr = (delegate* unmanaged<Display*, IntPtr, IntPtr, uint, uint, IntPtr, IntPtr, nint, void>)GLLoader.BindingsContext.GetProcAddress("glXCopyBufferSubDataNV");
+            _glXCopyBufferSubDataNV_fnptr = (delegate* unmanaged<Display*, IntPtr, IntPtr, uint, uint, IntPtr, IntPtr, nint, void>)GLXLoader.BindingsContext.GetProcAddress("glXCopyBufferSubDataNV");
             _glXCopyBufferSubDataNV_fnptr(dpy, readCtx, writeCtx, readTarget, writeTarget, readOffset, writeOffset, size);
         }
         
@@ -148,7 +148,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXCopyContext_Lazy(Display* dpy, IntPtr src, IntPtr dst, ulong mask)
         {
-            _glXCopyContext_fnptr = (delegate* unmanaged<Display*, IntPtr, IntPtr, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glXCopyContext");
+            _glXCopyContext_fnptr = (delegate* unmanaged<Display*, IntPtr, IntPtr, ulong, void>)GLXLoader.BindingsContext.GetProcAddress("glXCopyContext");
             _glXCopyContext_fnptr(dpy, src, dst, mask);
         }
         
@@ -157,7 +157,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXCopyImageSubDataNV_Lazy(Display* dpy, IntPtr srcCtx, uint srcName, uint srcTarget, int srcLevel, int srcX, int srcY, int srcZ, IntPtr dstCtx, uint dstName, uint dstTarget, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth)
         {
-            _glXCopyImageSubDataNV_fnptr = (delegate* unmanaged<Display*, IntPtr, uint, uint, int, int, int, int, IntPtr, uint, uint, int, int, int, int, int, int, int, void>)GLLoader.BindingsContext.GetProcAddress("glXCopyImageSubDataNV");
+            _glXCopyImageSubDataNV_fnptr = (delegate* unmanaged<Display*, IntPtr, uint, uint, int, int, int, int, IntPtr, uint, uint, int, int, int, int, int, int, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXCopyImageSubDataNV");
             _glXCopyImageSubDataNV_fnptr(dpy, srcCtx, srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstCtx, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
         }
         
@@ -166,7 +166,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXCopySubBufferMESA_Lazy(Display* dpy, nuint drawable, int x, int y, int width, int height)
         {
-            _glXCopySubBufferMESA_fnptr = (delegate* unmanaged<Display*, nuint, int, int, int, int, void>)GLLoader.BindingsContext.GetProcAddress("glXCopySubBufferMESA");
+            _glXCopySubBufferMESA_fnptr = (delegate* unmanaged<Display*, nuint, int, int, int, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXCopySubBufferMESA");
             _glXCopySubBufferMESA_fnptr(dpy, drawable, x, y, width, height);
         }
         
@@ -175,7 +175,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr glXCreateAssociatedContextAMD_Lazy(uint id, IntPtr share_list)
         {
-            _glXCreateAssociatedContextAMD_fnptr = (delegate* unmanaged<uint, IntPtr, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glXCreateAssociatedContextAMD");
+            _glXCreateAssociatedContextAMD_fnptr = (delegate* unmanaged<uint, IntPtr, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateAssociatedContextAMD");
             return _glXCreateAssociatedContextAMD_fnptr(id, share_list);
         }
         
@@ -184,7 +184,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr glXCreateAssociatedContextAttribsAMD_Lazy(uint id, IntPtr share_context, int* attribList)
         {
-            _glXCreateAssociatedContextAttribsAMD_fnptr = (delegate* unmanaged<uint, IntPtr, int*, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glXCreateAssociatedContextAttribsAMD");
+            _glXCreateAssociatedContextAttribsAMD_fnptr = (delegate* unmanaged<uint, IntPtr, int*, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateAssociatedContextAttribsAMD");
             return _glXCreateAssociatedContextAttribsAMD_fnptr(id, share_context, attribList);
         }
         
@@ -193,7 +193,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr glXCreateContext_Lazy(Display* dpy, XVisualInfo* vis, IntPtr shareList, byte direct)
         {
-            _glXCreateContext_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, IntPtr, byte, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glXCreateContext");
+            _glXCreateContext_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, IntPtr, byte, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateContext");
             return _glXCreateContext_fnptr(dpy, vis, shareList, direct);
         }
         
@@ -202,7 +202,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr glXCreateContextAttribsARB_Lazy(Display* dpy, IntPtr config, IntPtr share_context, byte direct, int* attrib_list)
         {
-            _glXCreateContextAttribsARB_fnptr = (delegate* unmanaged<Display*, IntPtr, IntPtr, byte, int*, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glXCreateContextAttribsARB");
+            _glXCreateContextAttribsARB_fnptr = (delegate* unmanaged<Display*, IntPtr, IntPtr, byte, int*, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateContextAttribsARB");
             return _glXCreateContextAttribsARB_fnptr(dpy, config, share_context, direct, attrib_list);
         }
         
@@ -211,7 +211,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr glXCreateContextWithConfigSGIX_Lazy(Display* dpy, IntPtr config, int render_type, IntPtr share_list, byte direct)
         {
-            _glXCreateContextWithConfigSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, int, IntPtr, byte, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glXCreateContextWithConfigSGIX");
+            _glXCreateContextWithConfigSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, int, IntPtr, byte, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateContextWithConfigSGIX");
             return _glXCreateContextWithConfigSGIX_fnptr(dpy, config, render_type, share_list, direct);
         }
         
@@ -220,7 +220,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static nuint glXCreateGLXPbufferSGIX_Lazy(Display* dpy, IntPtr config, uint width, uint height, int* attrib_list)
         {
-            _glXCreateGLXPbufferSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, uint, uint, int*, nuint>)GLLoader.BindingsContext.GetProcAddress("glXCreateGLXPbufferSGIX");
+            _glXCreateGLXPbufferSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, uint, uint, int*, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateGLXPbufferSGIX");
             return _glXCreateGLXPbufferSGIX_fnptr(dpy, config, width, height, attrib_list);
         }
         
@@ -229,7 +229,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static nuint glXCreateGLXPixmap_Lazy(Display* dpy, XVisualInfo* visual, nuint pixmap)
         {
-            _glXCreateGLXPixmap_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, nuint, nuint>)GLLoader.BindingsContext.GetProcAddress("glXCreateGLXPixmap");
+            _glXCreateGLXPixmap_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, nuint, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateGLXPixmap");
             return _glXCreateGLXPixmap_fnptr(dpy, visual, pixmap);
         }
         
@@ -238,7 +238,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static nuint glXCreateGLXPixmapMESA_Lazy(Display* dpy, XVisualInfo* visual, nuint pixmap, nuint cmap)
         {
-            _glXCreateGLXPixmapMESA_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, nuint, nuint, nuint>)GLLoader.BindingsContext.GetProcAddress("glXCreateGLXPixmapMESA");
+            _glXCreateGLXPixmapMESA_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, nuint, nuint, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateGLXPixmapMESA");
             return _glXCreateGLXPixmapMESA_fnptr(dpy, visual, pixmap, cmap);
         }
         
@@ -247,7 +247,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static nuint glXCreateGLXPixmapWithConfigSGIX_Lazy(Display* dpy, IntPtr config, nuint pixmap)
         {
-            _glXCreateGLXPixmapWithConfigSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, nuint, nuint>)GLLoader.BindingsContext.GetProcAddress("glXCreateGLXPixmapWithConfigSGIX");
+            _glXCreateGLXPixmapWithConfigSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, nuint, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateGLXPixmapWithConfigSGIX");
             return _glXCreateGLXPixmapWithConfigSGIX_fnptr(dpy, config, pixmap);
         }
         
@@ -256,7 +256,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr glXCreateNewContext_Lazy(Display* dpy, IntPtr config, int render_type, IntPtr share_list, byte direct)
         {
-            _glXCreateNewContext_fnptr = (delegate* unmanaged<Display*, IntPtr, int, IntPtr, byte, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glXCreateNewContext");
+            _glXCreateNewContext_fnptr = (delegate* unmanaged<Display*, IntPtr, int, IntPtr, byte, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXCreateNewContext");
             return _glXCreateNewContext_fnptr(dpy, config, render_type, share_list, direct);
         }
         
@@ -265,7 +265,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static nuint glXCreatePbuffer_Lazy(Display* dpy, IntPtr config, int* attrib_list)
         {
-            _glXCreatePbuffer_fnptr = (delegate* unmanaged<Display*, IntPtr, int*, nuint>)GLLoader.BindingsContext.GetProcAddress("glXCreatePbuffer");
+            _glXCreatePbuffer_fnptr = (delegate* unmanaged<Display*, IntPtr, int*, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreatePbuffer");
             return _glXCreatePbuffer_fnptr(dpy, config, attrib_list);
         }
         
@@ -274,7 +274,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static nuint glXCreatePixmap_Lazy(Display* dpy, IntPtr config, nuint pixmap, int* attrib_list)
         {
-            _glXCreatePixmap_fnptr = (delegate* unmanaged<Display*, IntPtr, nuint, int*, nuint>)GLLoader.BindingsContext.GetProcAddress("glXCreatePixmap");
+            _glXCreatePixmap_fnptr = (delegate* unmanaged<Display*, IntPtr, nuint, int*, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreatePixmap");
             return _glXCreatePixmap_fnptr(dpy, config, pixmap, attrib_list);
         }
         
@@ -283,7 +283,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static nuint glXCreateWindow_Lazy(Display* dpy, IntPtr config, nuint win, int* attrib_list)
         {
-            _glXCreateWindow_fnptr = (delegate* unmanaged<Display*, IntPtr, nuint, int*, nuint>)GLLoader.BindingsContext.GetProcAddress("glXCreateWindow");
+            _glXCreateWindow_fnptr = (delegate* unmanaged<Display*, IntPtr, nuint, int*, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXCreateWindow");
             return _glXCreateWindow_fnptr(dpy, config, win, attrib_list);
         }
         
@@ -292,7 +292,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXCushionSGI_Lazy(Display* dpy, nuint window, float cushion)
         {
-            _glXCushionSGI_fnptr = (delegate* unmanaged<Display*, nuint, float, void>)GLLoader.BindingsContext.GetProcAddress("glXCushionSGI");
+            _glXCushionSGI_fnptr = (delegate* unmanaged<Display*, nuint, float, void>)GLXLoader.BindingsContext.GetProcAddress("glXCushionSGI");
             _glXCushionSGI_fnptr(dpy, window, cushion);
         }
         
@@ -301,7 +301,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXDelayBeforeSwapNV_Lazy(Display* dpy, nuint drawable, float seconds)
         {
-            _glXDelayBeforeSwapNV_fnptr = (delegate* unmanaged<Display*, nuint, float, byte>)GLLoader.BindingsContext.GetProcAddress("glXDelayBeforeSwapNV");
+            _glXDelayBeforeSwapNV_fnptr = (delegate* unmanaged<Display*, nuint, float, byte>)GLXLoader.BindingsContext.GetProcAddress("glXDelayBeforeSwapNV");
             return _glXDelayBeforeSwapNV_fnptr(dpy, drawable, seconds);
         }
         
@@ -310,7 +310,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXDeleteAssociatedContextAMD_Lazy(IntPtr ctx)
         {
-            _glXDeleteAssociatedContextAMD_fnptr = (delegate* unmanaged<IntPtr, byte>)GLLoader.BindingsContext.GetProcAddress("glXDeleteAssociatedContextAMD");
+            _glXDeleteAssociatedContextAMD_fnptr = (delegate* unmanaged<IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXDeleteAssociatedContextAMD");
             return _glXDeleteAssociatedContextAMD_fnptr(ctx);
         }
         
@@ -319,7 +319,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXDestroyContext_Lazy(Display* dpy, IntPtr ctx)
         {
-            _glXDestroyContext_fnptr = (delegate* unmanaged<Display*, IntPtr, void>)GLLoader.BindingsContext.GetProcAddress("glXDestroyContext");
+            _glXDestroyContext_fnptr = (delegate* unmanaged<Display*, IntPtr, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyContext");
             _glXDestroyContext_fnptr(dpy, ctx);
         }
         
@@ -328,7 +328,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXDestroyGLXPbufferSGIX_Lazy(Display* dpy, nuint pbuf)
         {
-            _glXDestroyGLXPbufferSGIX_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLLoader.BindingsContext.GetProcAddress("glXDestroyGLXPbufferSGIX");
+            _glXDestroyGLXPbufferSGIX_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyGLXPbufferSGIX");
             _glXDestroyGLXPbufferSGIX_fnptr(dpy, pbuf);
         }
         
@@ -337,7 +337,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXDestroyGLXPixmap_Lazy(Display* dpy, nuint pixmap)
         {
-            _glXDestroyGLXPixmap_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLLoader.BindingsContext.GetProcAddress("glXDestroyGLXPixmap");
+            _glXDestroyGLXPixmap_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyGLXPixmap");
             _glXDestroyGLXPixmap_fnptr(dpy, pixmap);
         }
         
@@ -346,7 +346,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXDestroyHyperpipeConfigSGIX_Lazy(Display* dpy, int hpId)
         {
-            _glXDestroyHyperpipeConfigSGIX_fnptr = (delegate* unmanaged<Display*, int, int>)GLLoader.BindingsContext.GetProcAddress("glXDestroyHyperpipeConfigSGIX");
+            _glXDestroyHyperpipeConfigSGIX_fnptr = (delegate* unmanaged<Display*, int, int>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyHyperpipeConfigSGIX");
             return _glXDestroyHyperpipeConfigSGIX_fnptr(dpy, hpId);
         }
         
@@ -355,7 +355,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXDestroyPbuffer_Lazy(Display* dpy, nuint pbuf)
         {
-            _glXDestroyPbuffer_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLLoader.BindingsContext.GetProcAddress("glXDestroyPbuffer");
+            _glXDestroyPbuffer_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyPbuffer");
             _glXDestroyPbuffer_fnptr(dpy, pbuf);
         }
         
@@ -364,7 +364,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXDestroyPixmap_Lazy(Display* dpy, nuint pixmap)
         {
-            _glXDestroyPixmap_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLLoader.BindingsContext.GetProcAddress("glXDestroyPixmap");
+            _glXDestroyPixmap_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyPixmap");
             _glXDestroyPixmap_fnptr(dpy, pixmap);
         }
         
@@ -373,7 +373,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXDestroyWindow_Lazy(Display* dpy, nuint win)
         {
-            _glXDestroyWindow_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLLoader.BindingsContext.GetProcAddress("glXDestroyWindow");
+            _glXDestroyWindow_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXDestroyWindow");
             _glXDestroyWindow_fnptr(dpy, win);
         }
         
@@ -382,7 +382,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static nuint* glXEnumerateVideoCaptureDevicesNV_Lazy(Display* dpy, int screen, int* nelements)
         {
-            _glXEnumerateVideoCaptureDevicesNV_fnptr = (delegate* unmanaged<Display*, int, int*, nuint*>)GLLoader.BindingsContext.GetProcAddress("glXEnumerateVideoCaptureDevicesNV");
+            _glXEnumerateVideoCaptureDevicesNV_fnptr = (delegate* unmanaged<Display*, int, int*, nuint*>)GLXLoader.BindingsContext.GetProcAddress("glXEnumerateVideoCaptureDevicesNV");
             return _glXEnumerateVideoCaptureDevicesNV_fnptr(dpy, screen, nelements);
         }
         
@@ -391,7 +391,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static uint* glXEnumerateVideoDevicesNV_Lazy(Display* dpy, int screen, int* nelements)
         {
-            _glXEnumerateVideoDevicesNV_fnptr = (delegate* unmanaged<Display*, int, int*, uint*>)GLLoader.BindingsContext.GetProcAddress("glXEnumerateVideoDevicesNV");
+            _glXEnumerateVideoDevicesNV_fnptr = (delegate* unmanaged<Display*, int, int*, uint*>)GLXLoader.BindingsContext.GetProcAddress("glXEnumerateVideoDevicesNV");
             return _glXEnumerateVideoDevicesNV_fnptr(dpy, screen, nelements);
         }
         
@@ -400,7 +400,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXFreeContextEXT_Lazy(Display* dpy, IntPtr context)
         {
-            _glXFreeContextEXT_fnptr = (delegate* unmanaged<Display*, IntPtr, void>)GLLoader.BindingsContext.GetProcAddress("glXFreeContextEXT");
+            _glXFreeContextEXT_fnptr = (delegate* unmanaged<Display*, IntPtr, void>)GLXLoader.BindingsContext.GetProcAddress("glXFreeContextEXT");
             _glXFreeContextEXT_fnptr(dpy, context);
         }
         
@@ -409,7 +409,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static uint glXGetAGPOffsetMESA_Lazy(void* pointer)
         {
-            _glXGetAGPOffsetMESA_fnptr = (delegate* unmanaged<void*, uint>)GLLoader.BindingsContext.GetProcAddress("glXGetAGPOffsetMESA");
+            _glXGetAGPOffsetMESA_fnptr = (delegate* unmanaged<void*, uint>)GLXLoader.BindingsContext.GetProcAddress("glXGetAGPOffsetMESA");
             return _glXGetAGPOffsetMESA_fnptr(pointer);
         }
         
@@ -418,7 +418,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte* glXGetClientString_Lazy(Display* dpy, int name)
         {
-            _glXGetClientString_fnptr = (delegate* unmanaged<Display*, int, byte*>)GLLoader.BindingsContext.GetProcAddress("glXGetClientString");
+            _glXGetClientString_fnptr = (delegate* unmanaged<Display*, int, byte*>)GLXLoader.BindingsContext.GetProcAddress("glXGetClientString");
             return _glXGetClientString_fnptr(dpy, name);
         }
         
@@ -427,7 +427,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXGetConfig_Lazy(Display* dpy, XVisualInfo* visual, int attrib, int* value)
         {
-            _glXGetConfig_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, int, int*, int>)GLLoader.BindingsContext.GetProcAddress("glXGetConfig");
+            _glXGetConfig_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetConfig");
             return _glXGetConfig_fnptr(dpy, visual, attrib, value);
         }
         
@@ -436,7 +436,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static uint glXGetContextGPUIDAMD_Lazy(IntPtr ctx)
         {
-            _glXGetContextGPUIDAMD_fnptr = (delegate* unmanaged<IntPtr, uint>)GLLoader.BindingsContext.GetProcAddress("glXGetContextGPUIDAMD");
+            _glXGetContextGPUIDAMD_fnptr = (delegate* unmanaged<IntPtr, uint>)GLXLoader.BindingsContext.GetProcAddress("glXGetContextGPUIDAMD");
             return _glXGetContextGPUIDAMD_fnptr(ctx);
         }
         
@@ -445,7 +445,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static nuint glXGetContextIDEXT_Lazy(IntPtr context)
         {
-            _glXGetContextIDEXT_fnptr = (delegate* unmanaged<IntPtr, nuint>)GLLoader.BindingsContext.GetProcAddress("glXGetContextIDEXT");
+            _glXGetContextIDEXT_fnptr = (delegate* unmanaged<IntPtr, nuint>)GLXLoader.BindingsContext.GetProcAddress("glXGetContextIDEXT");
             return _glXGetContextIDEXT_fnptr(context);
         }
         
@@ -454,7 +454,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr glXGetCurrentAssociatedContextAMD_Lazy()
         {
-            _glXGetCurrentAssociatedContextAMD_fnptr = (delegate* unmanaged<IntPtr>)GLLoader.BindingsContext.GetProcAddress("glXGetCurrentAssociatedContextAMD");
+            _glXGetCurrentAssociatedContextAMD_fnptr = (delegate* unmanaged<IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXGetCurrentAssociatedContextAMD");
             return _glXGetCurrentAssociatedContextAMD_fnptr();
         }
         
@@ -463,7 +463,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr glXGetCurrentContext_Lazy()
         {
-            _glXGetCurrentContext_fnptr = (delegate* unmanaged<IntPtr>)GLLoader.BindingsContext.GetProcAddress("glXGetCurrentContext");
+            _glXGetCurrentContext_fnptr = (delegate* unmanaged<IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXGetCurrentContext");
             return _glXGetCurrentContext_fnptr();
         }
         
@@ -472,7 +472,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static Display* glXGetCurrentDisplay_Lazy()
         {
-            _glXGetCurrentDisplay_fnptr = (delegate* unmanaged<Display*>)GLLoader.BindingsContext.GetProcAddress("glXGetCurrentDisplay");
+            _glXGetCurrentDisplay_fnptr = (delegate* unmanaged<Display*>)GLXLoader.BindingsContext.GetProcAddress("glXGetCurrentDisplay");
             return _glXGetCurrentDisplay_fnptr();
         }
         
@@ -481,7 +481,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static Display* glXGetCurrentDisplayEXT_Lazy()
         {
-            _glXGetCurrentDisplayEXT_fnptr = (delegate* unmanaged<Display*>)GLLoader.BindingsContext.GetProcAddress("glXGetCurrentDisplayEXT");
+            _glXGetCurrentDisplayEXT_fnptr = (delegate* unmanaged<Display*>)GLXLoader.BindingsContext.GetProcAddress("glXGetCurrentDisplayEXT");
             return _glXGetCurrentDisplayEXT_fnptr();
         }
         
@@ -490,7 +490,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static nuint glXGetCurrentDrawable_Lazy()
         {
-            _glXGetCurrentDrawable_fnptr = (delegate* unmanaged<nuint>)GLLoader.BindingsContext.GetProcAddress("glXGetCurrentDrawable");
+            _glXGetCurrentDrawable_fnptr = (delegate* unmanaged<nuint>)GLXLoader.BindingsContext.GetProcAddress("glXGetCurrentDrawable");
             return _glXGetCurrentDrawable_fnptr();
         }
         
@@ -499,7 +499,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static nuint glXGetCurrentReadDrawable_Lazy()
         {
-            _glXGetCurrentReadDrawable_fnptr = (delegate* unmanaged<nuint>)GLLoader.BindingsContext.GetProcAddress("glXGetCurrentReadDrawable");
+            _glXGetCurrentReadDrawable_fnptr = (delegate* unmanaged<nuint>)GLXLoader.BindingsContext.GetProcAddress("glXGetCurrentReadDrawable");
             return _glXGetCurrentReadDrawable_fnptr();
         }
         
@@ -508,7 +508,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static nuint glXGetCurrentReadDrawableSGI_Lazy()
         {
-            _glXGetCurrentReadDrawableSGI_fnptr = (delegate* unmanaged<nuint>)GLLoader.BindingsContext.GetProcAddress("glXGetCurrentReadDrawableSGI");
+            _glXGetCurrentReadDrawableSGI_fnptr = (delegate* unmanaged<nuint>)GLXLoader.BindingsContext.GetProcAddress("glXGetCurrentReadDrawableSGI");
             return _glXGetCurrentReadDrawableSGI_fnptr();
         }
         
@@ -517,7 +517,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXGetFBConfigAttrib_Lazy(Display* dpy, IntPtr config, int attribute, int* value)
         {
-            _glXGetFBConfigAttrib_fnptr = (delegate* unmanaged<Display*, IntPtr, int, int*, int>)GLLoader.BindingsContext.GetProcAddress("glXGetFBConfigAttrib");
+            _glXGetFBConfigAttrib_fnptr = (delegate* unmanaged<Display*, IntPtr, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetFBConfigAttrib");
             return _glXGetFBConfigAttrib_fnptr(dpy, config, attribute, value);
         }
         
@@ -526,7 +526,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXGetFBConfigAttribSGIX_Lazy(Display* dpy, IntPtr config, int attribute, int* value)
         {
-            _glXGetFBConfigAttribSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, int, int*, int>)GLLoader.BindingsContext.GetProcAddress("glXGetFBConfigAttribSGIX");
+            _glXGetFBConfigAttribSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetFBConfigAttribSGIX");
             return _glXGetFBConfigAttribSGIX_fnptr(dpy, config, attribute, value);
         }
         
@@ -535,7 +535,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr glXGetFBConfigFromVisualSGIX_Lazy(Display* dpy, XVisualInfo* vis)
         {
-            _glXGetFBConfigFromVisualSGIX_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glXGetFBConfigFromVisualSGIX");
+            _glXGetFBConfigFromVisualSGIX_fnptr = (delegate* unmanaged<Display*, XVisualInfo*, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXGetFBConfigFromVisualSGIX");
             return _glXGetFBConfigFromVisualSGIX_fnptr(dpy, vis);
         }
         
@@ -544,7 +544,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr* glXGetFBConfigs_Lazy(Display* dpy, int screen, int* nelements)
         {
-            _glXGetFBConfigs_fnptr = (delegate* unmanaged<Display*, int, int*, IntPtr*>)GLLoader.BindingsContext.GetProcAddress("glXGetFBConfigs");
+            _glXGetFBConfigs_fnptr = (delegate* unmanaged<Display*, int, int*, IntPtr*>)GLXLoader.BindingsContext.GetProcAddress("glXGetFBConfigs");
             return _glXGetFBConfigs_fnptr(dpy, screen, nelements);
         }
         
@@ -553,7 +553,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static uint glXGetGPUIDsAMD_Lazy(uint maxCount, uint* ids)
         {
-            _glXGetGPUIDsAMD_fnptr = (delegate* unmanaged<uint, uint*, uint>)GLLoader.BindingsContext.GetProcAddress("glXGetGPUIDsAMD");
+            _glXGetGPUIDsAMD_fnptr = (delegate* unmanaged<uint, uint*, uint>)GLXLoader.BindingsContext.GetProcAddress("glXGetGPUIDsAMD");
             return _glXGetGPUIDsAMD_fnptr(maxCount, ids);
         }
         
@@ -562,7 +562,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXGetGPUInfoAMD_Lazy(uint id, int property, uint dataType, uint size, void* data)
         {
-            _glXGetGPUInfoAMD_fnptr = (delegate* unmanaged<uint, int, uint, uint, void*, int>)GLLoader.BindingsContext.GetProcAddress("glXGetGPUInfoAMD");
+            _glXGetGPUInfoAMD_fnptr = (delegate* unmanaged<uint, int, uint, uint, void*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetGPUInfoAMD");
             return _glXGetGPUInfoAMD_fnptr(id, property, dataType, size, data);
         }
         
@@ -571,7 +571,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXGetMscRateOML_Lazy(Display* dpy, nuint drawable, int* numerator, int* denominator)
         {
-            _glXGetMscRateOML_fnptr = (delegate* unmanaged<Display*, nuint, int*, int*, byte>)GLLoader.BindingsContext.GetProcAddress("glXGetMscRateOML");
+            _glXGetMscRateOML_fnptr = (delegate* unmanaged<Display*, nuint, int*, int*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXGetMscRateOML");
             return _glXGetMscRateOML_fnptr(dpy, drawable, numerator, denominator);
         }
         
@@ -580,7 +580,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr glXGetProcAddress_Lazy(byte* procName)
         {
-            _glXGetProcAddress_fnptr = (delegate* unmanaged<byte*, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glXGetProcAddress");
+            _glXGetProcAddress_fnptr = (delegate* unmanaged<byte*, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXGetProcAddress");
             return _glXGetProcAddress_fnptr(procName);
         }
         
@@ -589,7 +589,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr glXGetProcAddressARB_Lazy(byte* procName)
         {
-            _glXGetProcAddressARB_fnptr = (delegate* unmanaged<byte*, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glXGetProcAddressARB");
+            _glXGetProcAddressARB_fnptr = (delegate* unmanaged<byte*, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXGetProcAddressARB");
             return _glXGetProcAddressARB_fnptr(procName);
         }
         
@@ -598,7 +598,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXGetSelectedEvent_Lazy(Display* dpy, nuint draw, ulong* event_mask)
         {
-            _glXGetSelectedEvent_fnptr = (delegate* unmanaged<Display*, nuint, ulong*, void>)GLLoader.BindingsContext.GetProcAddress("glXGetSelectedEvent");
+            _glXGetSelectedEvent_fnptr = (delegate* unmanaged<Display*, nuint, ulong*, void>)GLXLoader.BindingsContext.GetProcAddress("glXGetSelectedEvent");
             _glXGetSelectedEvent_fnptr(dpy, draw, event_mask);
         }
         
@@ -607,7 +607,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXGetSelectedEventSGIX_Lazy(Display* dpy, nuint drawable, ulong* mask)
         {
-            _glXGetSelectedEventSGIX_fnptr = (delegate* unmanaged<Display*, nuint, ulong*, void>)GLLoader.BindingsContext.GetProcAddress("glXGetSelectedEventSGIX");
+            _glXGetSelectedEventSGIX_fnptr = (delegate* unmanaged<Display*, nuint, ulong*, void>)GLXLoader.BindingsContext.GetProcAddress("glXGetSelectedEventSGIX");
             _glXGetSelectedEventSGIX_fnptr(dpy, drawable, mask);
         }
         
@@ -616,7 +616,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXGetSwapIntervalMESA_Lazy()
         {
-            _glXGetSwapIntervalMESA_fnptr = (delegate* unmanaged<int>)GLLoader.BindingsContext.GetProcAddress("glXGetSwapIntervalMESA");
+            _glXGetSwapIntervalMESA_fnptr = (delegate* unmanaged<int>)GLXLoader.BindingsContext.GetProcAddress("glXGetSwapIntervalMESA");
             return _glXGetSwapIntervalMESA_fnptr();
         }
         
@@ -625,7 +625,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXGetSyncValuesOML_Lazy(Display* dpy, nuint drawable, long* ust, long* msc, long* sbc)
         {
-            _glXGetSyncValuesOML_fnptr = (delegate* unmanaged<Display*, nuint, long*, long*, long*, byte>)GLLoader.BindingsContext.GetProcAddress("glXGetSyncValuesOML");
+            _glXGetSyncValuesOML_fnptr = (delegate* unmanaged<Display*, nuint, long*, long*, long*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXGetSyncValuesOML");
             return _glXGetSyncValuesOML_fnptr(dpy, drawable, ust, msc, sbc);
         }
         
@@ -634,7 +634,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXGetTransparentIndexSUN_Lazy(Display* dpy, nuint overlay, nuint underlay, ulong* pTransparentIndex)
         {
-            _glXGetTransparentIndexSUN_fnptr = (delegate* unmanaged<Display*, nuint, nuint, ulong*, int>)GLLoader.BindingsContext.GetProcAddress("glXGetTransparentIndexSUN");
+            _glXGetTransparentIndexSUN_fnptr = (delegate* unmanaged<Display*, nuint, nuint, ulong*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetTransparentIndexSUN");
             return _glXGetTransparentIndexSUN_fnptr(dpy, overlay, underlay, pTransparentIndex);
         }
         
@@ -643,7 +643,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXGetVideoDeviceNV_Lazy(Display* dpy, int screen, int numVideoDevices, uint* pVideoDevice)
         {
-            _glXGetVideoDeviceNV_fnptr = (delegate* unmanaged<Display*, int, int, uint*, int>)GLLoader.BindingsContext.GetProcAddress("glXGetVideoDeviceNV");
+            _glXGetVideoDeviceNV_fnptr = (delegate* unmanaged<Display*, int, int, uint*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetVideoDeviceNV");
             return _glXGetVideoDeviceNV_fnptr(dpy, screen, numVideoDevices, pVideoDevice);
         }
         
@@ -652,7 +652,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXGetVideoInfoNV_Lazy(Display* dpy, int screen, uint VideoDevice, ulong* pulCounterOutputPbuffer, ulong* pulCounterOutputVideo)
         {
-            _glXGetVideoInfoNV_fnptr = (delegate* unmanaged<Display*, int, uint, ulong*, ulong*, int>)GLLoader.BindingsContext.GetProcAddress("glXGetVideoInfoNV");
+            _glXGetVideoInfoNV_fnptr = (delegate* unmanaged<Display*, int, uint, ulong*, ulong*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetVideoInfoNV");
             return _glXGetVideoInfoNV_fnptr(dpy, screen, VideoDevice, pulCounterOutputPbuffer, pulCounterOutputVideo);
         }
         
@@ -661,7 +661,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXGetVideoSyncSGI_Lazy(uint* count)
         {
-            _glXGetVideoSyncSGI_fnptr = (delegate* unmanaged<uint*, int>)GLLoader.BindingsContext.GetProcAddress("glXGetVideoSyncSGI");
+            _glXGetVideoSyncSGI_fnptr = (delegate* unmanaged<uint*, int>)GLXLoader.BindingsContext.GetProcAddress("glXGetVideoSyncSGI");
             return _glXGetVideoSyncSGI_fnptr(count);
         }
         
@@ -670,7 +670,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static XVisualInfo* glXGetVisualFromFBConfig_Lazy(Display* dpy, IntPtr config)
         {
-            _glXGetVisualFromFBConfig_fnptr = (delegate* unmanaged<Display*, IntPtr, XVisualInfo*>)GLLoader.BindingsContext.GetProcAddress("glXGetVisualFromFBConfig");
+            _glXGetVisualFromFBConfig_fnptr = (delegate* unmanaged<Display*, IntPtr, XVisualInfo*>)GLXLoader.BindingsContext.GetProcAddress("glXGetVisualFromFBConfig");
             return _glXGetVisualFromFBConfig_fnptr(dpy, config);
         }
         
@@ -679,7 +679,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static XVisualInfo* glXGetVisualFromFBConfigSGIX_Lazy(Display* dpy, IntPtr config)
         {
-            _glXGetVisualFromFBConfigSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, XVisualInfo*>)GLLoader.BindingsContext.GetProcAddress("glXGetVisualFromFBConfigSGIX");
+            _glXGetVisualFromFBConfigSGIX_fnptr = (delegate* unmanaged<Display*, IntPtr, XVisualInfo*>)GLXLoader.BindingsContext.GetProcAddress("glXGetVisualFromFBConfigSGIX");
             return _glXGetVisualFromFBConfigSGIX_fnptr(dpy, config);
         }
         
@@ -688,7 +688,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXHyperpipeAttribSGIX_Lazy(Display* dpy, int timeSlice, int attrib, int size, void* attribList)
         {
-            _glXHyperpipeAttribSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int, void*, int>)GLLoader.BindingsContext.GetProcAddress("glXHyperpipeAttribSGIX");
+            _glXHyperpipeAttribSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int, void*, int>)GLXLoader.BindingsContext.GetProcAddress("glXHyperpipeAttribSGIX");
             return _glXHyperpipeAttribSGIX_fnptr(dpy, timeSlice, attrib, size, attribList);
         }
         
@@ -697,7 +697,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXHyperpipeConfigSGIX_Lazy(Display* dpy, int networkId, int npipes, GLXHyperpipeConfigSGIX* cfg, int* hpId)
         {
-            _glXHyperpipeConfigSGIX_fnptr = (delegate* unmanaged<Display*, int, int, GLXHyperpipeConfigSGIX*, int*, int>)GLLoader.BindingsContext.GetProcAddress("glXHyperpipeConfigSGIX");
+            _glXHyperpipeConfigSGIX_fnptr = (delegate* unmanaged<Display*, int, int, GLXHyperpipeConfigSGIX*, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXHyperpipeConfigSGIX");
             return _glXHyperpipeConfigSGIX_fnptr(dpy, networkId, npipes, cfg, hpId);
         }
         
@@ -706,7 +706,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static IntPtr glXImportContextEXT_Lazy(Display* dpy, nuint contextID)
         {
-            _glXImportContextEXT_fnptr = (delegate* unmanaged<Display*, nuint, IntPtr>)GLLoader.BindingsContext.GetProcAddress("glXImportContextEXT");
+            _glXImportContextEXT_fnptr = (delegate* unmanaged<Display*, nuint, IntPtr>)GLXLoader.BindingsContext.GetProcAddress("glXImportContextEXT");
             return _glXImportContextEXT_fnptr(dpy, contextID);
         }
         
@@ -715,7 +715,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXIsDirect_Lazy(Display* dpy, IntPtr ctx)
         {
-            _glXIsDirect_fnptr = (delegate* unmanaged<Display*, IntPtr, byte>)GLLoader.BindingsContext.GetProcAddress("glXIsDirect");
+            _glXIsDirect_fnptr = (delegate* unmanaged<Display*, IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXIsDirect");
             return _glXIsDirect_fnptr(dpy, ctx);
         }
         
@@ -724,7 +724,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXJoinSwapGroupNV_Lazy(Display* dpy, nuint drawable, uint group)
         {
-            _glXJoinSwapGroupNV_fnptr = (delegate* unmanaged<Display*, nuint, uint, byte>)GLLoader.BindingsContext.GetProcAddress("glXJoinSwapGroupNV");
+            _glXJoinSwapGroupNV_fnptr = (delegate* unmanaged<Display*, nuint, uint, byte>)GLXLoader.BindingsContext.GetProcAddress("glXJoinSwapGroupNV");
             return _glXJoinSwapGroupNV_fnptr(dpy, drawable, group);
         }
         
@@ -733,7 +733,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXJoinSwapGroupSGIX_Lazy(Display* dpy, nuint drawable, nuint member)
         {
-            _glXJoinSwapGroupSGIX_fnptr = (delegate* unmanaged<Display*, nuint, nuint, void>)GLLoader.BindingsContext.GetProcAddress("glXJoinSwapGroupSGIX");
+            _glXJoinSwapGroupSGIX_fnptr = (delegate* unmanaged<Display*, nuint, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXJoinSwapGroupSGIX");
             _glXJoinSwapGroupSGIX_fnptr(dpy, drawable, member);
         }
         
@@ -742,7 +742,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXLockVideoCaptureDeviceNV_Lazy(Display* dpy, nuint device)
         {
-            _glXLockVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLLoader.BindingsContext.GetProcAddress("glXLockVideoCaptureDeviceNV");
+            _glXLockVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXLockVideoCaptureDeviceNV");
             _glXLockVideoCaptureDeviceNV_fnptr(dpy, device);
         }
         
@@ -751,7 +751,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXMakeAssociatedContextCurrentAMD_Lazy(IntPtr ctx)
         {
-            _glXMakeAssociatedContextCurrentAMD_fnptr = (delegate* unmanaged<IntPtr, byte>)GLLoader.BindingsContext.GetProcAddress("glXMakeAssociatedContextCurrentAMD");
+            _glXMakeAssociatedContextCurrentAMD_fnptr = (delegate* unmanaged<IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXMakeAssociatedContextCurrentAMD");
             return _glXMakeAssociatedContextCurrentAMD_fnptr(ctx);
         }
         
@@ -760,7 +760,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXMakeContextCurrent_Lazy(Display* dpy, nuint draw, nuint read, IntPtr ctx)
         {
-            _glXMakeContextCurrent_fnptr = (delegate* unmanaged<Display*, nuint, nuint, IntPtr, byte>)GLLoader.BindingsContext.GetProcAddress("glXMakeContextCurrent");
+            _glXMakeContextCurrent_fnptr = (delegate* unmanaged<Display*, nuint, nuint, IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXMakeContextCurrent");
             return _glXMakeContextCurrent_fnptr(dpy, draw, read, ctx);
         }
         
@@ -769,7 +769,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXMakeCurrent_Lazy(Display* dpy, nuint drawable, IntPtr ctx)
         {
-            _glXMakeCurrent_fnptr = (delegate* unmanaged<Display*, nuint, IntPtr, byte>)GLLoader.BindingsContext.GetProcAddress("glXMakeCurrent");
+            _glXMakeCurrent_fnptr = (delegate* unmanaged<Display*, nuint, IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXMakeCurrent");
             return _glXMakeCurrent_fnptr(dpy, drawable, ctx);
         }
         
@@ -778,7 +778,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXMakeCurrentReadSGI_Lazy(Display* dpy, nuint draw, nuint read, IntPtr ctx)
         {
-            _glXMakeCurrentReadSGI_fnptr = (delegate* unmanaged<Display*, nuint, nuint, IntPtr, byte>)GLLoader.BindingsContext.GetProcAddress("glXMakeCurrentReadSGI");
+            _glXMakeCurrentReadSGI_fnptr = (delegate* unmanaged<Display*, nuint, nuint, IntPtr, byte>)GLXLoader.BindingsContext.GetProcAddress("glXMakeCurrentReadSGI");
             return _glXMakeCurrentReadSGI_fnptr(dpy, draw, read, ctx);
         }
         
@@ -787,7 +787,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXNamedCopyBufferSubDataNV_Lazy(Display* dpy, IntPtr readCtx, IntPtr writeCtx, uint readBuffer, uint writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size)
         {
-            _glXNamedCopyBufferSubDataNV_fnptr = (delegate* unmanaged<Display*, IntPtr, IntPtr, uint, uint, IntPtr, IntPtr, nint, void>)GLLoader.BindingsContext.GetProcAddress("glXNamedCopyBufferSubDataNV");
+            _glXNamedCopyBufferSubDataNV_fnptr = (delegate* unmanaged<Display*, IntPtr, IntPtr, uint, uint, IntPtr, IntPtr, nint, void>)GLXLoader.BindingsContext.GetProcAddress("glXNamedCopyBufferSubDataNV");
             _glXNamedCopyBufferSubDataNV_fnptr(dpy, readCtx, writeCtx, readBuffer, writeBuffer, readOffset, writeOffset, size);
         }
         
@@ -796,7 +796,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXQueryChannelDeltasSGIX_Lazy(Display* display, int screen, int channel, int* x, int* y, int* w, int* h)
         {
-            _glXQueryChannelDeltasSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int*, int*, int*, int*, int>)GLLoader.BindingsContext.GetProcAddress("glXQueryChannelDeltasSGIX");
+            _glXQueryChannelDeltasSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int*, int*, int*, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryChannelDeltasSGIX");
             return _glXQueryChannelDeltasSGIX_fnptr(display, screen, channel, x, y, w, h);
         }
         
@@ -805,7 +805,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXQueryChannelRectSGIX_Lazy(Display* display, int screen, int channel, int* dx, int* dy, int* dw, int* dh)
         {
-            _glXQueryChannelRectSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int*, int*, int*, int*, int>)GLLoader.BindingsContext.GetProcAddress("glXQueryChannelRectSGIX");
+            _glXQueryChannelRectSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int*, int*, int*, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryChannelRectSGIX");
             return _glXQueryChannelRectSGIX_fnptr(display, screen, channel, dx, dy, dw, dh);
         }
         
@@ -814,7 +814,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXQueryContext_Lazy(Display* dpy, IntPtr ctx, int attribute, int* value)
         {
-            _glXQueryContext_fnptr = (delegate* unmanaged<Display*, IntPtr, int, int*, int>)GLLoader.BindingsContext.GetProcAddress("glXQueryContext");
+            _glXQueryContext_fnptr = (delegate* unmanaged<Display*, IntPtr, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryContext");
             return _glXQueryContext_fnptr(dpy, ctx, attribute, value);
         }
         
@@ -823,7 +823,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXQueryContextInfoEXT_Lazy(Display* dpy, IntPtr context, int attribute, int* value)
         {
-            _glXQueryContextInfoEXT_fnptr = (delegate* unmanaged<Display*, IntPtr, int, int*, int>)GLLoader.BindingsContext.GetProcAddress("glXQueryContextInfoEXT");
+            _glXQueryContextInfoEXT_fnptr = (delegate* unmanaged<Display*, IntPtr, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryContextInfoEXT");
             return _glXQueryContextInfoEXT_fnptr(dpy, context, attribute, value);
         }
         
@@ -832,7 +832,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXQueryCurrentRendererIntegerMESA_Lazy(int attribute, uint* value)
         {
-            _glXQueryCurrentRendererIntegerMESA_fnptr = (delegate* unmanaged<int, uint*, byte>)GLLoader.BindingsContext.GetProcAddress("glXQueryCurrentRendererIntegerMESA");
+            _glXQueryCurrentRendererIntegerMESA_fnptr = (delegate* unmanaged<int, uint*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryCurrentRendererIntegerMESA");
             return _glXQueryCurrentRendererIntegerMESA_fnptr(attribute, value);
         }
         
@@ -841,7 +841,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte* glXQueryCurrentRendererStringMESA_Lazy(int attribute)
         {
-            _glXQueryCurrentRendererStringMESA_fnptr = (delegate* unmanaged<int, byte*>)GLLoader.BindingsContext.GetProcAddress("glXQueryCurrentRendererStringMESA");
+            _glXQueryCurrentRendererStringMESA_fnptr = (delegate* unmanaged<int, byte*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryCurrentRendererStringMESA");
             return _glXQueryCurrentRendererStringMESA_fnptr(attribute);
         }
         
@@ -850,7 +850,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXQueryDrawable_Lazy(Display* dpy, nuint draw, int attribute, uint* value)
         {
-            _glXQueryDrawable_fnptr = (delegate* unmanaged<Display*, nuint, int, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glXQueryDrawable");
+            _glXQueryDrawable_fnptr = (delegate* unmanaged<Display*, nuint, int, uint*, void>)GLXLoader.BindingsContext.GetProcAddress("glXQueryDrawable");
             _glXQueryDrawable_fnptr(dpy, draw, attribute, value);
         }
         
@@ -859,7 +859,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXQueryExtension_Lazy(Display* dpy, int* errorb, int* @event)
         {
-            _glXQueryExtension_fnptr = (delegate* unmanaged<Display*, int*, int*, byte>)GLLoader.BindingsContext.GetProcAddress("glXQueryExtension");
+            _glXQueryExtension_fnptr = (delegate* unmanaged<Display*, int*, int*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryExtension");
             return _glXQueryExtension_fnptr(dpy, errorb, @event);
         }
         
@@ -868,7 +868,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte* glXQueryExtensionsString_Lazy(Display* dpy, int screen)
         {
-            _glXQueryExtensionsString_fnptr = (delegate* unmanaged<Display*, int, byte*>)GLLoader.BindingsContext.GetProcAddress("glXQueryExtensionsString");
+            _glXQueryExtensionsString_fnptr = (delegate* unmanaged<Display*, int, byte*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryExtensionsString");
             return _glXQueryExtensionsString_fnptr(dpy, screen);
         }
         
@@ -877,7 +877,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXQueryFrameCountNV_Lazy(Display* dpy, int screen, uint* count)
         {
-            _glXQueryFrameCountNV_fnptr = (delegate* unmanaged<Display*, int, uint*, byte>)GLLoader.BindingsContext.GetProcAddress("glXQueryFrameCountNV");
+            _glXQueryFrameCountNV_fnptr = (delegate* unmanaged<Display*, int, uint*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryFrameCountNV");
             return _glXQueryFrameCountNV_fnptr(dpy, screen, count);
         }
         
@@ -886,7 +886,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXQueryGLXPbufferSGIX_Lazy(Display* dpy, nuint pbuf, int attribute, uint* value)
         {
-            _glXQueryGLXPbufferSGIX_fnptr = (delegate* unmanaged<Display*, nuint, int, uint*, void>)GLLoader.BindingsContext.GetProcAddress("glXQueryGLXPbufferSGIX");
+            _glXQueryGLXPbufferSGIX_fnptr = (delegate* unmanaged<Display*, nuint, int, uint*, void>)GLXLoader.BindingsContext.GetProcAddress("glXQueryGLXPbufferSGIX");
             _glXQueryGLXPbufferSGIX_fnptr(dpy, pbuf, attribute, value);
         }
         
@@ -895,7 +895,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXQueryHyperpipeAttribSGIX_Lazy(Display* dpy, int timeSlice, int attrib, int size, void* returnAttribList)
         {
-            _glXQueryHyperpipeAttribSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int, void*, int>)GLLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeAttribSGIX");
+            _glXQueryHyperpipeAttribSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int, void*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeAttribSGIX");
             return _glXQueryHyperpipeAttribSGIX_fnptr(dpy, timeSlice, attrib, size, returnAttribList);
         }
         
@@ -904,7 +904,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXQueryHyperpipeBestAttribSGIX_Lazy(Display* dpy, int timeSlice, int attrib, int size, void* attribList, void* returnAttribList)
         {
-            _glXQueryHyperpipeBestAttribSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int, void*, void*, int>)GLLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeBestAttribSGIX");
+            _glXQueryHyperpipeBestAttribSGIX_fnptr = (delegate* unmanaged<Display*, int, int, int, void*, void*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeBestAttribSGIX");
             return _glXQueryHyperpipeBestAttribSGIX_fnptr(dpy, timeSlice, attrib, size, attribList, returnAttribList);
         }
         
@@ -913,7 +913,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static GLXHyperpipeConfigSGIX* glXQueryHyperpipeConfigSGIX_Lazy(Display* dpy, int hpId, int* npipes)
         {
-            _glXQueryHyperpipeConfigSGIX_fnptr = (delegate* unmanaged<Display*, int, int*, GLXHyperpipeConfigSGIX*>)GLLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeConfigSGIX");
+            _glXQueryHyperpipeConfigSGIX_fnptr = (delegate* unmanaged<Display*, int, int*, GLXHyperpipeConfigSGIX*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeConfigSGIX");
             return _glXQueryHyperpipeConfigSGIX_fnptr(dpy, hpId, npipes);
         }
         
@@ -922,7 +922,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static GLXHyperpipeNetworkSGIX* glXQueryHyperpipeNetworkSGIX_Lazy(Display* dpy, int* npipes)
         {
-            _glXQueryHyperpipeNetworkSGIX_fnptr = (delegate* unmanaged<Display*, int*, GLXHyperpipeNetworkSGIX*>)GLLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeNetworkSGIX");
+            _glXQueryHyperpipeNetworkSGIX_fnptr = (delegate* unmanaged<Display*, int*, GLXHyperpipeNetworkSGIX*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryHyperpipeNetworkSGIX");
             return _glXQueryHyperpipeNetworkSGIX_fnptr(dpy, npipes);
         }
         
@@ -931,7 +931,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXQueryMaxSwapBarriersSGIX_Lazy(Display* dpy, int screen, int* max)
         {
-            _glXQueryMaxSwapBarriersSGIX_fnptr = (delegate* unmanaged<Display*, int, int*, byte>)GLLoader.BindingsContext.GetProcAddress("glXQueryMaxSwapBarriersSGIX");
+            _glXQueryMaxSwapBarriersSGIX_fnptr = (delegate* unmanaged<Display*, int, int*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryMaxSwapBarriersSGIX");
             return _glXQueryMaxSwapBarriersSGIX_fnptr(dpy, screen, max);
         }
         
@@ -940,7 +940,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXQueryMaxSwapGroupsNV_Lazy(Display* dpy, int screen, uint* maxGroups, uint* maxBarriers)
         {
-            _glXQueryMaxSwapGroupsNV_fnptr = (delegate* unmanaged<Display*, int, uint*, uint*, byte>)GLLoader.BindingsContext.GetProcAddress("glXQueryMaxSwapGroupsNV");
+            _glXQueryMaxSwapGroupsNV_fnptr = (delegate* unmanaged<Display*, int, uint*, uint*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryMaxSwapGroupsNV");
             return _glXQueryMaxSwapGroupsNV_fnptr(dpy, screen, maxGroups, maxBarriers);
         }
         
@@ -949,7 +949,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXQueryRendererIntegerMESA_Lazy(Display* dpy, int screen, int renderer, int attribute, uint* value)
         {
-            _glXQueryRendererIntegerMESA_fnptr = (delegate* unmanaged<Display*, int, int, int, uint*, byte>)GLLoader.BindingsContext.GetProcAddress("glXQueryRendererIntegerMESA");
+            _glXQueryRendererIntegerMESA_fnptr = (delegate* unmanaged<Display*, int, int, int, uint*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryRendererIntegerMESA");
             return _glXQueryRendererIntegerMESA_fnptr(dpy, screen, renderer, attribute, value);
         }
         
@@ -958,7 +958,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte* glXQueryRendererStringMESA_Lazy(Display* dpy, int screen, int renderer, int attribute)
         {
-            _glXQueryRendererStringMESA_fnptr = (delegate* unmanaged<Display*, int, int, int, byte*>)GLLoader.BindingsContext.GetProcAddress("glXQueryRendererStringMESA");
+            _glXQueryRendererStringMESA_fnptr = (delegate* unmanaged<Display*, int, int, int, byte*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryRendererStringMESA");
             return _glXQueryRendererStringMESA_fnptr(dpy, screen, renderer, attribute);
         }
         
@@ -967,7 +967,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte* glXQueryServerString_Lazy(Display* dpy, int screen, int name)
         {
-            _glXQueryServerString_fnptr = (delegate* unmanaged<Display*, int, int, byte*>)GLLoader.BindingsContext.GetProcAddress("glXQueryServerString");
+            _glXQueryServerString_fnptr = (delegate* unmanaged<Display*, int, int, byte*>)GLXLoader.BindingsContext.GetProcAddress("glXQueryServerString");
             return _glXQueryServerString_fnptr(dpy, screen, name);
         }
         
@@ -976,7 +976,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXQuerySwapGroupNV_Lazy(Display* dpy, nuint drawable, uint* group, uint* barrier)
         {
-            _glXQuerySwapGroupNV_fnptr = (delegate* unmanaged<Display*, nuint, uint*, uint*, byte>)GLLoader.BindingsContext.GetProcAddress("glXQuerySwapGroupNV");
+            _glXQuerySwapGroupNV_fnptr = (delegate* unmanaged<Display*, nuint, uint*, uint*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQuerySwapGroupNV");
             return _glXQuerySwapGroupNV_fnptr(dpy, drawable, group, barrier);
         }
         
@@ -985,7 +985,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXQueryVersion_Lazy(Display* dpy, int* maj, int* min)
         {
-            _glXQueryVersion_fnptr = (delegate* unmanaged<Display*, int*, int*, byte>)GLLoader.BindingsContext.GetProcAddress("glXQueryVersion");
+            _glXQueryVersion_fnptr = (delegate* unmanaged<Display*, int*, int*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXQueryVersion");
             return _glXQueryVersion_fnptr(dpy, maj, min);
         }
         
@@ -994,7 +994,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXQueryVideoCaptureDeviceNV_Lazy(Display* dpy, nuint device, int attribute, int* value)
         {
-            _glXQueryVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<Display*, nuint, int, int*, int>)GLLoader.BindingsContext.GetProcAddress("glXQueryVideoCaptureDeviceNV");
+            _glXQueryVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<Display*, nuint, int, int*, int>)GLXLoader.BindingsContext.GetProcAddress("glXQueryVideoCaptureDeviceNV");
             return _glXQueryVideoCaptureDeviceNV_fnptr(dpy, device, attribute, value);
         }
         
@@ -1003,7 +1003,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXReleaseBuffersMESA_Lazy(Display* dpy, nuint drawable)
         {
-            _glXReleaseBuffersMESA_fnptr = (delegate* unmanaged<Display*, nuint, byte>)GLLoader.BindingsContext.GetProcAddress("glXReleaseBuffersMESA");
+            _glXReleaseBuffersMESA_fnptr = (delegate* unmanaged<Display*, nuint, byte>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseBuffersMESA");
             return _glXReleaseBuffersMESA_fnptr(dpy, drawable);
         }
         
@@ -1012,7 +1012,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXReleaseTexImageEXT_Lazy(Display* dpy, nuint drawable, int buffer)
         {
-            _glXReleaseTexImageEXT_fnptr = (delegate* unmanaged<Display*, nuint, int, void>)GLLoader.BindingsContext.GetProcAddress("glXReleaseTexImageEXT");
+            _glXReleaseTexImageEXT_fnptr = (delegate* unmanaged<Display*, nuint, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseTexImageEXT");
             _glXReleaseTexImageEXT_fnptr(dpy, drawable, buffer);
         }
         
@@ -1021,7 +1021,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXReleaseVideoCaptureDeviceNV_Lazy(Display* dpy, nuint device)
         {
-            _glXReleaseVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLLoader.BindingsContext.GetProcAddress("glXReleaseVideoCaptureDeviceNV");
+            _glXReleaseVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseVideoCaptureDeviceNV");
             _glXReleaseVideoCaptureDeviceNV_fnptr(dpy, device);
         }
         
@@ -1030,7 +1030,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXReleaseVideoDeviceNV_Lazy(Display* dpy, int screen, uint VideoDevice)
         {
-            _glXReleaseVideoDeviceNV_fnptr = (delegate* unmanaged<Display*, int, uint, int>)GLLoader.BindingsContext.GetProcAddress("glXReleaseVideoDeviceNV");
+            _glXReleaseVideoDeviceNV_fnptr = (delegate* unmanaged<Display*, int, uint, int>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseVideoDeviceNV");
             return _glXReleaseVideoDeviceNV_fnptr(dpy, screen, VideoDevice);
         }
         
@@ -1039,7 +1039,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXReleaseVideoImageNV_Lazy(Display* dpy, nuint pbuf)
         {
-            _glXReleaseVideoImageNV_fnptr = (delegate* unmanaged<Display*, nuint, int>)GLLoader.BindingsContext.GetProcAddress("glXReleaseVideoImageNV");
+            _glXReleaseVideoImageNV_fnptr = (delegate* unmanaged<Display*, nuint, int>)GLXLoader.BindingsContext.GetProcAddress("glXReleaseVideoImageNV");
             return _glXReleaseVideoImageNV_fnptr(dpy, pbuf);
         }
         
@@ -1048,7 +1048,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXResetFrameCountNV_Lazy(Display* dpy, int screen)
         {
-            _glXResetFrameCountNV_fnptr = (delegate* unmanaged<Display*, int, byte>)GLLoader.BindingsContext.GetProcAddress("glXResetFrameCountNV");
+            _glXResetFrameCountNV_fnptr = (delegate* unmanaged<Display*, int, byte>)GLXLoader.BindingsContext.GetProcAddress("glXResetFrameCountNV");
             return _glXResetFrameCountNV_fnptr(dpy, screen);
         }
         
@@ -1057,7 +1057,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXSelectEvent_Lazy(Display* dpy, nuint draw, ulong event_mask)
         {
-            _glXSelectEvent_fnptr = (delegate* unmanaged<Display*, nuint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glXSelectEvent");
+            _glXSelectEvent_fnptr = (delegate* unmanaged<Display*, nuint, ulong, void>)GLXLoader.BindingsContext.GetProcAddress("glXSelectEvent");
             _glXSelectEvent_fnptr(dpy, draw, event_mask);
         }
         
@@ -1066,7 +1066,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXSelectEventSGIX_Lazy(Display* dpy, nuint drawable, ulong mask)
         {
-            _glXSelectEventSGIX_fnptr = (delegate* unmanaged<Display*, nuint, ulong, void>)GLLoader.BindingsContext.GetProcAddress("glXSelectEventSGIX");
+            _glXSelectEventSGIX_fnptr = (delegate* unmanaged<Display*, nuint, ulong, void>)GLXLoader.BindingsContext.GetProcAddress("glXSelectEventSGIX");
             _glXSelectEventSGIX_fnptr(dpy, drawable, mask);
         }
         
@@ -1075,7 +1075,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXSendPbufferToVideoNV_Lazy(Display* dpy, nuint pbuf, int iBufferType, ulong* pulCounterPbuffer, byte bBlock)
         {
-            _glXSendPbufferToVideoNV_fnptr = (delegate* unmanaged<Display*, nuint, int, ulong*, byte, int>)GLLoader.BindingsContext.GetProcAddress("glXSendPbufferToVideoNV");
+            _glXSendPbufferToVideoNV_fnptr = (delegate* unmanaged<Display*, nuint, int, ulong*, byte, int>)GLXLoader.BindingsContext.GetProcAddress("glXSendPbufferToVideoNV");
             return _glXSendPbufferToVideoNV_fnptr(dpy, pbuf, iBufferType, pulCounterPbuffer, bBlock);
         }
         
@@ -1084,7 +1084,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXSet3DfxModeMESA_Lazy(int mode)
         {
-            _glXSet3DfxModeMESA_fnptr = (delegate* unmanaged<int, byte>)GLLoader.BindingsContext.GetProcAddress("glXSet3DfxModeMESA");
+            _glXSet3DfxModeMESA_fnptr = (delegate* unmanaged<int, byte>)GLXLoader.BindingsContext.GetProcAddress("glXSet3DfxModeMESA");
             return _glXSet3DfxModeMESA_fnptr(mode);
         }
         
@@ -1093,7 +1093,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXSwapBuffers_Lazy(Display* dpy, nuint drawable)
         {
-            _glXSwapBuffers_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLLoader.BindingsContext.GetProcAddress("glXSwapBuffers");
+            _glXSwapBuffers_fnptr = (delegate* unmanaged<Display*, nuint, void>)GLXLoader.BindingsContext.GetProcAddress("glXSwapBuffers");
             _glXSwapBuffers_fnptr(dpy, drawable);
         }
         
@@ -1102,7 +1102,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static long glXSwapBuffersMscOML_Lazy(Display* dpy, nuint drawable, long target_msc, long divisor, long remainder)
         {
-            _glXSwapBuffersMscOML_fnptr = (delegate* unmanaged<Display*, nuint, long, long, long, long>)GLLoader.BindingsContext.GetProcAddress("glXSwapBuffersMscOML");
+            _glXSwapBuffersMscOML_fnptr = (delegate* unmanaged<Display*, nuint, long, long, long, long>)GLXLoader.BindingsContext.GetProcAddress("glXSwapBuffersMscOML");
             return _glXSwapBuffersMscOML_fnptr(dpy, drawable, target_msc, divisor, remainder);
         }
         
@@ -1111,7 +1111,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXSwapIntervalEXT_Lazy(Display* dpy, nuint drawable, int interval)
         {
-            _glXSwapIntervalEXT_fnptr = (delegate* unmanaged<Display*, nuint, int, void>)GLLoader.BindingsContext.GetProcAddress("glXSwapIntervalEXT");
+            _glXSwapIntervalEXT_fnptr = (delegate* unmanaged<Display*, nuint, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXSwapIntervalEXT");
             _glXSwapIntervalEXT_fnptr(dpy, drawable, interval);
         }
         
@@ -1120,7 +1120,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXSwapIntervalMESA_Lazy(uint interval)
         {
-            _glXSwapIntervalMESA_fnptr = (delegate* unmanaged<uint, int>)GLLoader.BindingsContext.GetProcAddress("glXSwapIntervalMESA");
+            _glXSwapIntervalMESA_fnptr = (delegate* unmanaged<uint, int>)GLXLoader.BindingsContext.GetProcAddress("glXSwapIntervalMESA");
             return _glXSwapIntervalMESA_fnptr(interval);
         }
         
@@ -1129,7 +1129,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXSwapIntervalSGI_Lazy(int interval)
         {
-            _glXSwapIntervalSGI_fnptr = (delegate* unmanaged<int, int>)GLLoader.BindingsContext.GetProcAddress("glXSwapIntervalSGI");
+            _glXSwapIntervalSGI_fnptr = (delegate* unmanaged<int, int>)GLXLoader.BindingsContext.GetProcAddress("glXSwapIntervalSGI");
             return _glXSwapIntervalSGI_fnptr(interval);
         }
         
@@ -1138,7 +1138,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXUseXFont_Lazy(nuint font, int first, int count, int list)
         {
-            _glXUseXFont_fnptr = (delegate* unmanaged<nuint, int, int, int, void>)GLLoader.BindingsContext.GetProcAddress("glXUseXFont");
+            _glXUseXFont_fnptr = (delegate* unmanaged<nuint, int, int, int, void>)GLXLoader.BindingsContext.GetProcAddress("glXUseXFont");
             _glXUseXFont_fnptr(font, first, count, list);
         }
         
@@ -1147,7 +1147,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXWaitForMscOML_Lazy(Display* dpy, nuint drawable, long target_msc, long divisor, long remainder, long* ust, long* msc, long* sbc)
         {
-            _glXWaitForMscOML_fnptr = (delegate* unmanaged<Display*, nuint, long, long, long, long*, long*, long*, byte>)GLLoader.BindingsContext.GetProcAddress("glXWaitForMscOML");
+            _glXWaitForMscOML_fnptr = (delegate* unmanaged<Display*, nuint, long, long, long, long*, long*, long*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXWaitForMscOML");
             return _glXWaitForMscOML_fnptr(dpy, drawable, target_msc, divisor, remainder, ust, msc, sbc);
         }
         
@@ -1156,7 +1156,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static byte glXWaitForSbcOML_Lazy(Display* dpy, nuint drawable, long target_sbc, long* ust, long* msc, long* sbc)
         {
-            _glXWaitForSbcOML_fnptr = (delegate* unmanaged<Display*, nuint, long, long*, long*, long*, byte>)GLLoader.BindingsContext.GetProcAddress("glXWaitForSbcOML");
+            _glXWaitForSbcOML_fnptr = (delegate* unmanaged<Display*, nuint, long, long*, long*, long*, byte>)GLXLoader.BindingsContext.GetProcAddress("glXWaitForSbcOML");
             return _glXWaitForSbcOML_fnptr(dpy, drawable, target_sbc, ust, msc, sbc);
         }
         
@@ -1165,7 +1165,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXWaitGL_Lazy()
         {
-            _glXWaitGL_fnptr = (delegate* unmanaged<void>)GLLoader.BindingsContext.GetProcAddress("glXWaitGL");
+            _glXWaitGL_fnptr = (delegate* unmanaged<void>)GLXLoader.BindingsContext.GetProcAddress("glXWaitGL");
             _glXWaitGL_fnptr();
         }
         
@@ -1174,7 +1174,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static int glXWaitVideoSyncSGI_Lazy(int divisor, int remainder, uint* count)
         {
-            _glXWaitVideoSyncSGI_fnptr = (delegate* unmanaged<int, int, uint*, int>)GLLoader.BindingsContext.GetProcAddress("glXWaitVideoSyncSGI");
+            _glXWaitVideoSyncSGI_fnptr = (delegate* unmanaged<int, int, uint*, int>)GLXLoader.BindingsContext.GetProcAddress("glXWaitVideoSyncSGI");
             return _glXWaitVideoSyncSGI_fnptr(divisor, remainder, count);
         }
         
@@ -1183,7 +1183,7 @@ namespace OpenTK.Graphics.Glx
         [UnmanagedCallersOnly]
         private static void glXWaitX_Lazy()
         {
-            _glXWaitX_fnptr = (delegate* unmanaged<void>)GLLoader.BindingsContext.GetProcAddress("glXWaitX");
+            _glXWaitX_fnptr = (delegate* unmanaged<void>)GLXLoader.BindingsContext.GetProcAddress("glXWaitX");
             _glXWaitX_fnptr();
         }
         

--- a/src/OpenTK.Graphics/GLXLoader.cs
+++ b/src/OpenTK.Graphics/GLXLoader.cs
@@ -13,13 +13,58 @@ namespace OpenTK.Graphics
     {
         public static class BindingsContext
         {
-            // FIXME: Extend this to be able to use glXGetProcAddress and glXGetProcAddressARB?
-            // Alternatively allow for user provided bindings contexts to be used...
-            // - Noggin_bops 2024-03-06
-            public static IntPtr GetProcAddress(string procName) => NativeLibrary.GetExport(GLXHandle, procName);
+            public static unsafe IntPtr GetProcAddress(string procName)
+            {
+                if (NativeLibrary.TryGetExport(GLXHandle, procName, out IntPtr ret))
+                {
+                    return ret;
+                }
+
+                if (glXGetProcAddress != null)
+                {
+                    byte* str = (byte*)Marshal.StringToCoTaskMemAnsi(procName);
+                    ret = glXGetProcAddress(str);
+                    Marshal.FreeCoTaskMem((IntPtr)str);
+
+                    if (ret != IntPtr.Zero)
+                    {
+                        return ret;
+                    }
+                }
+
+                if (glXGetProcAddressARB != null)
+                {
+                    byte* str = (byte*)Marshal.StringToCoTaskMemAnsi(procName);
+                    ret = glXGetProcAddressARB(str);
+                    Marshal.FreeCoTaskMem((IntPtr)str);
+
+                    if (ret != IntPtr.Zero)
+                    {
+                        return ret;
+                    }
+                }
+
+                return 0;
+            }
         }
 
-        // FIXME: More advanced resolution?
+        // FIXME: More advanced .so resolution?
         private static readonly IntPtr GLXHandle = NativeLibrary.Load("libGL.so");
+
+        // Unfortunately we can't mark function pointers as nullable, but
+        // if the function cannot be loaded it's null so we need to check before using.
+        // - Noggin_bops 2024-03-07
+        private static readonly unsafe delegate* unmanaged<byte*, IntPtr> glXGetProcAddress;
+        private static readonly unsafe delegate* unmanaged<byte*, IntPtr> glXGetProcAddressARB;
+
+        // Try load the function pointers..
+        static unsafe GLXLoader()
+        {
+            NativeLibrary.TryGetExport(GLXHandle, "glXGetProcAddress", out IntPtr ptr);
+            glXGetProcAddress = (delegate* unmanaged<byte*, IntPtr>)ptr;
+
+            NativeLibrary.TryGetExport(GLXHandle, "glXGetProcAddressARB", out ptr);
+            glXGetProcAddressARB = (delegate* unmanaged<byte*, IntPtr>)ptr;
+        }
     }
 }

--- a/src/OpenTK.Graphics/GLXLoader.cs
+++ b/src/OpenTK.Graphics/GLXLoader.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenTK.Graphics
+{
+    // FIXME: Actually implement this properly.
+    public static class GLXLoader
+    {
+        public static class BindingsContext
+        {
+            // FIXME: Extend this to be able to use glXGetProcAddress and glXGetProcAddressARB?
+            // Alternatively allow for user provided bindings contexts to be used...
+            // - Noggin_bops 2024-03-06
+            public static IntPtr GetProcAddress(string procName) => NativeLibrary.GetExport(GLXHandle, procName);
+        }
+
+        // FIXME: More advanced resolution?
+        private static readonly IntPtr GLXHandle = NativeLibrary.Load("libGL.so");
+    }
+}

--- a/src/OpenTK.Graphics/Glx/Enums.cs
+++ b/src/OpenTK.Graphics/Glx/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.Glx

--- a/src/OpenTK.Graphics/Glx/Enums.cs
+++ b/src/OpenTK.Graphics/Glx/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.Glx

--- a/src/OpenTK.Graphics/Glx/GLX.Native.cs
+++ b/src/OpenTK.Graphics/Glx/GLX.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/Glx/GLX.Native.cs
+++ b/src/OpenTK.Graphics/Glx/GLX.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;
@@ -10,58 +10,58 @@ namespace OpenTK.Graphics.Glx
     public static unsafe partial class Glx
     {
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXChooseFBConfig</c>]</b><br/>  </summary>
-        public static GLXFBConfig* ChooseFBConfig(Display* dpy, int screen, int* attrib_list, int* nelements) => (GLXFBConfig*) GlxPointers._glXChooseFBConfig_fnptr(dpy, screen, attrib_list, nelements);
+        public static GLXFBConfig* ChooseFBConfig(DisplayPtr dpy, int screen, int* attrib_list, int* nelements) => (GLXFBConfig*) GlxPointers._glXChooseFBConfig_fnptr((IntPtr)dpy, screen, attrib_list, nelements);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXChooseVisual</c>]</b><br/>  </summary>
-        public static XVisualInfo* ChooseVisual(Display* dpy, int screen, int* attribList) => GlxPointers._glXChooseVisual_fnptr(dpy, screen, attribList);
+        public static XVisualInfoPtr ChooseVisual(DisplayPtr dpy, int screen, int* attribList) => (XVisualInfoPtr) GlxPointers._glXChooseVisual_fnptr((IntPtr)dpy, screen, attribList);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXCopyContext</c>]</b><br/>  </summary>
-        public static void CopyContext(Display* dpy, GLXContext src, GLXContext dst, ulong mask) => GlxPointers._glXCopyContext_fnptr(dpy, (IntPtr)src, (IntPtr)dst, mask);
+        public static void CopyContext(DisplayPtr dpy, GLXContext src, GLXContext dst, ulong mask) => GlxPointers._glXCopyContext_fnptr((IntPtr)dpy, (IntPtr)src, (IntPtr)dst, mask);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXCreateContext</c>]</b><br/>  </summary>
-        public static GLXContext CreateContext(Display* dpy, XVisualInfo* vis, GLXContext shareList, bool direct) => (GLXContext) GlxPointers._glXCreateContext_fnptr(dpy, vis, (IntPtr)shareList, (byte)(direct ? 1 : 0));
+        public static GLXContext CreateContext(DisplayPtr dpy, XVisualInfoPtr vis, GLXContext shareList, bool direct) => (GLXContext) GlxPointers._glXCreateContext_fnptr((IntPtr)dpy, (IntPtr)vis, (IntPtr)shareList, (byte)(direct ? 1 : 0));
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXCreateGLXPixmap</c>]</b><br/>  </summary>
-        public static GLXPixmap CreateGLXPixmap(Display* dpy, XVisualInfo* visual, Pixmap pixmap) => (GLXPixmap) GlxPointers._glXCreateGLXPixmap_fnptr(dpy, visual, (nuint)pixmap);
+        public static GLXPixmap CreateGLXPixmap(DisplayPtr dpy, XVisualInfoPtr visual, Pixmap pixmap) => (GLXPixmap) GlxPointers._glXCreateGLXPixmap_fnptr((IntPtr)dpy, (IntPtr)visual, (nuint)pixmap);
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXCreateNewContext</c>]</b><br/>  </summary>
-        public static GLXContext CreateNewContext(Display* dpy, GLXFBConfig config, int render_type, GLXContext share_list, bool direct) => (GLXContext) GlxPointers._glXCreateNewContext_fnptr(dpy, (IntPtr)config, render_type, (IntPtr)share_list, (byte)(direct ? 1 : 0));
+        public static GLXContext CreateNewContext(DisplayPtr dpy, GLXFBConfig config, int render_type, GLXContext share_list, bool direct) => (GLXContext) GlxPointers._glXCreateNewContext_fnptr((IntPtr)dpy, (IntPtr)config, render_type, (IntPtr)share_list, (byte)(direct ? 1 : 0));
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXCreatePbuffer</c>]</b><br/>  </summary>
-        public static GLXPbuffer CreatePbuffer(Display* dpy, GLXFBConfig config, int* attrib_list) => (GLXPbuffer) GlxPointers._glXCreatePbuffer_fnptr(dpy, (IntPtr)config, attrib_list);
+        public static GLXPbuffer CreatePbuffer(DisplayPtr dpy, GLXFBConfig config, int* attrib_list) => (GLXPbuffer) GlxPointers._glXCreatePbuffer_fnptr((IntPtr)dpy, (IntPtr)config, attrib_list);
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXCreatePixmap</c>]</b><br/>  </summary>
-        public static GLXPixmap CreatePixmap(Display* dpy, GLXFBConfig config, Pixmap pixmap, int* attrib_list) => (GLXPixmap) GlxPointers._glXCreatePixmap_fnptr(dpy, (IntPtr)config, (nuint)pixmap, attrib_list);
+        public static GLXPixmap CreatePixmap(DisplayPtr dpy, GLXFBConfig config, Pixmap pixmap, int* attrib_list) => (GLXPixmap) GlxPointers._glXCreatePixmap_fnptr((IntPtr)dpy, (IntPtr)config, (nuint)pixmap, attrib_list);
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXCreateWindow</c>]</b><br/>  </summary>
-        public static GLXWindow CreateWindow(Display* dpy, GLXFBConfig config, Window win, int* attrib_list) => (GLXWindow) GlxPointers._glXCreateWindow_fnptr(dpy, (IntPtr)config, (nuint)win, attrib_list);
+        public static GLXWindow CreateWindow(DisplayPtr dpy, GLXFBConfig config, Window win, int* attrib_list) => (GLXWindow) GlxPointers._glXCreateWindow_fnptr((IntPtr)dpy, (IntPtr)config, (nuint)win, attrib_list);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXDestroyContext</c>]</b><br/>  </summary>
-        public static void DestroyContext(Display* dpy, GLXContext ctx) => GlxPointers._glXDestroyContext_fnptr(dpy, (IntPtr)ctx);
+        public static void DestroyContext(DisplayPtr dpy, GLXContext ctx) => GlxPointers._glXDestroyContext_fnptr((IntPtr)dpy, (IntPtr)ctx);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXDestroyGLXPixmap</c>]</b><br/>  </summary>
-        public static void DestroyGLXPixmap(Display* dpy, GLXPixmap pixmap) => GlxPointers._glXDestroyGLXPixmap_fnptr(dpy, (nuint)pixmap);
+        public static void DestroyGLXPixmap(DisplayPtr dpy, GLXPixmap pixmap) => GlxPointers._glXDestroyGLXPixmap_fnptr((IntPtr)dpy, (nuint)pixmap);
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXDestroyPbuffer</c>]</b><br/>  </summary>
-        public static void DestroyPbuffer(Display* dpy, GLXPbuffer pbuf) => GlxPointers._glXDestroyPbuffer_fnptr(dpy, (nuint)pbuf);
+        public static void DestroyPbuffer(DisplayPtr dpy, GLXPbuffer pbuf) => GlxPointers._glXDestroyPbuffer_fnptr((IntPtr)dpy, (nuint)pbuf);
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXDestroyPixmap</c>]</b><br/>  </summary>
-        public static void DestroyPixmap(Display* dpy, GLXPixmap pixmap) => GlxPointers._glXDestroyPixmap_fnptr(dpy, (nuint)pixmap);
+        public static void DestroyPixmap(DisplayPtr dpy, GLXPixmap pixmap) => GlxPointers._glXDestroyPixmap_fnptr((IntPtr)dpy, (nuint)pixmap);
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXDestroyWindow</c>]</b><br/>  </summary>
-        public static void DestroyWindow(Display* dpy, GLXWindow win) => GlxPointers._glXDestroyWindow_fnptr(dpy, (nuint)win);
+        public static void DestroyWindow(DisplayPtr dpy, GLXWindow win) => GlxPointers._glXDestroyWindow_fnptr((IntPtr)dpy, (nuint)win);
         
         /// <summary> <b>[requires: v1.1]</b> <b>[entry point: <c>glXGetClientString</c>]</b><br/>  </summary>
-        public static byte* GetClientString(Display* dpy, int name) => GlxPointers._glXGetClientString_fnptr(dpy, name);
+        public static byte* GetClientString_(DisplayPtr dpy, int name) => GlxPointers._glXGetClientString_fnptr((IntPtr)dpy, name);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXGetConfig</c>]</b><br/>  </summary>
-        public static int GetConfig(Display* dpy, XVisualInfo* visual, int attrib, int* value) => GlxPointers._glXGetConfig_fnptr(dpy, visual, attrib, value);
+        public static int GetConfig(DisplayPtr dpy, XVisualInfoPtr visual, int attrib, int* value) => GlxPointers._glXGetConfig_fnptr((IntPtr)dpy, (IntPtr)visual, attrib, value);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXGetCurrentContext</c>]</b><br/>  </summary>
         public static GLXContext GetCurrentContext() => (GLXContext) GlxPointers._glXGetCurrentContext_fnptr();
         
         /// <summary> <b>[requires: v1.2]</b> <b>[entry point: <c>glXGetCurrentDisplay</c>]</b><br/>  </summary>
-        public static Display* GetCurrentDisplay() => GlxPointers._glXGetCurrentDisplay_fnptr();
+        public static DisplayPtr GetCurrentDisplay() => (DisplayPtr) GlxPointers._glXGetCurrentDisplay_fnptr();
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXGetCurrentDrawable</c>]</b><br/>  </summary>
         public static GLXDrawable GetCurrentDrawable() => (GLXDrawable) GlxPointers._glXGetCurrentDrawable_fnptr();
@@ -70,52 +70,52 @@ namespace OpenTK.Graphics.Glx
         public static GLXDrawable GetCurrentReadDrawable() => (GLXDrawable) GlxPointers._glXGetCurrentReadDrawable_fnptr();
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXGetFBConfigAttrib</c>]</b><br/>  </summary>
-        public static int GetFBConfigAttrib(Display* dpy, GLXFBConfig config, int attribute, int* value) => GlxPointers._glXGetFBConfigAttrib_fnptr(dpy, (IntPtr)config, attribute, value);
+        public static int GetFBConfigAttrib(DisplayPtr dpy, GLXFBConfig config, int attribute, int* value) => GlxPointers._glXGetFBConfigAttrib_fnptr((IntPtr)dpy, (IntPtr)config, attribute, value);
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXGetFBConfigs</c>]</b><br/>  </summary>
-        public static GLXFBConfig* GetFBConfigs(Display* dpy, int screen, int* nelements) => (GLXFBConfig*) GlxPointers._glXGetFBConfigs_fnptr(dpy, screen, nelements);
+        public static GLXFBConfig* GetFBConfigs(DisplayPtr dpy, int screen, int* nelements) => (GLXFBConfig*) GlxPointers._glXGetFBConfigs_fnptr((IntPtr)dpy, screen, nelements);
         
         /// <summary> <b>[requires: v1.4]</b> <b>[entry point: <c>glXGetProcAddress</c>]</b><br/>  </summary>
         public static IntPtr GetProcAddress(byte* procName) => GlxPointers._glXGetProcAddress_fnptr(procName);
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXGetSelectedEvent</c>]</b><br/>  </summary>
-        public static void GetSelectedEvent(Display* dpy, GLXDrawable draw, ulong* event_mask) => GlxPointers._glXGetSelectedEvent_fnptr(dpy, (nuint)draw, event_mask);
+        public static void GetSelectedEvent(DisplayPtr dpy, GLXDrawable draw, ulong* event_mask) => GlxPointers._glXGetSelectedEvent_fnptr((IntPtr)dpy, (nuint)draw, event_mask);
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXGetVisualFromFBConfig</c>]</b><br/>  </summary>
-        public static XVisualInfo* GetVisualFromFBConfig(Display* dpy, GLXFBConfig config) => GlxPointers._glXGetVisualFromFBConfig_fnptr(dpy, (IntPtr)config);
+        public static XVisualInfoPtr GetVisualFromFBConfig(DisplayPtr dpy, GLXFBConfig config) => (XVisualInfoPtr) GlxPointers._glXGetVisualFromFBConfig_fnptr((IntPtr)dpy, (IntPtr)config);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXIsDirect</c>]</b><br/>  </summary>
-        public static bool IsDirect(Display* dpy, GLXContext ctx) => GlxPointers._glXIsDirect_fnptr(dpy, (IntPtr)ctx) != 0;
+        public static bool IsDirect(DisplayPtr dpy, GLXContext ctx) => GlxPointers._glXIsDirect_fnptr((IntPtr)dpy, (IntPtr)ctx) != 0;
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXMakeContextCurrent</c>]</b><br/>  </summary>
-        public static bool MakeContextCurrent(Display* dpy, GLXDrawable draw, GLXDrawable read, GLXContext ctx) => GlxPointers._glXMakeContextCurrent_fnptr(dpy, (nuint)draw, (nuint)read, (IntPtr)ctx) != 0;
+        public static bool MakeContextCurrent(DisplayPtr dpy, GLXDrawable draw, GLXDrawable read, GLXContext ctx) => GlxPointers._glXMakeContextCurrent_fnptr((IntPtr)dpy, (nuint)draw, (nuint)read, (IntPtr)ctx) != 0;
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXMakeCurrent</c>]</b><br/>  </summary>
-        public static bool MakeCurrent(Display* dpy, GLXDrawable drawable, GLXContext ctx) => GlxPointers._glXMakeCurrent_fnptr(dpy, (nuint)drawable, (IntPtr)ctx) != 0;
+        public static bool MakeCurrent(DisplayPtr dpy, GLXDrawable drawable, GLXContext ctx) => GlxPointers._glXMakeCurrent_fnptr((IntPtr)dpy, (nuint)drawable, (IntPtr)ctx) != 0;
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXQueryContext</c>]</b><br/>  </summary>
-        public static int QueryContext(Display* dpy, GLXContext ctx, int attribute, int* value) => GlxPointers._glXQueryContext_fnptr(dpy, (IntPtr)ctx, attribute, value);
+        public static int QueryContext(DisplayPtr dpy, GLXContext ctx, int attribute, int* value) => GlxPointers._glXQueryContext_fnptr((IntPtr)dpy, (IntPtr)ctx, attribute, value);
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXQueryDrawable</c>]</b><br/>  </summary>
-        public static void QueryDrawable(Display* dpy, GLXDrawable draw, int attribute, uint* value) => GlxPointers._glXQueryDrawable_fnptr(dpy, (nuint)draw, attribute, value);
+        public static void QueryDrawable(DisplayPtr dpy, GLXDrawable draw, int attribute, uint* value) => GlxPointers._glXQueryDrawable_fnptr((IntPtr)dpy, (nuint)draw, attribute, value);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXQueryExtension</c>]</b><br/>  </summary>
-        public static bool QueryExtension(Display* dpy, int* errorb, int* @event) => GlxPointers._glXQueryExtension_fnptr(dpy, errorb, @event) != 0;
+        public static bool QueryExtension(DisplayPtr dpy, int* errorb, int* @event) => GlxPointers._glXQueryExtension_fnptr((IntPtr)dpy, errorb, @event) != 0;
         
         /// <summary> <b>[requires: v1.1]</b> <b>[entry point: <c>glXQueryExtensionsString</c>]</b><br/>  </summary>
-        public static byte* QueryExtensionsString(Display* dpy, int screen) => GlxPointers._glXQueryExtensionsString_fnptr(dpy, screen);
+        public static byte* QueryExtensionsString_(DisplayPtr dpy, int screen) => GlxPointers._glXQueryExtensionsString_fnptr((IntPtr)dpy, screen);
         
         /// <summary> <b>[requires: v1.1]</b> <b>[entry point: <c>glXQueryServerString</c>]</b><br/>  </summary>
-        public static byte* QueryServerString(Display* dpy, int screen, int name) => GlxPointers._glXQueryServerString_fnptr(dpy, screen, name);
+        public static byte* QueryServerString_(DisplayPtr dpy, int screen, int name) => GlxPointers._glXQueryServerString_fnptr((IntPtr)dpy, screen, name);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXQueryVersion</c>]</b><br/>  </summary>
-        public static bool QueryVersion(Display* dpy, int* maj, int* min) => GlxPointers._glXQueryVersion_fnptr(dpy, maj, min) != 0;
+        public static bool QueryVersion(DisplayPtr dpy, int* maj, int* min) => GlxPointers._glXQueryVersion_fnptr((IntPtr)dpy, maj, min) != 0;
         
         /// <summary> <b>[requires: v1.3]</b> <b>[entry point: <c>glXSelectEvent</c>]</b><br/>  </summary>
-        public static void SelectEvent(Display* dpy, GLXDrawable draw, ulong event_mask) => GlxPointers._glXSelectEvent_fnptr(dpy, (nuint)draw, event_mask);
+        public static void SelectEvent(DisplayPtr dpy, GLXDrawable draw, ulong event_mask) => GlxPointers._glXSelectEvent_fnptr((IntPtr)dpy, (nuint)draw, event_mask);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXSwapBuffers</c>]</b><br/>  </summary>
-        public static void SwapBuffers(Display* dpy, GLXDrawable drawable) => GlxPointers._glXSwapBuffers_fnptr(dpy, (nuint)drawable);
+        public static void SwapBuffers(DisplayPtr dpy, GLXDrawable drawable) => GlxPointers._glXSwapBuffers_fnptr((IntPtr)dpy, (nuint)drawable);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>glXUseXFont</c>]</b><br/>  </summary>
         public static void UseXFont(Font font, int first, int count, int list) => GlxPointers._glXUseXFont_fnptr((nuint)font, first, count, list);
@@ -161,7 +161,7 @@ namespace OpenTK.Graphics.Glx
         public static unsafe partial class ARB
         {
             /// <summary> <b>[requires: GLX_ARB_create_context]</b> <b>[entry point: <c>glXCreateContextAttribsARB</c>]</b><br/>  </summary>
-            public static GLXContext CreateContextAttribsARB(Display* dpy, GLXFBConfig config, GLXContext share_context, bool direct, int* attrib_list) => (GLXContext) GlxPointers._glXCreateContextAttribsARB_fnptr(dpy, (IntPtr)config, (IntPtr)share_context, (byte)(direct ? 1 : 0), attrib_list);
+            public static GLXContext CreateContextAttribsARB(DisplayPtr dpy, GLXFBConfig config, GLXContext share_context, bool direct, int* attrib_list) => (GLXContext) GlxPointers._glXCreateContextAttribsARB_fnptr((IntPtr)dpy, (IntPtr)config, (IntPtr)share_context, (byte)(direct ? 1 : 0), attrib_list);
             
             /// <summary> <b>[requires: GLX_ARB_get_proc_address]</b> <b>[entry point: <c>glXGetProcAddressARB</c>]</b><br/>  </summary>
             public static IntPtr GetProcAddressARB(byte* procName) => GlxPointers._glXGetProcAddressARB_fnptr(procName);
@@ -171,38 +171,38 @@ namespace OpenTK.Graphics.Glx
         public static unsafe partial class EXT
         {
             /// <summary> <b>[requires: GLX_EXT_texture_from_pixmap]</b> <b>[entry point: <c>glXBindTexImageEXT</c>]</b><br/>  </summary>
-            public static void BindTexImageEXT(Display* dpy, GLXDrawable drawable, int buffer, int* attrib_list) => GlxPointers._glXBindTexImageEXT_fnptr(dpy, (nuint)drawable, buffer, attrib_list);
+            public static void BindTexImageEXT(DisplayPtr dpy, GLXDrawable drawable, int buffer, int* attrib_list) => GlxPointers._glXBindTexImageEXT_fnptr((IntPtr)dpy, (nuint)drawable, buffer, attrib_list);
             
             /// <summary> <b>[requires: GLX_EXT_import_context]</b> <b>[entry point: <c>glXFreeContextEXT</c>]</b><br/>  </summary>
-            public static void FreeContextEXT(Display* dpy, GLXContext context) => GlxPointers._glXFreeContextEXT_fnptr(dpy, (IntPtr)context);
+            public static void FreeContextEXT(DisplayPtr dpy, GLXContext context) => GlxPointers._glXFreeContextEXT_fnptr((IntPtr)dpy, (IntPtr)context);
             
             /// <summary> <b>[requires: GLX_EXT_import_context]</b> <b>[entry point: <c>glXGetContextIDEXT</c>]</b><br/>  </summary>
             public static GLXContextID GetContextIDEXT(GLXContext context) => (GLXContextID) GlxPointers._glXGetContextIDEXT_fnptr((IntPtr)context);
             
             /// <summary> <b>[requires: GLX_EXT_import_context]</b> <b>[entry point: <c>glXGetCurrentDisplayEXT</c>]</b><br/>  </summary>
-            public static Display* GetCurrentDisplayEXT() => GlxPointers._glXGetCurrentDisplayEXT_fnptr();
+            public static DisplayPtr GetCurrentDisplayEXT() => (DisplayPtr) GlxPointers._glXGetCurrentDisplayEXT_fnptr();
             
             /// <summary> <b>[requires: GLX_EXT_import_context]</b> <b>[entry point: <c>glXImportContextEXT</c>]</b><br/>  </summary>
-            public static GLXContext ImportContextEXT(Display* dpy, GLXContextID contextID) => (GLXContext) GlxPointers._glXImportContextEXT_fnptr(dpy, (nuint)contextID);
+            public static GLXContext ImportContextEXT(DisplayPtr dpy, GLXContextID contextID) => (GLXContext) GlxPointers._glXImportContextEXT_fnptr((IntPtr)dpy, (nuint)contextID);
             
             /// <summary> <b>[requires: GLX_EXT_import_context]</b> <b>[entry point: <c>glXQueryContextInfoEXT</c>]</b><br/>  </summary>
-            public static int QueryContextInfoEXT(Display* dpy, GLXContext context, int attribute, int* value) => GlxPointers._glXQueryContextInfoEXT_fnptr(dpy, (IntPtr)context, attribute, value);
+            public static int QueryContextInfoEXT(DisplayPtr dpy, GLXContext context, int attribute, int* value) => GlxPointers._glXQueryContextInfoEXT_fnptr((IntPtr)dpy, (IntPtr)context, attribute, value);
             
             /// <summary> <b>[requires: GLX_EXT_texture_from_pixmap]</b> <b>[entry point: <c>glXReleaseTexImageEXT</c>]</b><br/>  </summary>
-            public static void ReleaseTexImageEXT(Display* dpy, GLXDrawable drawable, int buffer) => GlxPointers._glXReleaseTexImageEXT_fnptr(dpy, (nuint)drawable, buffer);
+            public static void ReleaseTexImageEXT(DisplayPtr dpy, GLXDrawable drawable, int buffer) => GlxPointers._glXReleaseTexImageEXT_fnptr((IntPtr)dpy, (nuint)drawable, buffer);
             
             /// <summary> <b>[requires: GLX_EXT_swap_control]</b> <b>[entry point: <c>glXSwapIntervalEXT</c>]</b><br/>  </summary>
-            public static void SwapIntervalEXT(Display* dpy, GLXDrawable drawable, int interval) => GlxPointers._glXSwapIntervalEXT_fnptr(dpy, (nuint)drawable, interval);
+            public static void SwapIntervalEXT(DisplayPtr dpy, GLXDrawable drawable, int interval) => GlxPointers._glXSwapIntervalEXT_fnptr((IntPtr)dpy, (nuint)drawable, interval);
             
         }
         /// <summary>MESA extensions.</summary>
         public static unsafe partial class MESA
         {
             /// <summary> <b>[requires: GLX_MESA_copy_sub_buffer]</b> <b>[entry point: <c>glXCopySubBufferMESA</c>]</b><br/>  </summary>
-            public static void CopySubBufferMESA(Display* dpy, GLXDrawable drawable, int x, int y, int width, int height) => GlxPointers._glXCopySubBufferMESA_fnptr(dpy, (nuint)drawable, x, y, width, height);
+            public static void CopySubBufferMESA(DisplayPtr dpy, GLXDrawable drawable, int x, int y, int width, int height) => GlxPointers._glXCopySubBufferMESA_fnptr((IntPtr)dpy, (nuint)drawable, x, y, width, height);
             
             /// <summary> <b>[requires: GLX_MESA_pixmap_colormap]</b> <b>[entry point: <c>glXCreateGLXPixmapMESA</c>]</b><br/>  </summary>
-            public static GLXPixmap CreateGLXPixmapMESA(Display* dpy, XVisualInfo* visual, Pixmap pixmap, Colormap cmap) => (GLXPixmap) GlxPointers._glXCreateGLXPixmapMESA_fnptr(dpy, visual, (nuint)pixmap, (nuint)cmap);
+            public static GLXPixmap CreateGLXPixmapMESA(DisplayPtr dpy, XVisualInfoPtr visual, Pixmap pixmap, Colormap cmap) => (GLXPixmap) GlxPointers._glXCreateGLXPixmapMESA_fnptr((IntPtr)dpy, (IntPtr)visual, (nuint)pixmap, (nuint)cmap);
             
             /// <summary> <b>[requires: GLX_MESA_agp_offset]</b> <b>[entry point: <c>glXGetAGPOffsetMESA</c>]</b><br/>  </summary>
             public static uint GetAGPOffsetMESA(void* pointer) => GlxPointers._glXGetAGPOffsetMESA_fnptr(pointer);
@@ -217,13 +217,13 @@ namespace OpenTK.Graphics.Glx
             public static byte* QueryCurrentRendererStringMESA_(int attribute) => GlxPointers._glXQueryCurrentRendererStringMESA_fnptr(attribute);
             
             /// <summary> <b>[requires: GLX_MESA_query_renderer]</b> <b>[entry point: <c>glXQueryRendererIntegerMESA</c>]</b><br/>  </summary>
-            public static bool QueryRendererIntegerMESA(Display* dpy, int screen, int renderer, int attribute, uint* value) => GlxPointers._glXQueryRendererIntegerMESA_fnptr(dpy, screen, renderer, attribute, value) != 0;
+            public static bool QueryRendererIntegerMESA(DisplayPtr dpy, int screen, int renderer, int attribute, uint* value) => GlxPointers._glXQueryRendererIntegerMESA_fnptr((IntPtr)dpy, screen, renderer, attribute, value) != 0;
             
             /// <summary> <b>[requires: GLX_MESA_query_renderer]</b> <b>[entry point: <c>glXQueryRendererStringMESA</c>]</b><br/>  </summary>
-            public static byte* QueryRendererStringMESA(Display* dpy, int screen, int renderer, int attribute) => GlxPointers._glXQueryRendererStringMESA_fnptr(dpy, screen, renderer, attribute);
+            public static byte* QueryRendererStringMESA_(DisplayPtr dpy, int screen, int renderer, int attribute) => GlxPointers._glXQueryRendererStringMESA_fnptr((IntPtr)dpy, screen, renderer, attribute);
             
             /// <summary> <b>[requires: GLX_MESA_release_buffers]</b> <b>[entry point: <c>glXReleaseBuffersMESA</c>]</b><br/>  </summary>
-            public static bool ReleaseBuffersMESA(Display* dpy, GLXDrawable drawable) => GlxPointers._glXReleaseBuffersMESA_fnptr(dpy, (nuint)drawable) != 0;
+            public static bool ReleaseBuffersMESA(DisplayPtr dpy, GLXDrawable drawable) => GlxPointers._glXReleaseBuffersMESA_fnptr((IntPtr)dpy, (nuint)drawable) != 0;
             
             /// <summary> <b>[requires: GLX_MESA_set_3dfx_mode]</b> <b>[entry point: <c>glXSet3DfxModeMESA</c>]</b><br/>  </summary>
             public static bool Set3DfxModeMESA(int mode) => GlxPointers._glXSet3DfxModeMESA_fnptr(mode) != 0;
@@ -236,99 +236,99 @@ namespace OpenTK.Graphics.Glx
         public static unsafe partial class NV
         {
             /// <summary> <b>[requires: GLX_NV_swap_group]</b> <b>[entry point: <c>glXBindSwapBarrierNV</c>]</b><br/>  </summary>
-            public static bool BindSwapBarrierNV(Display* dpy, uint group, uint barrier) => GlxPointers._glXBindSwapBarrierNV_fnptr(dpy, group, barrier) != 0;
+            public static bool BindSwapBarrierNV(DisplayPtr dpy, uint group, uint barrier) => GlxPointers._glXBindSwapBarrierNV_fnptr((IntPtr)dpy, group, barrier) != 0;
             
             /// <summary> <b>[requires: GLX_NV_video_capture]</b> <b>[entry point: <c>glXBindVideoCaptureDeviceNV</c>]</b><br/>  </summary>
-            public static int BindVideoCaptureDeviceNV(Display* dpy, uint video_capture_slot, GLXVideoCaptureDeviceNV device) => GlxPointers._glXBindVideoCaptureDeviceNV_fnptr(dpy, video_capture_slot, (nuint)device);
+            public static int BindVideoCaptureDeviceNV(DisplayPtr dpy, uint video_capture_slot, GLXVideoCaptureDeviceNV device) => GlxPointers._glXBindVideoCaptureDeviceNV_fnptr((IntPtr)dpy, video_capture_slot, (nuint)device);
             
             /// <summary> <b>[requires: GLX_NV_present_video]</b> <b>[entry point: <c>glXBindVideoDeviceNV</c>]</b><br/>  </summary>
-            public static int BindVideoDeviceNV(Display* dpy, uint video_slot, uint video_device, int* attrib_list) => GlxPointers._glXBindVideoDeviceNV_fnptr(dpy, video_slot, video_device, attrib_list);
+            public static int BindVideoDeviceNV(DisplayPtr dpy, uint video_slot, uint video_device, int* attrib_list) => GlxPointers._glXBindVideoDeviceNV_fnptr((IntPtr)dpy, video_slot, video_device, attrib_list);
             
             /// <summary> <b>[requires: GLX_NV_video_out]</b> <b>[entry point: <c>glXBindVideoImageNV</c>]</b><br/>  </summary>
-            public static int BindVideoImageNV(Display* dpy, GLXVideoDeviceNV VideoDevice, GLXPbuffer pbuf, int iVideoBuffer) => GlxPointers._glXBindVideoImageNV_fnptr(dpy, (uint)VideoDevice, (nuint)pbuf, iVideoBuffer);
+            public static int BindVideoImageNV(DisplayPtr dpy, GLXVideoDeviceNV VideoDevice, GLXPbuffer pbuf, int iVideoBuffer) => GlxPointers._glXBindVideoImageNV_fnptr((IntPtr)dpy, (uint)VideoDevice, (nuint)pbuf, iVideoBuffer);
             
             /// <summary> <b>[requires: GLX_NV_copy_buffer]</b> <b>[entry point: <c>glXCopyBufferSubDataNV</c>]</b><br/>  </summary>
-            public static void CopyBufferSubDataNV(Display* dpy, GLXContext readCtx, GLXContext writeCtx, All readTarget, All writeTarget, IntPtr readOffset, IntPtr writeOffset, nint size) => GlxPointers._glXCopyBufferSubDataNV_fnptr(dpy, (IntPtr)readCtx, (IntPtr)writeCtx, (uint)readTarget, (uint)writeTarget, readOffset, writeOffset, size);
+            public static void CopyBufferSubDataNV(DisplayPtr dpy, GLXContext readCtx, GLXContext writeCtx, All readTarget, All writeTarget, IntPtr readOffset, IntPtr writeOffset, nint size) => GlxPointers._glXCopyBufferSubDataNV_fnptr((IntPtr)dpy, (IntPtr)readCtx, (IntPtr)writeCtx, (uint)readTarget, (uint)writeTarget, readOffset, writeOffset, size);
             
             /// <summary> <b>[requires: GLX_NV_copy_image]</b> <b>[entry point: <c>glXCopyImageSubDataNV</c>]</b><br/>  </summary>
-            public static void CopyImageSubDataNV(Display* dpy, GLXContext srcCtx, uint srcName, All srcTarget, int srcLevel, int srcX, int srcY, int srcZ, GLXContext dstCtx, uint dstName, All dstTarget, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth) => GlxPointers._glXCopyImageSubDataNV_fnptr(dpy, (IntPtr)srcCtx, srcName, (uint)srcTarget, srcLevel, srcX, srcY, srcZ, (IntPtr)dstCtx, dstName, (uint)dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
+            public static void CopyImageSubDataNV(DisplayPtr dpy, GLXContext srcCtx, uint srcName, All srcTarget, int srcLevel, int srcX, int srcY, int srcZ, GLXContext dstCtx, uint dstName, All dstTarget, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth) => GlxPointers._glXCopyImageSubDataNV_fnptr((IntPtr)dpy, (IntPtr)srcCtx, srcName, (uint)srcTarget, srcLevel, srcX, srcY, srcZ, (IntPtr)dstCtx, dstName, (uint)dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
             
             /// <summary> <b>[requires: GLX_NV_delay_before_swap]</b> <b>[entry point: <c>glXDelayBeforeSwapNV</c>]</b><br/>  </summary>
-            public static bool DelayBeforeSwapNV(Display* dpy, GLXDrawable drawable, float seconds) => GlxPointers._glXDelayBeforeSwapNV_fnptr(dpy, (nuint)drawable, seconds) != 0;
+            public static bool DelayBeforeSwapNV(DisplayPtr dpy, GLXDrawable drawable, float seconds) => GlxPointers._glXDelayBeforeSwapNV_fnptr((IntPtr)dpy, (nuint)drawable, seconds) != 0;
             
             /// <summary> <b>[requires: GLX_NV_video_capture]</b> <b>[entry point: <c>glXEnumerateVideoCaptureDevicesNV</c>]</b><br/>  </summary>
-            public static GLXVideoCaptureDeviceNV* EnumerateVideoCaptureDevicesNV(Display* dpy, int screen, int* nelements) => (GLXVideoCaptureDeviceNV*) GlxPointers._glXEnumerateVideoCaptureDevicesNV_fnptr(dpy, screen, nelements);
+            public static GLXVideoCaptureDeviceNV* EnumerateVideoCaptureDevicesNV(DisplayPtr dpy, int screen, int* nelements) => (GLXVideoCaptureDeviceNV*) GlxPointers._glXEnumerateVideoCaptureDevicesNV_fnptr((IntPtr)dpy, screen, nelements);
             
             /// <summary> <b>[requires: GLX_NV_present_video]</b> <b>[entry point: <c>glXEnumerateVideoDevicesNV</c>]</b><br/>  </summary>
-            public static uint* EnumerateVideoDevicesNV(Display* dpy, int screen, int* nelements) => GlxPointers._glXEnumerateVideoDevicesNV_fnptr(dpy, screen, nelements);
+            public static uint* EnumerateVideoDevicesNV(DisplayPtr dpy, int screen, int* nelements) => GlxPointers._glXEnumerateVideoDevicesNV_fnptr((IntPtr)dpy, screen, nelements);
             
             /// <summary> <b>[requires: GLX_NV_video_out]</b> <b>[entry point: <c>glXGetVideoDeviceNV</c>]</b><br/>  </summary>
-            public static int GetVideoDeviceNV(Display* dpy, int screen, int numVideoDevices, GLXVideoDeviceNV* pVideoDevice) => GlxPointers._glXGetVideoDeviceNV_fnptr(dpy, screen, numVideoDevices, (uint*)pVideoDevice);
+            public static int GetVideoDeviceNV(DisplayPtr dpy, int screen, int numVideoDevices, GLXVideoDeviceNV* pVideoDevice) => GlxPointers._glXGetVideoDeviceNV_fnptr((IntPtr)dpy, screen, numVideoDevices, (uint*)pVideoDevice);
             
             /// <summary> <b>[requires: GLX_NV_video_out]</b> <b>[entry point: <c>glXGetVideoInfoNV</c>]</b><br/>  </summary>
-            public static int GetVideoInfoNV(Display* dpy, int screen, GLXVideoDeviceNV VideoDevice, ulong* pulCounterOutputPbuffer, ulong* pulCounterOutputVideo) => GlxPointers._glXGetVideoInfoNV_fnptr(dpy, screen, (uint)VideoDevice, pulCounterOutputPbuffer, pulCounterOutputVideo);
+            public static int GetVideoInfoNV(DisplayPtr dpy, int screen, GLXVideoDeviceNV VideoDevice, ulong* pulCounterOutputPbuffer, ulong* pulCounterOutputVideo) => GlxPointers._glXGetVideoInfoNV_fnptr((IntPtr)dpy, screen, (uint)VideoDevice, pulCounterOutputPbuffer, pulCounterOutputVideo);
             
             /// <summary> <b>[requires: GLX_NV_swap_group]</b> <b>[entry point: <c>glXJoinSwapGroupNV</c>]</b><br/>  </summary>
-            public static bool JoinSwapGroupNV(Display* dpy, GLXDrawable drawable, uint group) => GlxPointers._glXJoinSwapGroupNV_fnptr(dpy, (nuint)drawable, group) != 0;
+            public static bool JoinSwapGroupNV(DisplayPtr dpy, GLXDrawable drawable, uint group) => GlxPointers._glXJoinSwapGroupNV_fnptr((IntPtr)dpy, (nuint)drawable, group) != 0;
             
             /// <summary> <b>[requires: GLX_NV_video_capture]</b> <b>[entry point: <c>glXLockVideoCaptureDeviceNV</c>]</b><br/>  </summary>
-            public static void LockVideoCaptureDeviceNV(Display* dpy, GLXVideoCaptureDeviceNV device) => GlxPointers._glXLockVideoCaptureDeviceNV_fnptr(dpy, (nuint)device);
+            public static void LockVideoCaptureDeviceNV(DisplayPtr dpy, GLXVideoCaptureDeviceNV device) => GlxPointers._glXLockVideoCaptureDeviceNV_fnptr((IntPtr)dpy, (nuint)device);
             
             /// <summary> <b>[requires: GLX_NV_copy_buffer]</b> <b>[entry point: <c>glXNamedCopyBufferSubDataNV</c>]</b><br/>  </summary>
-            public static void NamedCopyBufferSubDataNV(Display* dpy, GLXContext readCtx, GLXContext writeCtx, uint readBuffer, uint writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GlxPointers._glXNamedCopyBufferSubDataNV_fnptr(dpy, (IntPtr)readCtx, (IntPtr)writeCtx, readBuffer, writeBuffer, readOffset, writeOffset, size);
+            public static void NamedCopyBufferSubDataNV(DisplayPtr dpy, GLXContext readCtx, GLXContext writeCtx, uint readBuffer, uint writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size) => GlxPointers._glXNamedCopyBufferSubDataNV_fnptr((IntPtr)dpy, (IntPtr)readCtx, (IntPtr)writeCtx, readBuffer, writeBuffer, readOffset, writeOffset, size);
             
             /// <summary> <b>[requires: GLX_NV_swap_group]</b> <b>[entry point: <c>glXQueryFrameCountNV</c>]</b><br/>  </summary>
-            public static bool QueryFrameCountNV(Display* dpy, int screen, uint* count) => GlxPointers._glXQueryFrameCountNV_fnptr(dpy, screen, count) != 0;
+            public static bool QueryFrameCountNV(DisplayPtr dpy, int screen, uint* count) => GlxPointers._glXQueryFrameCountNV_fnptr((IntPtr)dpy, screen, count) != 0;
             
             /// <summary> <b>[requires: GLX_NV_swap_group]</b> <b>[entry point: <c>glXQueryMaxSwapGroupsNV</c>]</b><br/>  </summary>
-            public static bool QueryMaxSwapGroupsNV(Display* dpy, int screen, uint* maxGroups, uint* maxBarriers) => GlxPointers._glXQueryMaxSwapGroupsNV_fnptr(dpy, screen, maxGroups, maxBarriers) != 0;
+            public static bool QueryMaxSwapGroupsNV(DisplayPtr dpy, int screen, uint* maxGroups, uint* maxBarriers) => GlxPointers._glXQueryMaxSwapGroupsNV_fnptr((IntPtr)dpy, screen, maxGroups, maxBarriers) != 0;
             
             /// <summary> <b>[requires: GLX_NV_swap_group]</b> <b>[entry point: <c>glXQuerySwapGroupNV</c>]</b><br/>  </summary>
-            public static bool QuerySwapGroupNV(Display* dpy, GLXDrawable drawable, uint* group, uint* barrier) => GlxPointers._glXQuerySwapGroupNV_fnptr(dpy, (nuint)drawable, group, barrier) != 0;
+            public static bool QuerySwapGroupNV(DisplayPtr dpy, GLXDrawable drawable, uint* group, uint* barrier) => GlxPointers._glXQuerySwapGroupNV_fnptr((IntPtr)dpy, (nuint)drawable, group, barrier) != 0;
             
             /// <summary> <b>[requires: GLX_NV_video_capture]</b> <b>[entry point: <c>glXQueryVideoCaptureDeviceNV</c>]</b><br/>  </summary>
-            public static int QueryVideoCaptureDeviceNV(Display* dpy, GLXVideoCaptureDeviceNV device, int attribute, int* value) => GlxPointers._glXQueryVideoCaptureDeviceNV_fnptr(dpy, (nuint)device, attribute, value);
+            public static int QueryVideoCaptureDeviceNV(DisplayPtr dpy, GLXVideoCaptureDeviceNV device, int attribute, int* value) => GlxPointers._glXQueryVideoCaptureDeviceNV_fnptr((IntPtr)dpy, (nuint)device, attribute, value);
             
             /// <summary> <b>[requires: GLX_NV_video_capture]</b> <b>[entry point: <c>glXReleaseVideoCaptureDeviceNV</c>]</b><br/>  </summary>
-            public static void ReleaseVideoCaptureDeviceNV(Display* dpy, GLXVideoCaptureDeviceNV device) => GlxPointers._glXReleaseVideoCaptureDeviceNV_fnptr(dpy, (nuint)device);
+            public static void ReleaseVideoCaptureDeviceNV(DisplayPtr dpy, GLXVideoCaptureDeviceNV device) => GlxPointers._glXReleaseVideoCaptureDeviceNV_fnptr((IntPtr)dpy, (nuint)device);
             
             /// <summary> <b>[requires: GLX_NV_video_out]</b> <b>[entry point: <c>glXReleaseVideoDeviceNV</c>]</b><br/>  </summary>
-            public static int ReleaseVideoDeviceNV(Display* dpy, int screen, GLXVideoDeviceNV VideoDevice) => GlxPointers._glXReleaseVideoDeviceNV_fnptr(dpy, screen, (uint)VideoDevice);
+            public static int ReleaseVideoDeviceNV(DisplayPtr dpy, int screen, GLXVideoDeviceNV VideoDevice) => GlxPointers._glXReleaseVideoDeviceNV_fnptr((IntPtr)dpy, screen, (uint)VideoDevice);
             
             /// <summary> <b>[requires: GLX_NV_video_out]</b> <b>[entry point: <c>glXReleaseVideoImageNV</c>]</b><br/>  </summary>
-            public static int ReleaseVideoImageNV(Display* dpy, GLXPbuffer pbuf) => GlxPointers._glXReleaseVideoImageNV_fnptr(dpy, (nuint)pbuf);
+            public static int ReleaseVideoImageNV(DisplayPtr dpy, GLXPbuffer pbuf) => GlxPointers._glXReleaseVideoImageNV_fnptr((IntPtr)dpy, (nuint)pbuf);
             
             /// <summary> <b>[requires: GLX_NV_swap_group]</b> <b>[entry point: <c>glXResetFrameCountNV</c>]</b><br/>  </summary>
-            public static bool ResetFrameCountNV(Display* dpy, int screen) => GlxPointers._glXResetFrameCountNV_fnptr(dpy, screen) != 0;
+            public static bool ResetFrameCountNV(DisplayPtr dpy, int screen) => GlxPointers._glXResetFrameCountNV_fnptr((IntPtr)dpy, screen) != 0;
             
             /// <summary> <b>[requires: GLX_NV_video_out]</b> <b>[entry point: <c>glXSendPbufferToVideoNV</c>]</b><br/>  </summary>
-            public static int SendPbufferToVideoNV(Display* dpy, GLXPbuffer pbuf, int iBufferType, ulong* pulCounterPbuffer, bool bBlock) => GlxPointers._glXSendPbufferToVideoNV_fnptr(dpy, (nuint)pbuf, iBufferType, pulCounterPbuffer, (byte)(bBlock ? 1 : 0));
+            public static int SendPbufferToVideoNV(DisplayPtr dpy, GLXPbuffer pbuf, int iBufferType, ulong* pulCounterPbuffer, bool bBlock) => GlxPointers._glXSendPbufferToVideoNV_fnptr((IntPtr)dpy, (nuint)pbuf, iBufferType, pulCounterPbuffer, (byte)(bBlock ? 1 : 0));
             
         }
         /// <summary>OML extensions.</summary>
         public static unsafe partial class OML
         {
             /// <summary> <b>[requires: GLX_OML_sync_control]</b> <b>[entry point: <c>glXGetMscRateOML</c>]</b><br/>  </summary>
-            public static bool GetMscRateOML(Display* dpy, GLXDrawable drawable, int* numerator, int* denominator) => GlxPointers._glXGetMscRateOML_fnptr(dpy, (nuint)drawable, numerator, denominator) != 0;
+            public static bool GetMscRateOML(DisplayPtr dpy, GLXDrawable drawable, int* numerator, int* denominator) => GlxPointers._glXGetMscRateOML_fnptr((IntPtr)dpy, (nuint)drawable, numerator, denominator) != 0;
             
             /// <summary> <b>[requires: GLX_OML_sync_control]</b> <b>[entry point: <c>glXGetSyncValuesOML</c>]</b><br/>  </summary>
-            public static bool GetSyncValuesOML(Display* dpy, GLXDrawable drawable, long* ust, long* msc, long* sbc) => GlxPointers._glXGetSyncValuesOML_fnptr(dpy, (nuint)drawable, ust, msc, sbc) != 0;
+            public static bool GetSyncValuesOML(DisplayPtr dpy, GLXDrawable drawable, long* ust, long* msc, long* sbc) => GlxPointers._glXGetSyncValuesOML_fnptr((IntPtr)dpy, (nuint)drawable, ust, msc, sbc) != 0;
             
             /// <summary> <b>[requires: GLX_OML_sync_control]</b> <b>[entry point: <c>glXSwapBuffersMscOML</c>]</b><br/>  </summary>
-            public static long SwapBuffersMscOML(Display* dpy, GLXDrawable drawable, long target_msc, long divisor, long remainder) => GlxPointers._glXSwapBuffersMscOML_fnptr(dpy, (nuint)drawable, target_msc, divisor, remainder);
+            public static long SwapBuffersMscOML(DisplayPtr dpy, GLXDrawable drawable, long target_msc, long divisor, long remainder) => GlxPointers._glXSwapBuffersMscOML_fnptr((IntPtr)dpy, (nuint)drawable, target_msc, divisor, remainder);
             
             /// <summary> <b>[requires: GLX_OML_sync_control]</b> <b>[entry point: <c>glXWaitForMscOML</c>]</b><br/>  </summary>
-            public static bool WaitForMscOML(Display* dpy, GLXDrawable drawable, long target_msc, long divisor, long remainder, long* ust, long* msc, long* sbc) => GlxPointers._glXWaitForMscOML_fnptr(dpy, (nuint)drawable, target_msc, divisor, remainder, ust, msc, sbc) != 0;
+            public static bool WaitForMscOML(DisplayPtr dpy, GLXDrawable drawable, long target_msc, long divisor, long remainder, long* ust, long* msc, long* sbc) => GlxPointers._glXWaitForMscOML_fnptr((IntPtr)dpy, (nuint)drawable, target_msc, divisor, remainder, ust, msc, sbc) != 0;
             
             /// <summary> <b>[requires: GLX_OML_sync_control]</b> <b>[entry point: <c>glXWaitForSbcOML</c>]</b><br/>  </summary>
-            public static bool WaitForSbcOML(Display* dpy, GLXDrawable drawable, long target_sbc, long* ust, long* msc, long* sbc) => GlxPointers._glXWaitForSbcOML_fnptr(dpy, (nuint)drawable, target_sbc, ust, msc, sbc) != 0;
+            public static bool WaitForSbcOML(DisplayPtr dpy, GLXDrawable drawable, long target_sbc, long* ust, long* msc, long* sbc) => GlxPointers._glXWaitForSbcOML_fnptr((IntPtr)dpy, (nuint)drawable, target_sbc, ust, msc, sbc) != 0;
             
         }
         /// <summary>SGI extensions.</summary>
         public static unsafe partial class SGI
         {
             /// <summary> <b>[requires: GLX_SGI_cushion]</b> <b>[entry point: <c>glXCushionSGI</c>]</b><br/>  </summary>
-            public static void CushionSGI(Display* dpy, Window window, float cushion) => GlxPointers._glXCushionSGI_fnptr(dpy, (nuint)window, cushion);
+            public static void CushionSGI(DisplayPtr dpy, Window window, float cushion) => GlxPointers._glXCushionSGI_fnptr((IntPtr)dpy, (nuint)window, cushion);
             
             /// <summary> <b>[requires: GLX_SGI_make_current_read]</b> <b>[entry point: <c>glXGetCurrentReadDrawableSGI</c>]</b><br/>  </summary>
             public static GLXDrawable GetCurrentReadDrawableSGI() => (GLXDrawable) GlxPointers._glXGetCurrentReadDrawableSGI_fnptr();
@@ -337,7 +337,7 @@ namespace OpenTK.Graphics.Glx
             public static int GetVideoSyncSGI(uint* count) => GlxPointers._glXGetVideoSyncSGI_fnptr(count);
             
             /// <summary> <b>[requires: GLX_SGI_make_current_read]</b> <b>[entry point: <c>glXMakeCurrentReadSGI</c>]</b><br/>  </summary>
-            public static bool MakeCurrentReadSGI(Display* dpy, GLXDrawable draw, GLXDrawable read, GLXContext ctx) => GlxPointers._glXMakeCurrentReadSGI_fnptr(dpy, (nuint)draw, (nuint)read, (IntPtr)ctx) != 0;
+            public static bool MakeCurrentReadSGI(DisplayPtr dpy, GLXDrawable draw, GLXDrawable read, GLXContext ctx) => GlxPointers._glXMakeCurrentReadSGI_fnptr((IntPtr)dpy, (nuint)draw, (nuint)read, (IntPtr)ctx) != 0;
             
             /// <summary> <b>[requires: GLX_SGI_swap_control]</b> <b>[entry point: <c>glXSwapIntervalSGI</c>]</b><br/>  </summary>
             public static int SwapIntervalSGI(int interval) => GlxPointers._glXSwapIntervalSGI_fnptr(interval);
@@ -350,92 +350,92 @@ namespace OpenTK.Graphics.Glx
         public static unsafe partial class SGIX
         {
             /// <summary> <b>[requires: GLX_SGIX_video_resize]</b> <b>[entry point: <c>glXBindChannelToWindowSGIX</c>]</b><br/>  </summary>
-            public static int BindChannelToWindowSGIX(Display* display, int screen, int channel, Window window) => GlxPointers._glXBindChannelToWindowSGIX_fnptr(display, screen, channel, (nuint)window);
+            public static int BindChannelToWindowSGIX(DisplayPtr display, int screen, int channel, Window window) => GlxPointers._glXBindChannelToWindowSGIX_fnptr((IntPtr)display, screen, channel, (nuint)window);
             
             /// <summary> <b>[requires: GLX_SGIX_hyperpipe]</b> <b>[entry point: <c>glXBindHyperpipeSGIX</c>]</b><br/>  </summary>
-            public static int BindHyperpipeSGIX(Display* dpy, int hpId) => GlxPointers._glXBindHyperpipeSGIX_fnptr(dpy, hpId);
+            public static int BindHyperpipeSGIX(DisplayPtr dpy, int hpId) => GlxPointers._glXBindHyperpipeSGIX_fnptr((IntPtr)dpy, hpId);
             
             /// <summary> <b>[requires: GLX_SGIX_swap_barrier]</b> <b>[entry point: <c>glXBindSwapBarrierSGIX</c>]</b><br/>  </summary>
-            public static void BindSwapBarrierSGIX(Display* dpy, GLXDrawable drawable, int barrier) => GlxPointers._glXBindSwapBarrierSGIX_fnptr(dpy, (nuint)drawable, barrier);
+            public static void BindSwapBarrierSGIX(DisplayPtr dpy, GLXDrawable drawable, int barrier) => GlxPointers._glXBindSwapBarrierSGIX_fnptr((IntPtr)dpy, (nuint)drawable, barrier);
             
             /// <summary> <b>[requires: GLX_SGIX_video_resize]</b> <b>[entry point: <c>glXChannelRectSGIX</c>]</b><br/>  </summary>
-            public static int ChannelRectSGIX(Display* display, int screen, int channel, int x, int y, int w, int h) => GlxPointers._glXChannelRectSGIX_fnptr(display, screen, channel, x, y, w, h);
+            public static int ChannelRectSGIX(DisplayPtr display, int screen, int channel, int x, int y, int w, int h) => GlxPointers._glXChannelRectSGIX_fnptr((IntPtr)display, screen, channel, x, y, w, h);
             
             /// <summary> <b>[requires: GLX_SGIX_video_resize]</b> <b>[entry point: <c>glXChannelRectSyncSGIX</c>]</b><br/>  </summary>
-            public static int ChannelRectSyncSGIX(Display* display, int screen, int channel, All synctype) => GlxPointers._glXChannelRectSyncSGIX_fnptr(display, screen, channel, (uint)synctype);
+            public static int ChannelRectSyncSGIX(DisplayPtr display, int screen, int channel, All synctype) => GlxPointers._glXChannelRectSyncSGIX_fnptr((IntPtr)display, screen, channel, (uint)synctype);
             
             /// <summary> <b>[requires: GLX_SGIX_fbconfig]</b> <b>[entry point: <c>glXChooseFBConfigSGIX</c>]</b><br/>  </summary>
-            public static GLXFBConfigSGIX* ChooseFBConfigSGIX(Display* dpy, int screen, int* attrib_list, int* nelements) => (GLXFBConfigSGIX*) GlxPointers._glXChooseFBConfigSGIX_fnptr(dpy, screen, attrib_list, nelements);
+            public static GLXFBConfigSGIX* ChooseFBConfigSGIX(DisplayPtr dpy, int screen, int* attrib_list, int* nelements) => (GLXFBConfigSGIX*) GlxPointers._glXChooseFBConfigSGIX_fnptr((IntPtr)dpy, screen, attrib_list, nelements);
             
             /// <summary> <b>[requires: GLX_SGIX_fbconfig]</b> <b>[entry point: <c>glXCreateContextWithConfigSGIX</c>]</b><br/>  </summary>
-            public static GLXContext CreateContextWithConfigSGIX(Display* dpy, GLXFBConfigSGIX config, int render_type, GLXContext share_list, bool direct) => (GLXContext) GlxPointers._glXCreateContextWithConfigSGIX_fnptr(dpy, (IntPtr)config, render_type, (IntPtr)share_list, (byte)(direct ? 1 : 0));
+            public static GLXContext CreateContextWithConfigSGIX(DisplayPtr dpy, GLXFBConfigSGIX config, int render_type, GLXContext share_list, bool direct) => (GLXContext) GlxPointers._glXCreateContextWithConfigSGIX_fnptr((IntPtr)dpy, (IntPtr)config, render_type, (IntPtr)share_list, (byte)(direct ? 1 : 0));
             
             /// <summary> <b>[requires: GLX_SGIX_pbuffer]</b> <b>[entry point: <c>glXCreateGLXPbufferSGIX</c>]</b><br/>  </summary>
-            public static GLXPbufferSGIX CreateGLXPbufferSGIX(Display* dpy, GLXFBConfigSGIX config, uint width, uint height, int* attrib_list) => (GLXPbufferSGIX) GlxPointers._glXCreateGLXPbufferSGIX_fnptr(dpy, (IntPtr)config, width, height, attrib_list);
+            public static GLXPbufferSGIX CreateGLXPbufferSGIX(DisplayPtr dpy, GLXFBConfigSGIX config, uint width, uint height, int* attrib_list) => (GLXPbufferSGIX) GlxPointers._glXCreateGLXPbufferSGIX_fnptr((IntPtr)dpy, (IntPtr)config, width, height, attrib_list);
             
             /// <summary> <b>[requires: GLX_SGIX_fbconfig]</b> <b>[entry point: <c>glXCreateGLXPixmapWithConfigSGIX</c>]</b><br/>  </summary>
-            public static GLXPixmap CreateGLXPixmapWithConfigSGIX(Display* dpy, GLXFBConfigSGIX config, Pixmap pixmap) => (GLXPixmap) GlxPointers._glXCreateGLXPixmapWithConfigSGIX_fnptr(dpy, (IntPtr)config, (nuint)pixmap);
+            public static GLXPixmap CreateGLXPixmapWithConfigSGIX(DisplayPtr dpy, GLXFBConfigSGIX config, Pixmap pixmap) => (GLXPixmap) GlxPointers._glXCreateGLXPixmapWithConfigSGIX_fnptr((IntPtr)dpy, (IntPtr)config, (nuint)pixmap);
             
             /// <summary> <b>[requires: GLX_SGIX_pbuffer]</b> <b>[entry point: <c>glXDestroyGLXPbufferSGIX</c>]</b><br/>  </summary>
-            public static void DestroyGLXPbufferSGIX(Display* dpy, GLXPbufferSGIX pbuf) => GlxPointers._glXDestroyGLXPbufferSGIX_fnptr(dpy, (nuint)pbuf);
+            public static void DestroyGLXPbufferSGIX(DisplayPtr dpy, GLXPbufferSGIX pbuf) => GlxPointers._glXDestroyGLXPbufferSGIX_fnptr((IntPtr)dpy, (nuint)pbuf);
             
             /// <summary> <b>[requires: GLX_SGIX_hyperpipe]</b> <b>[entry point: <c>glXDestroyHyperpipeConfigSGIX</c>]</b><br/>  </summary>
-            public static int DestroyHyperpipeConfigSGIX(Display* dpy, int hpId) => GlxPointers._glXDestroyHyperpipeConfigSGIX_fnptr(dpy, hpId);
+            public static int DestroyHyperpipeConfigSGIX(DisplayPtr dpy, int hpId) => GlxPointers._glXDestroyHyperpipeConfigSGIX_fnptr((IntPtr)dpy, hpId);
             
             /// <summary> <b>[requires: GLX_SGIX_fbconfig]</b> <b>[entry point: <c>glXGetFBConfigAttribSGIX</c>]</b><br/>  </summary>
-            public static int GetFBConfigAttribSGIX(Display* dpy, GLXFBConfigSGIX config, int attribute, int* value) => GlxPointers._glXGetFBConfigAttribSGIX_fnptr(dpy, (IntPtr)config, attribute, value);
+            public static int GetFBConfigAttribSGIX(DisplayPtr dpy, GLXFBConfigSGIX config, int attribute, int* value) => GlxPointers._glXGetFBConfigAttribSGIX_fnptr((IntPtr)dpy, (IntPtr)config, attribute, value);
             
             /// <summary> <b>[requires: GLX_SGIX_fbconfig]</b> <b>[entry point: <c>glXGetFBConfigFromVisualSGIX</c>]</b><br/>  </summary>
-            public static GLXFBConfigSGIX GetFBConfigFromVisualSGIX(Display* dpy, XVisualInfo* vis) => (GLXFBConfigSGIX) GlxPointers._glXGetFBConfigFromVisualSGIX_fnptr(dpy, vis);
+            public static GLXFBConfigSGIX GetFBConfigFromVisualSGIX(DisplayPtr dpy, XVisualInfoPtr vis) => (GLXFBConfigSGIX) GlxPointers._glXGetFBConfigFromVisualSGIX_fnptr((IntPtr)dpy, (IntPtr)vis);
             
             /// <summary> <b>[requires: GLX_SGIX_pbuffer]</b> <b>[entry point: <c>glXGetSelectedEventSGIX</c>]</b><br/>  </summary>
-            public static void GetSelectedEventSGIX(Display* dpy, GLXDrawable drawable, ulong* mask) => GlxPointers._glXGetSelectedEventSGIX_fnptr(dpy, (nuint)drawable, mask);
+            public static void GetSelectedEventSGIX(DisplayPtr dpy, GLXDrawable drawable, ulong* mask) => GlxPointers._glXGetSelectedEventSGIX_fnptr((IntPtr)dpy, (nuint)drawable, mask);
             
             /// <summary> <b>[requires: GLX_SGIX_fbconfig]</b> <b>[entry point: <c>glXGetVisualFromFBConfigSGIX</c>]</b><br/>  </summary>
-            public static XVisualInfo* GetVisualFromFBConfigSGIX(Display* dpy, GLXFBConfigSGIX config) => GlxPointers._glXGetVisualFromFBConfigSGIX_fnptr(dpy, (IntPtr)config);
+            public static XVisualInfoPtr GetVisualFromFBConfigSGIX(DisplayPtr dpy, GLXFBConfigSGIX config) => (XVisualInfoPtr) GlxPointers._glXGetVisualFromFBConfigSGIX_fnptr((IntPtr)dpy, (IntPtr)config);
             
             /// <summary> <b>[requires: GLX_SGIX_hyperpipe]</b> <b>[entry point: <c>glXHyperpipeAttribSGIX</c>]</b><br/>  </summary>
-            public static int HyperpipeAttribSGIX(Display* dpy, int timeSlice, int attrib, int size, void* attribList) => GlxPointers._glXHyperpipeAttribSGIX_fnptr(dpy, timeSlice, attrib, size, attribList);
+            public static int HyperpipeAttribSGIX(DisplayPtr dpy, int timeSlice, int attrib, int size, void* attribList) => GlxPointers._glXHyperpipeAttribSGIX_fnptr((IntPtr)dpy, timeSlice, attrib, size, attribList);
             
             /// <summary> <b>[requires: GLX_SGIX_hyperpipe]</b> <b>[entry point: <c>glXHyperpipeConfigSGIX</c>]</b><br/>  </summary>
-            public static int HyperpipeConfigSGIX(Display* dpy, int networkId, int npipes, GLXHyperpipeConfigSGIX* cfg, int* hpId) => GlxPointers._glXHyperpipeConfigSGIX_fnptr(dpy, networkId, npipes, cfg, hpId);
+            public static int HyperpipeConfigSGIX(DisplayPtr dpy, int networkId, int npipes, GLXHyperpipeConfigSGIX* cfg, int* hpId) => GlxPointers._glXHyperpipeConfigSGIX_fnptr((IntPtr)dpy, networkId, npipes, cfg, hpId);
             
             /// <summary> <b>[requires: GLX_SGIX_swap_group]</b> <b>[entry point: <c>glXJoinSwapGroupSGIX</c>]</b><br/>  </summary>
-            public static void JoinSwapGroupSGIX(Display* dpy, GLXDrawable drawable, GLXDrawable member) => GlxPointers._glXJoinSwapGroupSGIX_fnptr(dpy, (nuint)drawable, (nuint)member);
+            public static void JoinSwapGroupSGIX(DisplayPtr dpy, GLXDrawable drawable, GLXDrawable member) => GlxPointers._glXJoinSwapGroupSGIX_fnptr((IntPtr)dpy, (nuint)drawable, (nuint)member);
             
             /// <summary> <b>[requires: GLX_SGIX_video_resize]</b> <b>[entry point: <c>glXQueryChannelDeltasSGIX</c>]</b><br/>  </summary>
-            public static int QueryChannelDeltasSGIX(Display* display, int screen, int channel, int* x, int* y, int* w, int* h) => GlxPointers._glXQueryChannelDeltasSGIX_fnptr(display, screen, channel, x, y, w, h);
+            public static int QueryChannelDeltasSGIX(DisplayPtr display, int screen, int channel, int* x, int* y, int* w, int* h) => GlxPointers._glXQueryChannelDeltasSGIX_fnptr((IntPtr)display, screen, channel, x, y, w, h);
             
             /// <summary> <b>[requires: GLX_SGIX_video_resize]</b> <b>[entry point: <c>glXQueryChannelRectSGIX</c>]</b><br/>  </summary>
-            public static int QueryChannelRectSGIX(Display* display, int screen, int channel, int* dx, int* dy, int* dw, int* dh) => GlxPointers._glXQueryChannelRectSGIX_fnptr(display, screen, channel, dx, dy, dw, dh);
+            public static int QueryChannelRectSGIX(DisplayPtr display, int screen, int channel, int* dx, int* dy, int* dw, int* dh) => GlxPointers._glXQueryChannelRectSGIX_fnptr((IntPtr)display, screen, channel, dx, dy, dw, dh);
             
             /// <summary> <b>[requires: GLX_SGIX_pbuffer]</b> <b>[entry point: <c>glXQueryGLXPbufferSGIX</c>]</b><br/>  </summary>
-            public static void QueryGLXPbufferSGIX(Display* dpy, GLXPbufferSGIX pbuf, int attribute, uint* value) => GlxPointers._glXQueryGLXPbufferSGIX_fnptr(dpy, (nuint)pbuf, attribute, value);
+            public static void QueryGLXPbufferSGIX(DisplayPtr dpy, GLXPbufferSGIX pbuf, int attribute, uint* value) => GlxPointers._glXQueryGLXPbufferSGIX_fnptr((IntPtr)dpy, (nuint)pbuf, attribute, value);
             
             /// <summary> <b>[requires: GLX_SGIX_hyperpipe]</b> <b>[entry point: <c>glXQueryHyperpipeAttribSGIX</c>]</b><br/>  </summary>
-            public static int QueryHyperpipeAttribSGIX(Display* dpy, int timeSlice, int attrib, int size, void* returnAttribList) => GlxPointers._glXQueryHyperpipeAttribSGIX_fnptr(dpy, timeSlice, attrib, size, returnAttribList);
+            public static int QueryHyperpipeAttribSGIX(DisplayPtr dpy, int timeSlice, int attrib, int size, void* returnAttribList) => GlxPointers._glXQueryHyperpipeAttribSGIX_fnptr((IntPtr)dpy, timeSlice, attrib, size, returnAttribList);
             
             /// <summary> <b>[requires: GLX_SGIX_hyperpipe]</b> <b>[entry point: <c>glXQueryHyperpipeBestAttribSGIX</c>]</b><br/>  </summary>
-            public static int QueryHyperpipeBestAttribSGIX(Display* dpy, int timeSlice, int attrib, int size, void* attribList, void* returnAttribList) => GlxPointers._glXQueryHyperpipeBestAttribSGIX_fnptr(dpy, timeSlice, attrib, size, attribList, returnAttribList);
+            public static int QueryHyperpipeBestAttribSGIX(DisplayPtr dpy, int timeSlice, int attrib, int size, void* attribList, void* returnAttribList) => GlxPointers._glXQueryHyperpipeBestAttribSGIX_fnptr((IntPtr)dpy, timeSlice, attrib, size, attribList, returnAttribList);
             
             /// <summary> <b>[requires: GLX_SGIX_hyperpipe]</b> <b>[entry point: <c>glXQueryHyperpipeConfigSGIX</c>]</b><br/>  </summary>
-            public static GLXHyperpipeConfigSGIX* QueryHyperpipeConfigSGIX(Display* dpy, int hpId, int* npipes) => GlxPointers._glXQueryHyperpipeConfigSGIX_fnptr(dpy, hpId, npipes);
+            public static GLXHyperpipeConfigSGIX* QueryHyperpipeConfigSGIX(DisplayPtr dpy, int hpId, int* npipes) => GlxPointers._glXQueryHyperpipeConfigSGIX_fnptr((IntPtr)dpy, hpId, npipes);
             
             /// <summary> <b>[requires: GLX_SGIX_hyperpipe]</b> <b>[entry point: <c>glXQueryHyperpipeNetworkSGIX</c>]</b><br/>  </summary>
-            public static GLXHyperpipeNetworkSGIX* QueryHyperpipeNetworkSGIX(Display* dpy, int* npipes) => GlxPointers._glXQueryHyperpipeNetworkSGIX_fnptr(dpy, npipes);
+            public static GLXHyperpipeNetworkSGIX* QueryHyperpipeNetworkSGIX(DisplayPtr dpy, int* npipes) => GlxPointers._glXQueryHyperpipeNetworkSGIX_fnptr((IntPtr)dpy, npipes);
             
             /// <summary> <b>[requires: GLX_SGIX_swap_barrier]</b> <b>[entry point: <c>glXQueryMaxSwapBarriersSGIX</c>]</b><br/>  </summary>
-            public static bool QueryMaxSwapBarriersSGIX(Display* dpy, int screen, int* max) => GlxPointers._glXQueryMaxSwapBarriersSGIX_fnptr(dpy, screen, max) != 0;
+            public static bool QueryMaxSwapBarriersSGIX(DisplayPtr dpy, int screen, int* max) => GlxPointers._glXQueryMaxSwapBarriersSGIX_fnptr((IntPtr)dpy, screen, max) != 0;
             
             /// <summary> <b>[requires: GLX_SGIX_pbuffer]</b> <b>[entry point: <c>glXSelectEventSGIX</c>]</b><br/>  </summary>
-            public static void SelectEventSGIX(Display* dpy, GLXDrawable drawable, ulong mask) => GlxPointers._glXSelectEventSGIX_fnptr(dpy, (nuint)drawable, mask);
+            public static void SelectEventSGIX(DisplayPtr dpy, GLXDrawable drawable, ulong mask) => GlxPointers._glXSelectEventSGIX_fnptr((IntPtr)dpy, (nuint)drawable, mask);
             
         }
         /// <summary>SUN extensions.</summary>
         public static unsafe partial class SUN
         {
             /// <summary> <b>[requires: GLX_SUN_get_transparent_index]</b> <b>[entry point: <c>glXGetTransparentIndexSUN</c>]</b><br/>  </summary>
-            public static int GetTransparentIndexSUN(Display* dpy, Window overlay, Window underlay, ulong* pTransparentIndex) => GlxPointers._glXGetTransparentIndexSUN_fnptr(dpy, (nuint)overlay, (nuint)underlay, pTransparentIndex);
+            public static int GetTransparentIndexSUN(DisplayPtr dpy, Window overlay, Window underlay, ulong* pTransparentIndex) => GlxPointers._glXGetTransparentIndexSUN_fnptr((IntPtr)dpy, (nuint)overlay, (nuint)underlay, pTransparentIndex);
             
         }
     }

--- a/src/OpenTK.Graphics/Glx/GLX.Overloads.cs
+++ b/src/OpenTK.Graphics/Glx/GLX.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -11,185 +11,93 @@ namespace OpenTK.Graphics.Glx
 {
     public static unsafe partial class Glx
     {
-        /// <inheritdoc cref="ChooseFBConfig(Display*, int, int*, int*)"/>
-        public static unsafe GLXFBConfig* ChooseFBConfig(ref Display dpy, int screen, in int attrib_list, ref int nelements)
+        /// <inheritdoc cref="ChooseFBConfig(DisplayPtr, int, int*, int*)"/>
+        public static unsafe GLXFBConfig* ChooseFBConfig(DisplayPtr dpy, int screen, in int attrib_list, ref int nelements)
         {
             GLXFBConfig* returnValue;
-            fixed (Display* dpy_ptr = &dpy)
             fixed (int* attrib_list_ptr = &attrib_list)
             fixed (int* nelements_ptr = &nelements)
             {
-                returnValue = ChooseFBConfig(dpy_ptr, screen, attrib_list_ptr, nelements_ptr);
+                returnValue = ChooseFBConfig(dpy, screen, attrib_list_ptr, nelements_ptr);
             }
             return returnValue;
         }
-        /// <inheritdoc cref="ChooseVisual(Display*, int, int*)"/>
-        public static unsafe XVisualInfo* ChooseVisual(ref Display dpy, int screen, ref int attribList)
+        /// <inheritdoc cref="ChooseVisual(DisplayPtr, int, int*)"/>
+        public static unsafe XVisualInfoPtr ChooseVisual(DisplayPtr dpy, int screen, ref int attribList)
         {
-            XVisualInfo* returnValue;
-            fixed (Display* dpy_ptr = &dpy)
+            XVisualInfoPtr returnValue;
             fixed (int* attribList_ptr = &attribList)
             {
-                returnValue = ChooseVisual(dpy_ptr, screen, attribList_ptr);
+                returnValue = ChooseVisual(dpy, screen, attribList_ptr);
             }
             return returnValue;
         }
-        /// <inheritdoc cref="CopyContext(Display*, GLXContext, GLXContext, ulong)"/>
-        public static unsafe void CopyContext(ref Display dpy, GLXContext src, GLXContext dst, ulong mask)
-        {
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                CopyContext(dpy_ptr, src, dst, mask);
-            }
-        }
-        /// <inheritdoc cref="CreateContext(Display*, XVisualInfo*, GLXContext, bool)"/>
-        public static unsafe GLXContext CreateContext(ref Display dpy, ref XVisualInfo vis, GLXContext shareList, bool direct)
-        {
-            GLXContext returnValue;
-            fixed (Display* dpy_ptr = &dpy)
-            fixed (XVisualInfo* vis_ptr = &vis)
-            {
-                returnValue = CreateContext(dpy_ptr, vis_ptr, shareList, direct);
-            }
-            return returnValue;
-        }
-        /// <inheritdoc cref="CreateGLXPixmap(Display*, XVisualInfo*, Pixmap)"/>
-        public static unsafe GLXPixmap CreateGLXPixmap(ref Display dpy, ref XVisualInfo visual, Pixmap pixmap)
-        {
-            GLXPixmap returnValue;
-            fixed (Display* dpy_ptr = &dpy)
-            fixed (XVisualInfo* visual_ptr = &visual)
-            {
-                returnValue = CreateGLXPixmap(dpy_ptr, visual_ptr, pixmap);
-            }
-            return returnValue;
-        }
-        /// <inheritdoc cref="CreateNewContext(Display*, GLXFBConfig, int, GLXContext, bool)"/>
-        public static unsafe GLXContext CreateNewContext(ref Display dpy, GLXFBConfig config, int render_type, GLXContext share_list, bool direct)
-        {
-            GLXContext returnValue;
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                returnValue = CreateNewContext(dpy_ptr, config, render_type, share_list, direct);
-            }
-            return returnValue;
-        }
-        /// <inheritdoc cref="CreatePbuffer(Display*, GLXFBConfig, int*)"/>
-        public static unsafe GLXPbuffer CreatePbuffer(ref Display dpy, GLXFBConfig config, in int attrib_list)
+        /// <inheritdoc cref="CreatePbuffer(DisplayPtr, GLXFBConfig, int*)"/>
+        public static unsafe GLXPbuffer CreatePbuffer(DisplayPtr dpy, GLXFBConfig config, in int attrib_list)
         {
             GLXPbuffer returnValue;
-            fixed (Display* dpy_ptr = &dpy)
             fixed (int* attrib_list_ptr = &attrib_list)
             {
-                returnValue = CreatePbuffer(dpy_ptr, config, attrib_list_ptr);
+                returnValue = CreatePbuffer(dpy, config, attrib_list_ptr);
             }
             return returnValue;
         }
-        /// <inheritdoc cref="CreatePixmap(Display*, GLXFBConfig, Pixmap, int*)"/>
-        public static unsafe GLXPixmap CreatePixmap(ref Display dpy, GLXFBConfig config, Pixmap pixmap, in int attrib_list)
+        /// <inheritdoc cref="CreatePixmap(DisplayPtr, GLXFBConfig, Pixmap, int*)"/>
+        public static unsafe GLXPixmap CreatePixmap(DisplayPtr dpy, GLXFBConfig config, Pixmap pixmap, in int attrib_list)
         {
             GLXPixmap returnValue;
-            fixed (Display* dpy_ptr = &dpy)
             fixed (int* attrib_list_ptr = &attrib_list)
             {
-                returnValue = CreatePixmap(dpy_ptr, config, pixmap, attrib_list_ptr);
+                returnValue = CreatePixmap(dpy, config, pixmap, attrib_list_ptr);
             }
             return returnValue;
         }
-        /// <inheritdoc cref="CreateWindow(Display*, GLXFBConfig, Window, int*)"/>
-        public static unsafe GLXWindow CreateWindow(ref Display dpy, GLXFBConfig config, Window win, in int attrib_list)
+        /// <inheritdoc cref="CreateWindow(DisplayPtr, GLXFBConfig, Window, int*)"/>
+        public static unsafe GLXWindow CreateWindow(DisplayPtr dpy, GLXFBConfig config, Window win, in int attrib_list)
         {
             GLXWindow returnValue;
-            fixed (Display* dpy_ptr = &dpy)
             fixed (int* attrib_list_ptr = &attrib_list)
             {
-                returnValue = CreateWindow(dpy_ptr, config, win, attrib_list_ptr);
+                returnValue = CreateWindow(dpy, config, win, attrib_list_ptr);
             }
             return returnValue;
         }
-        /// <inheritdoc cref="DestroyContext(Display*, GLXContext)"/>
-        public static unsafe void DestroyContext(ref Display dpy, GLXContext ctx)
-        {
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                DestroyContext(dpy_ptr, ctx);
-            }
-        }
-        /// <inheritdoc cref="DestroyGLXPixmap(Display*, GLXPixmap)"/>
-        public static unsafe void DestroyGLXPixmap(ref Display dpy, GLXPixmap pixmap)
-        {
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                DestroyGLXPixmap(dpy_ptr, pixmap);
-            }
-        }
-        /// <inheritdoc cref="DestroyPbuffer(Display*, GLXPbuffer)"/>
-        public static unsafe void DestroyPbuffer(ref Display dpy, GLXPbuffer pbuf)
-        {
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                DestroyPbuffer(dpy_ptr, pbuf);
-            }
-        }
-        /// <inheritdoc cref="DestroyPixmap(Display*, GLXPixmap)"/>
-        public static unsafe void DestroyPixmap(ref Display dpy, GLXPixmap pixmap)
-        {
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                DestroyPixmap(dpy_ptr, pixmap);
-            }
-        }
-        /// <inheritdoc cref="DestroyWindow(Display*, GLXWindow)"/>
-        public static unsafe void DestroyWindow(ref Display dpy, GLXWindow win)
-        {
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                DestroyWindow(dpy_ptr, win);
-            }
-        }
-        /// <inheritdoc cref="GetClientString(Display*, int)"/>
-        public static unsafe string? GetClientString(ref Display dpy, int name)
+        /// <inheritdoc cref="GetClientString(DisplayPtr, int)"/>
+        public static unsafe string? GetClientString(DisplayPtr dpy, int name)
         {
             string? returnValue_str;
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                byte* returnValue;
-                returnValue = GetClientString(dpy_ptr, name);
-                returnValue_str = Marshal.PtrToStringAnsi((IntPtr)returnValue);
-            }
+            byte* returnValue;
+            returnValue = GetClientString_(dpy, name);
+            returnValue_str = Marshal.PtrToStringAnsi((IntPtr)returnValue);
             return returnValue_str;
         }
-        /// <inheritdoc cref="GetConfig(Display*, XVisualInfo*, int, int*)"/>
-        public static unsafe int GetConfig(ref Display dpy, ref XVisualInfo visual, int attrib, ref int value)
+        /// <inheritdoc cref="GetConfig(DisplayPtr, XVisualInfoPtr, int, int*)"/>
+        public static unsafe int GetConfig(DisplayPtr dpy, XVisualInfoPtr visual, int attrib, ref int value)
         {
             int returnValue;
-            fixed (Display* dpy_ptr = &dpy)
-            fixed (XVisualInfo* visual_ptr = &visual)
             fixed (int* value_ptr = &value)
             {
-                returnValue = GetConfig(dpy_ptr, visual_ptr, attrib, value_ptr);
+                returnValue = GetConfig(dpy, visual, attrib, value_ptr);
             }
             return returnValue;
         }
-        /// <inheritdoc cref="GetFBConfigAttrib(Display*, GLXFBConfig, int, int*)"/>
-        public static unsafe int GetFBConfigAttrib(ref Display dpy, GLXFBConfig config, int attribute, ref int value)
+        /// <inheritdoc cref="GetFBConfigAttrib(DisplayPtr, GLXFBConfig, int, int*)"/>
+        public static unsafe int GetFBConfigAttrib(DisplayPtr dpy, GLXFBConfig config, int attribute, ref int value)
         {
             int returnValue;
-            fixed (Display* dpy_ptr = &dpy)
             fixed (int* value_ptr = &value)
             {
-                returnValue = GetFBConfigAttrib(dpy_ptr, config, attribute, value_ptr);
+                returnValue = GetFBConfigAttrib(dpy, config, attribute, value_ptr);
             }
             return returnValue;
         }
-        /// <inheritdoc cref="GetFBConfigs(Display*, int, int*)"/>
-        public static unsafe GLXFBConfig* GetFBConfig(ref Display dpy, int screen, ref int nelements)
+        /// <inheritdoc cref="GetFBConfigs(DisplayPtr, int, int*)"/>
+        public static unsafe GLXFBConfig* GetFBConfig(DisplayPtr dpy, int screen, ref int nelements)
         {
             GLXFBConfig* returnValue;
-            fixed (Display* dpy_ptr = &dpy)
             fixed (int* nelements_ptr = &nelements)
             {
-                returnValue = GetFBConfigs(dpy_ptr, screen, nelements_ptr);
+                returnValue = GetFBConfigs(dpy, screen, nelements_ptr);
             }
             return returnValue;
         }
@@ -203,138 +111,71 @@ namespace OpenTK.Graphics.Glx
             }
             return returnValue;
         }
-        /// <inheritdoc cref="GetSelectedEvent(Display*, GLXDrawable, ulong*)"/>
-        public static unsafe void GetSelectedEvent(ref Display dpy, GLXDrawable draw, ref ulong event_mask)
+        /// <inheritdoc cref="GetSelectedEvent(DisplayPtr, GLXDrawable, ulong*)"/>
+        public static unsafe void GetSelectedEvent(DisplayPtr dpy, GLXDrawable draw, ref ulong event_mask)
         {
-            fixed (Display* dpy_ptr = &dpy)
             fixed (ulong* event_mask_ptr = &event_mask)
             {
-                GetSelectedEvent(dpy_ptr, draw, event_mask_ptr);
+                GetSelectedEvent(dpy, draw, event_mask_ptr);
             }
         }
-        /// <inheritdoc cref="GetVisualFromFBConfig(Display*, GLXFBConfig)"/>
-        public static unsafe XVisualInfo* GetVisualFromFBConfig(ref Display dpy, GLXFBConfig config)
-        {
-            XVisualInfo* returnValue;
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                returnValue = GetVisualFromFBConfig(dpy_ptr, config);
-            }
-            return returnValue;
-        }
-        /// <inheritdoc cref="IsDirect(Display*, GLXContext)"/>
-        public static unsafe bool IsDirect(ref Display dpy, GLXContext ctx)
-        {
-            bool returnValue;
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                returnValue = IsDirect(dpy_ptr, ctx);
-            }
-            return returnValue;
-        }
-        /// <inheritdoc cref="MakeContextCurrent(Display*, GLXDrawable, GLXDrawable, GLXContext)"/>
-        public static unsafe bool MakeContextCurrent(ref Display dpy, GLXDrawable draw, GLXDrawable read, GLXContext ctx)
-        {
-            bool returnValue;
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                returnValue = MakeContextCurrent(dpy_ptr, draw, read, ctx);
-            }
-            return returnValue;
-        }
-        /// <inheritdoc cref="MakeCurrent(Display*, GLXDrawable, GLXContext)"/>
-        public static unsafe bool MakeCurrent(ref Display dpy, GLXDrawable drawable, GLXContext ctx)
-        {
-            bool returnValue;
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                returnValue = MakeCurrent(dpy_ptr, drawable, ctx);
-            }
-            return returnValue;
-        }
-        /// <inheritdoc cref="QueryContext(Display*, GLXContext, int, int*)"/>
-        public static unsafe int QueryContext(ref Display dpy, GLXContext ctx, int attribute, ref int value)
+        /// <inheritdoc cref="QueryContext(DisplayPtr, GLXContext, int, int*)"/>
+        public static unsafe int QueryContext(DisplayPtr dpy, GLXContext ctx, int attribute, ref int value)
         {
             int returnValue;
-            fixed (Display* dpy_ptr = &dpy)
             fixed (int* value_ptr = &value)
             {
-                returnValue = QueryContext(dpy_ptr, ctx, attribute, value_ptr);
+                returnValue = QueryContext(dpy, ctx, attribute, value_ptr);
             }
             return returnValue;
         }
-        /// <inheritdoc cref="QueryDrawable(Display*, GLXDrawable, int, uint*)"/>
-        public static unsafe void QueryDrawable(ref Display dpy, GLXDrawable draw, int attribute, ref uint value)
+        /// <inheritdoc cref="QueryDrawable(DisplayPtr, GLXDrawable, int, uint*)"/>
+        public static unsafe void QueryDrawable(DisplayPtr dpy, GLXDrawable draw, int attribute, ref uint value)
         {
-            fixed (Display* dpy_ptr = &dpy)
             fixed (uint* value_ptr = &value)
             {
-                QueryDrawable(dpy_ptr, draw, attribute, value_ptr);
+                QueryDrawable(dpy, draw, attribute, value_ptr);
             }
         }
-        /// <inheritdoc cref="QueryExtension(Display*, int*, int*)"/>
-        public static unsafe bool QueryExtension(ref Display dpy, ref int errorb, ref int @event)
+        /// <inheritdoc cref="QueryExtension(DisplayPtr, int*, int*)"/>
+        public static unsafe bool QueryExtension(DisplayPtr dpy, ref int errorb, ref int @event)
         {
             bool returnValue;
-            fixed (Display* dpy_ptr = &dpy)
             fixed (int* errorb_ptr = &errorb)
             fixed (int* @event_ptr = &@event)
             {
-                returnValue = QueryExtension(dpy_ptr, errorb_ptr, @event_ptr);
+                returnValue = QueryExtension(dpy, errorb_ptr, @event_ptr);
             }
             return returnValue;
         }
-        /// <inheritdoc cref="QueryExtensionsString(Display*, int)"/>
-        public static unsafe string? QueryExtensionsString(ref Display dpy, int screen)
+        /// <inheritdoc cref="QueryExtensionsString(DisplayPtr, int)"/>
+        public static unsafe string? QueryExtensionsString(DisplayPtr dpy, int screen)
         {
             string? returnValue_str;
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                byte* returnValue;
-                returnValue = QueryExtensionsString(dpy_ptr, screen);
-                returnValue_str = Marshal.PtrToStringAnsi((IntPtr)returnValue);
-            }
+            byte* returnValue;
+            returnValue = QueryExtensionsString_(dpy, screen);
+            returnValue_str = Marshal.PtrToStringAnsi((IntPtr)returnValue);
             return returnValue_str;
         }
-        /// <inheritdoc cref="QueryServerString(Display*, int, int)"/>
-        public static unsafe string? QueryServerString(ref Display dpy, int screen, int name)
+        /// <inheritdoc cref="QueryServerString(DisplayPtr, int, int)"/>
+        public static unsafe string? QueryServerString(DisplayPtr dpy, int screen, int name)
         {
             string? returnValue_str;
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                byte* returnValue;
-                returnValue = QueryServerString(dpy_ptr, screen, name);
-                returnValue_str = Marshal.PtrToStringAnsi((IntPtr)returnValue);
-            }
+            byte* returnValue;
+            returnValue = QueryServerString_(dpy, screen, name);
+            returnValue_str = Marshal.PtrToStringAnsi((IntPtr)returnValue);
             return returnValue_str;
         }
-        /// <inheritdoc cref="QueryVersion(Display*, int*, int*)"/>
-        public static unsafe bool QueryVersion(ref Display dpy, ref int maj, ref int min)
+        /// <inheritdoc cref="QueryVersion(DisplayPtr, int*, int*)"/>
+        public static unsafe bool QueryVersion(DisplayPtr dpy, ref int maj, ref int min)
         {
             bool returnValue;
-            fixed (Display* dpy_ptr = &dpy)
             fixed (int* maj_ptr = &maj)
             fixed (int* min_ptr = &min)
             {
-                returnValue = QueryVersion(dpy_ptr, maj_ptr, min_ptr);
+                returnValue = QueryVersion(dpy, maj_ptr, min_ptr);
             }
             return returnValue;
-        }
-        /// <inheritdoc cref="SelectEvent(Display*, GLXDrawable, ulong)"/>
-        public static unsafe void SelectEvent(ref Display dpy, GLXDrawable draw, ulong event_mask)
-        {
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                SelectEvent(dpy_ptr, draw, event_mask);
-            }
-        }
-        /// <inheritdoc cref="SwapBuffers(Display*, GLXDrawable)"/>
-        public static unsafe void SwapBuffers(ref Display dpy, GLXDrawable drawable)
-        {
-            fixed (Display* dpy_ptr = &dpy)
-            {
-                SwapBuffers(dpy_ptr, drawable);
-            }
         }
         public static unsafe partial class AMD
         {
@@ -380,14 +221,13 @@ namespace OpenTK.Graphics.Glx
         }
         public static unsafe partial class ARB
         {
-            /// <inheritdoc cref="CreateContextAttribsARB(Display*, GLXFBConfig, GLXContext, bool, int*)"/>
-            public static unsafe GLXContext CreateContextAttribsARB(ref Display dpy, GLXFBConfig config, GLXContext share_context, bool direct, in int attrib_list)
+            /// <inheritdoc cref="CreateContextAttribsARB(DisplayPtr, GLXFBConfig, GLXContext, bool, int*)"/>
+            public static unsafe GLXContext CreateContextAttribsARB(DisplayPtr dpy, GLXFBConfig config, GLXContext share_context, bool direct, in int attrib_list)
             {
                 GLXContext returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* attrib_list_ptr = &attrib_list)
                 {
-                    returnValue = CreateContextAttribsARB(dpy_ptr, config, share_context, direct, attrib_list_ptr);
+                    returnValue = CreateContextAttribsARB(dpy, config, share_context, direct, attrib_list_ptr);
                 }
                 return returnValue;
             }
@@ -404,82 +244,27 @@ namespace OpenTK.Graphics.Glx
         }
         public static unsafe partial class EXT
         {
-            /// <inheritdoc cref="BindTexImageEXT(Display*, GLXDrawable, int, int*)"/>
-            public static unsafe void BindTexImageEXT(ref Display dpy, GLXDrawable drawable, int buffer, in int attrib_list)
+            /// <inheritdoc cref="BindTexImageEXT(DisplayPtr, GLXDrawable, int, int*)"/>
+            public static unsafe void BindTexImageEXT(DisplayPtr dpy, GLXDrawable drawable, int buffer, in int attrib_list)
             {
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* attrib_list_ptr = &attrib_list)
                 {
-                    BindTexImageEXT(dpy_ptr, drawable, buffer, attrib_list_ptr);
+                    BindTexImageEXT(dpy, drawable, buffer, attrib_list_ptr);
                 }
             }
-            /// <inheritdoc cref="FreeContextEXT(Display*, GLXContext)"/>
-            public static unsafe void FreeContextEXT(ref Display dpy, GLXContext context)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    FreeContextEXT(dpy_ptr, context);
-                }
-            }
-            /// <inheritdoc cref="ImportContextEXT(Display*, GLXContextID)"/>
-            public static unsafe GLXContext ImportContextEXT(ref Display dpy, GLXContextID contextID)
-            {
-                GLXContext returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = ImportContextEXT(dpy_ptr, contextID);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="QueryContextInfoEXT(Display*, GLXContext, int, int*)"/>
-            public static unsafe int QueryContextInfoEXT(ref Display dpy, GLXContext context, int attribute, ref int value)
+            /// <inheritdoc cref="QueryContextInfoEXT(DisplayPtr, GLXContext, int, int*)"/>
+            public static unsafe int QueryContextInfoEXT(DisplayPtr dpy, GLXContext context, int attribute, ref int value)
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* value_ptr = &value)
                 {
-                    returnValue = QueryContextInfoEXT(dpy_ptr, context, attribute, value_ptr);
+                    returnValue = QueryContextInfoEXT(dpy, context, attribute, value_ptr);
                 }
                 return returnValue;
-            }
-            /// <inheritdoc cref="ReleaseTexImageEXT(Display*, GLXDrawable, int)"/>
-            public static unsafe void ReleaseTexImageEXT(ref Display dpy, GLXDrawable drawable, int buffer)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    ReleaseTexImageEXT(dpy_ptr, drawable, buffer);
-                }
-            }
-            /// <inheritdoc cref="SwapIntervalEXT(Display*, GLXDrawable, int)"/>
-            public static unsafe void SwapIntervalEXT(ref Display dpy, GLXDrawable drawable, int interval)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    SwapIntervalEXT(dpy_ptr, drawable, interval);
-                }
             }
         }
         public static unsafe partial class MESA
         {
-            /// <inheritdoc cref="CopySubBufferMESA(Display*, GLXDrawable, int, int, int, int)"/>
-            public static unsafe void CopySubBufferMESA(ref Display dpy, GLXDrawable drawable, int x, int y, int width, int height)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    CopySubBufferMESA(dpy_ptr, drawable, x, y, width, height);
-                }
-            }
-            /// <inheritdoc cref="CreateGLXPixmapMESA(Display*, XVisualInfo*, Pixmap, Colormap)"/>
-            public static unsafe GLXPixmap CreateGLXPixmapMESA(ref Display dpy, ref XVisualInfo visual, Pixmap pixmap, Colormap cmap)
-            {
-                GLXPixmap returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                fixed (XVisualInfo* visual_ptr = &visual)
-                {
-                    returnValue = CreateGLXPixmapMESA(dpy_ptr, visual_ptr, pixmap, cmap);
-                }
-                return returnValue;
-            }
             /// <inheritdoc cref="GetAGPOffsetMESA(void*)"/>
             public static unsafe uint GetAGPOffsetMESA(IntPtr pointer)
             {
@@ -518,350 +303,184 @@ namespace OpenTK.Graphics.Glx
                 returnValue_str = Marshal.PtrToStringAnsi((IntPtr)returnValue);
                 return returnValue_str;
             }
-            /// <inheritdoc cref="QueryRendererIntegerMESA(Display*, int, int, int, uint*)"/>
-            public static unsafe bool QueryRendererIntegerMESA(ref Display dpy, int screen, int renderer, int attribute, ref uint value)
+            /// <inheritdoc cref="QueryRendererIntegerMESA(DisplayPtr, int, int, int, uint*)"/>
+            public static unsafe bool QueryRendererIntegerMESA(DisplayPtr dpy, int screen, int renderer, int attribute, ref uint value)
             {
                 bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (uint* value_ptr = &value)
                 {
-                    returnValue = QueryRendererIntegerMESA(dpy_ptr, screen, renderer, attribute, value_ptr);
+                    returnValue = QueryRendererIntegerMESA(dpy, screen, renderer, attribute, value_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="QueryRendererStringMESA(Display*, int, int, int)"/>
-            public static unsafe string? QueryRendererStringMESA(ref Display dpy, int screen, int renderer, int attribute)
+            /// <inheritdoc cref="QueryRendererStringMESA(DisplayPtr, int, int, int)"/>
+            public static unsafe string? QueryRendererStringMESA(DisplayPtr dpy, int screen, int renderer, int attribute)
             {
                 string? returnValue_str;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    byte* returnValue;
-                    returnValue = QueryRendererStringMESA(dpy_ptr, screen, renderer, attribute);
-                    returnValue_str = Marshal.PtrToStringAnsi((IntPtr)returnValue);
-                }
+                byte* returnValue;
+                returnValue = QueryRendererStringMESA_(dpy, screen, renderer, attribute);
+                returnValue_str = Marshal.PtrToStringAnsi((IntPtr)returnValue);
                 return returnValue_str;
-            }
-            /// <inheritdoc cref="ReleaseBuffersMESA(Display*, GLXDrawable)"/>
-            public static unsafe bool ReleaseBuffersMESA(ref Display dpy, GLXDrawable drawable)
-            {
-                bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = ReleaseBuffersMESA(dpy_ptr, drawable);
-                }
-                return returnValue;
             }
         }
         public static unsafe partial class NV
         {
-            /// <inheritdoc cref="BindSwapBarrierNV(Display*, uint, uint)"/>
-            public static unsafe bool BindSwapBarrierNV(ref Display dpy, uint group, uint barrier)
-            {
-                bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = BindSwapBarrierNV(dpy_ptr, group, barrier);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="BindVideoCaptureDeviceNV(Display*, uint, GLXVideoCaptureDeviceNV)"/>
-            public static unsafe int BindVideoCaptureDeviceNV(ref Display dpy, uint video_capture_slot, GLXVideoCaptureDeviceNV device)
+            /// <inheritdoc cref="BindVideoDeviceNV(DisplayPtr, uint, uint, int*)"/>
+            public static unsafe int BindVideoDeviceNV(DisplayPtr dpy, uint video_slot, uint video_device, in int attrib_list)
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = BindVideoCaptureDeviceNV(dpy_ptr, video_capture_slot, device);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="BindVideoDeviceNV(Display*, uint, uint, int*)"/>
-            public static unsafe int BindVideoDeviceNV(ref Display dpy, uint video_slot, uint video_device, in int attrib_list)
-            {
-                int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* attrib_list_ptr = &attrib_list)
                 {
-                    returnValue = BindVideoDeviceNV(dpy_ptr, video_slot, video_device, attrib_list_ptr);
+                    returnValue = BindVideoDeviceNV(dpy, video_slot, video_device, attrib_list_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="BindVideoImageNV(Display*, GLXVideoDeviceNV, GLXPbuffer, int)"/>
-            public static unsafe int BindVideoImageNV(ref Display dpy, GLXVideoDeviceNV VideoDevice, GLXPbuffer pbuf, int iVideoBuffer)
-            {
-                int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = BindVideoImageNV(dpy_ptr, VideoDevice, pbuf, iVideoBuffer);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="CopyBufferSubDataNV(Display*, GLXContext, GLXContext, All, All, IntPtr, IntPtr, nint)"/>
-            public static unsafe void CopyBufferSubDataNV(ref Display dpy, GLXContext readCtx, GLXContext writeCtx, All readTarget, All writeTarget, IntPtr readOffset, IntPtr writeOffset, nint size)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    CopyBufferSubDataNV(dpy_ptr, readCtx, writeCtx, readTarget, writeTarget, readOffset, writeOffset, size);
-                }
-            }
-            /// <inheritdoc cref="CopyImageSubDataNV(Display*, GLXContext, uint, All, int, int, int, int, GLXContext, uint, All, int, int, int, int, int, int, int)"/>
-            public static unsafe void CopyImageSubDataNV(ref Display dpy, GLXContext srcCtx, uint srcName, All srcTarget, int srcLevel, int srcX, int srcY, int srcZ, GLXContext dstCtx, uint dstName, All dstTarget, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    CopyImageSubDataNV(dpy_ptr, srcCtx, srcName, srcTarget, srcLevel, srcX, srcY, srcZ, dstCtx, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
-                }
-            }
-            /// <inheritdoc cref="DelayBeforeSwapNV(Display*, GLXDrawable, float)"/>
-            public static unsafe bool DelayBeforeSwapNV(ref Display dpy, GLXDrawable drawable, float seconds)
-            {
-                bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = DelayBeforeSwapNV(dpy_ptr, drawable, seconds);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="EnumerateVideoCaptureDevicesNV(Display*, int, int*)"/>
-            public static unsafe GLXVideoCaptureDeviceNV* EnumerateVideoCaptureDevicesNV(ref Display dpy, int screen, ref int nelements)
+            /// <inheritdoc cref="EnumerateVideoCaptureDevicesNV(DisplayPtr, int, int*)"/>
+            public static unsafe GLXVideoCaptureDeviceNV* EnumerateVideoCaptureDevicesNV(DisplayPtr dpy, int screen, ref int nelements)
             {
                 GLXVideoCaptureDeviceNV* returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* nelements_ptr = &nelements)
                 {
-                    returnValue = EnumerateVideoCaptureDevicesNV(dpy_ptr, screen, nelements_ptr);
+                    returnValue = EnumerateVideoCaptureDevicesNV(dpy, screen, nelements_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="EnumerateVideoDevicesNV(Display*, int, int*)"/>
-            public static unsafe uint* EnumerateVideoDevicesNV(ref Display dpy, int screen, ref int nelements)
+            /// <inheritdoc cref="EnumerateVideoDevicesNV(DisplayPtr, int, int*)"/>
+            public static unsafe uint* EnumerateVideoDevicesNV(DisplayPtr dpy, int screen, ref int nelements)
             {
                 uint* returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* nelements_ptr = &nelements)
                 {
-                    returnValue = EnumerateVideoDevicesNV(dpy_ptr, screen, nelements_ptr);
+                    returnValue = EnumerateVideoDevicesNV(dpy, screen, nelements_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="GetVideoDeviceNV(Display*, int, int, GLXVideoDeviceNV*)"/>
-            public static unsafe int GetVideoDeviceNV(ref Display dpy, int screen, int numVideoDevices, ref GLXVideoDeviceNV pVideoDevice)
+            /// <inheritdoc cref="GetVideoDeviceNV(DisplayPtr, int, int, GLXVideoDeviceNV*)"/>
+            public static unsafe int GetVideoDeviceNV(DisplayPtr dpy, int screen, int numVideoDevices, ref GLXVideoDeviceNV pVideoDevice)
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (GLXVideoDeviceNV* pVideoDevice_ptr = &pVideoDevice)
                 {
-                    returnValue = GetVideoDeviceNV(dpy_ptr, screen, numVideoDevices, pVideoDevice_ptr);
+                    returnValue = GetVideoDeviceNV(dpy, screen, numVideoDevices, pVideoDevice_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="GetVideoInfoNV(Display*, int, GLXVideoDeviceNV, ulong*, ulong*)"/>
-            public static unsafe int GetVideoInfoNV(ref Display dpy, int screen, GLXVideoDeviceNV VideoDevice, ref ulong pulCounterOutputPbuffer, ref ulong pulCounterOutputVideo)
+            /// <inheritdoc cref="GetVideoInfoNV(DisplayPtr, int, GLXVideoDeviceNV, ulong*, ulong*)"/>
+            public static unsafe int GetVideoInfoNV(DisplayPtr dpy, int screen, GLXVideoDeviceNV VideoDevice, ref ulong pulCounterOutputPbuffer, ref ulong pulCounterOutputVideo)
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (ulong* pulCounterOutputPbuffer_ptr = &pulCounterOutputPbuffer)
                 fixed (ulong* pulCounterOutputVideo_ptr = &pulCounterOutputVideo)
                 {
-                    returnValue = GetVideoInfoNV(dpy_ptr, screen, VideoDevice, pulCounterOutputPbuffer_ptr, pulCounterOutputVideo_ptr);
+                    returnValue = GetVideoInfoNV(dpy, screen, VideoDevice, pulCounterOutputPbuffer_ptr, pulCounterOutputVideo_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="JoinSwapGroupNV(Display*, GLXDrawable, uint)"/>
-            public static unsafe bool JoinSwapGroupNV(ref Display dpy, GLXDrawable drawable, uint group)
+            /// <inheritdoc cref="QueryFrameCountNV(DisplayPtr, int, uint*)"/>
+            public static unsafe bool QueryFrameCountNV(DisplayPtr dpy, int screen, ref uint count)
             {
                 bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = JoinSwapGroupNV(dpy_ptr, drawable, group);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="LockVideoCaptureDeviceNV(Display*, GLXVideoCaptureDeviceNV)"/>
-            public static unsafe void LockVideoCaptureDeviceNV(ref Display dpy, GLXVideoCaptureDeviceNV device)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    LockVideoCaptureDeviceNV(dpy_ptr, device);
-                }
-            }
-            /// <inheritdoc cref="NamedCopyBufferSubDataNV(Display*, GLXContext, GLXContext, uint, uint, IntPtr, IntPtr, nint)"/>
-            public static unsafe void NamedCopyBufferSubDataNV(ref Display dpy, GLXContext readCtx, GLXContext writeCtx, uint readBuffer, uint writeBuffer, IntPtr readOffset, IntPtr writeOffset, nint size)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    NamedCopyBufferSubDataNV(dpy_ptr, readCtx, writeCtx, readBuffer, writeBuffer, readOffset, writeOffset, size);
-                }
-            }
-            /// <inheritdoc cref="QueryFrameCountNV(Display*, int, uint*)"/>
-            public static unsafe bool QueryFrameCountNV(ref Display dpy, int screen, ref uint count)
-            {
-                bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (uint* count_ptr = &count)
                 {
-                    returnValue = QueryFrameCountNV(dpy_ptr, screen, count_ptr);
+                    returnValue = QueryFrameCountNV(dpy, screen, count_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="QueryMaxSwapGroupsNV(Display*, int, uint*, uint*)"/>
-            public static unsafe bool QueryMaxSwapGroupsNV(ref Display dpy, int screen, ref uint maxGroups, ref uint maxBarriers)
+            /// <inheritdoc cref="QueryMaxSwapGroupsNV(DisplayPtr, int, uint*, uint*)"/>
+            public static unsafe bool QueryMaxSwapGroupsNV(DisplayPtr dpy, int screen, ref uint maxGroups, ref uint maxBarriers)
             {
                 bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (uint* maxGroups_ptr = &maxGroups)
                 fixed (uint* maxBarriers_ptr = &maxBarriers)
                 {
-                    returnValue = QueryMaxSwapGroupsNV(dpy_ptr, screen, maxGroups_ptr, maxBarriers_ptr);
+                    returnValue = QueryMaxSwapGroupsNV(dpy, screen, maxGroups_ptr, maxBarriers_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="QuerySwapGroupNV(Display*, GLXDrawable, uint*, uint*)"/>
-            public static unsafe bool QuerySwapGroupNV(ref Display dpy, GLXDrawable drawable, ref uint group, ref uint barrier)
+            /// <inheritdoc cref="QuerySwapGroupNV(DisplayPtr, GLXDrawable, uint*, uint*)"/>
+            public static unsafe bool QuerySwapGroupNV(DisplayPtr dpy, GLXDrawable drawable, ref uint group, ref uint barrier)
             {
                 bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (uint* group_ptr = &group)
                 fixed (uint* barrier_ptr = &barrier)
                 {
-                    returnValue = QuerySwapGroupNV(dpy_ptr, drawable, group_ptr, barrier_ptr);
+                    returnValue = QuerySwapGroupNV(dpy, drawable, group_ptr, barrier_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="QueryVideoCaptureDeviceNV(Display*, GLXVideoCaptureDeviceNV, int, int*)"/>
-            public static unsafe int QueryVideoCaptureDeviceNV(ref Display dpy, GLXVideoCaptureDeviceNV device, int attribute, ref int value)
+            /// <inheritdoc cref="QueryVideoCaptureDeviceNV(DisplayPtr, GLXVideoCaptureDeviceNV, int, int*)"/>
+            public static unsafe int QueryVideoCaptureDeviceNV(DisplayPtr dpy, GLXVideoCaptureDeviceNV device, int attribute, ref int value)
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* value_ptr = &value)
                 {
-                    returnValue = QueryVideoCaptureDeviceNV(dpy_ptr, device, attribute, value_ptr);
+                    returnValue = QueryVideoCaptureDeviceNV(dpy, device, attribute, value_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="ReleaseVideoCaptureDeviceNV(Display*, GLXVideoCaptureDeviceNV)"/>
-            public static unsafe void ReleaseVideoCaptureDeviceNV(ref Display dpy, GLXVideoCaptureDeviceNV device)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    ReleaseVideoCaptureDeviceNV(dpy_ptr, device);
-                }
-            }
-            /// <inheritdoc cref="ReleaseVideoDeviceNV(Display*, int, GLXVideoDeviceNV)"/>
-            public static unsafe int ReleaseVideoDeviceNV(ref Display dpy, int screen, GLXVideoDeviceNV VideoDevice)
+            /// <inheritdoc cref="SendPbufferToVideoNV(DisplayPtr, GLXPbuffer, int, ulong*, bool)"/>
+            public static unsafe int SendPbufferToVideoNV(DisplayPtr dpy, GLXPbuffer pbuf, int iBufferType, ref ulong pulCounterPbuffer, bool bBlock)
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = ReleaseVideoDeviceNV(dpy_ptr, screen, VideoDevice);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="ReleaseVideoImageNV(Display*, GLXPbuffer)"/>
-            public static unsafe int ReleaseVideoImageNV(ref Display dpy, GLXPbuffer pbuf)
-            {
-                int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = ReleaseVideoImageNV(dpy_ptr, pbuf);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="ResetFrameCountNV(Display*, int)"/>
-            public static unsafe bool ResetFrameCountNV(ref Display dpy, int screen)
-            {
-                bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = ResetFrameCountNV(dpy_ptr, screen);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="SendPbufferToVideoNV(Display*, GLXPbuffer, int, ulong*, bool)"/>
-            public static unsafe int SendPbufferToVideoNV(ref Display dpy, GLXPbuffer pbuf, int iBufferType, ref ulong pulCounterPbuffer, bool bBlock)
-            {
-                int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (ulong* pulCounterPbuffer_ptr = &pulCounterPbuffer)
                 {
-                    returnValue = SendPbufferToVideoNV(dpy_ptr, pbuf, iBufferType, pulCounterPbuffer_ptr, bBlock);
+                    returnValue = SendPbufferToVideoNV(dpy, pbuf, iBufferType, pulCounterPbuffer_ptr, bBlock);
                 }
                 return returnValue;
             }
         }
         public static unsafe partial class OML
         {
-            /// <inheritdoc cref="GetMscRateOML(Display*, GLXDrawable, int*, int*)"/>
-            public static unsafe bool GetMscRateOML(ref Display dpy, GLXDrawable drawable, ref int numerator, ref int denominator)
+            /// <inheritdoc cref="GetMscRateOML(DisplayPtr, GLXDrawable, int*, int*)"/>
+            public static unsafe bool GetMscRateOML(DisplayPtr dpy, GLXDrawable drawable, ref int numerator, ref int denominator)
             {
                 bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* numerator_ptr = &numerator)
                 fixed (int* denominator_ptr = &denominator)
                 {
-                    returnValue = GetMscRateOML(dpy_ptr, drawable, numerator_ptr, denominator_ptr);
+                    returnValue = GetMscRateOML(dpy, drawable, numerator_ptr, denominator_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="GetSyncValuesOML(Display*, GLXDrawable, long*, long*, long*)"/>
-            public static unsafe bool GetSyncValuesOML(ref Display dpy, GLXDrawable drawable, ref long ust, ref long msc, ref long sbc)
+            /// <inheritdoc cref="GetSyncValuesOML(DisplayPtr, GLXDrawable, long*, long*, long*)"/>
+            public static unsafe bool GetSyncValuesOML(DisplayPtr dpy, GLXDrawable drawable, ref long ust, ref long msc, ref long sbc)
             {
                 bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (long* ust_ptr = &ust)
                 fixed (long* msc_ptr = &msc)
                 fixed (long* sbc_ptr = &sbc)
                 {
-                    returnValue = GetSyncValuesOML(dpy_ptr, drawable, ust_ptr, msc_ptr, sbc_ptr);
+                    returnValue = GetSyncValuesOML(dpy, drawable, ust_ptr, msc_ptr, sbc_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="SwapBuffersMscOML(Display*, GLXDrawable, long, long, long)"/>
-            public static unsafe long SwapBuffersMscOML(ref Display dpy, GLXDrawable drawable, long target_msc, long divisor, long remainder)
-            {
-                long returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = SwapBuffersMscOML(dpy_ptr, drawable, target_msc, divisor, remainder);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="WaitForMscOML(Display*, GLXDrawable, long, long, long, long*, long*, long*)"/>
-            public static unsafe bool WaitForMscOML(ref Display dpy, GLXDrawable drawable, long target_msc, long divisor, long remainder, ref long ust, ref long msc, ref long sbc)
+            /// <inheritdoc cref="WaitForMscOML(DisplayPtr, GLXDrawable, long, long, long, long*, long*, long*)"/>
+            public static unsafe bool WaitForMscOML(DisplayPtr dpy, GLXDrawable drawable, long target_msc, long divisor, long remainder, ref long ust, ref long msc, ref long sbc)
             {
                 bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (long* ust_ptr = &ust)
                 fixed (long* msc_ptr = &msc)
                 fixed (long* sbc_ptr = &sbc)
                 {
-                    returnValue = WaitForMscOML(dpy_ptr, drawable, target_msc, divisor, remainder, ust_ptr, msc_ptr, sbc_ptr);
+                    returnValue = WaitForMscOML(dpy, drawable, target_msc, divisor, remainder, ust_ptr, msc_ptr, sbc_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="WaitForSbcOML(Display*, GLXDrawable, long, long*, long*, long*)"/>
-            public static unsafe bool WaitForSbcOML(ref Display dpy, GLXDrawable drawable, long target_sbc, ref long ust, ref long msc, ref long sbc)
+            /// <inheritdoc cref="WaitForSbcOML(DisplayPtr, GLXDrawable, long, long*, long*, long*)"/>
+            public static unsafe bool WaitForSbcOML(DisplayPtr dpy, GLXDrawable drawable, long target_sbc, ref long ust, ref long msc, ref long sbc)
             {
                 bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (long* ust_ptr = &ust)
                 fixed (long* msc_ptr = &msc)
                 fixed (long* sbc_ptr = &sbc)
                 {
-                    returnValue = WaitForSbcOML(dpy_ptr, drawable, target_sbc, ust_ptr, msc_ptr, sbc_ptr);
+                    returnValue = WaitForSbcOML(dpy, drawable, target_sbc, ust_ptr, msc_ptr, sbc_ptr);
                 }
                 return returnValue;
             }
         }
         public static unsafe partial class SGI
         {
-            /// <inheritdoc cref="CushionSGI(Display*, Window, float)"/>
-            public static unsafe void CushionSGI(ref Display dpy, Window window, float cushion)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    CushionSGI(dpy_ptr, window, cushion);
-                }
-            }
             /// <inheritdoc cref="GetVideoSyncSGI(uint*)"/>
             public static unsafe int GetVideoSyncSGI(ref uint count)
             {
@@ -869,16 +488,6 @@ namespace OpenTK.Graphics.Glx
                 fixed (uint* count_ptr = &count)
                 {
                     returnValue = GetVideoSyncSGI(count_ptr);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="MakeCurrentReadSGI(Display*, GLXDrawable, GLXDrawable, GLXContext)"/>
-            public static unsafe bool MakeCurrentReadSGI(ref Display dpy, GLXDrawable draw, GLXDrawable read, GLXContext ctx)
-            {
-                bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = MakeCurrentReadSGI(dpy_ptr, draw, read, ctx);
                 }
                 return returnValue;
             }
@@ -895,337 +504,190 @@ namespace OpenTK.Graphics.Glx
         }
         public static unsafe partial class SGIX
         {
-            /// <inheritdoc cref="BindChannelToWindowSGIX(Display*, int, int, Window)"/>
-            public static unsafe int BindChannelToWindowSGIX(ref Display display, int screen, int channel, Window window)
-            {
-                int returnValue;
-                fixed (Display* display_ptr = &display)
-                {
-                    returnValue = BindChannelToWindowSGIX(display_ptr, screen, channel, window);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="BindHyperpipeSGIX(Display*, int)"/>
-            public static unsafe int BindHyperpipeSGIX(ref Display dpy, int hpId)
-            {
-                int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = BindHyperpipeSGIX(dpy_ptr, hpId);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="BindSwapBarrierSGIX(Display*, GLXDrawable, int)"/>
-            public static unsafe void BindSwapBarrierSGIX(ref Display dpy, GLXDrawable drawable, int barrier)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    BindSwapBarrierSGIX(dpy_ptr, drawable, barrier);
-                }
-            }
-            /// <inheritdoc cref="ChannelRectSGIX(Display*, int, int, int, int, int, int)"/>
-            public static unsafe int ChannelRectSGIX(ref Display display, int screen, int channel, int x, int y, int w, int h)
-            {
-                int returnValue;
-                fixed (Display* display_ptr = &display)
-                {
-                    returnValue = ChannelRectSGIX(display_ptr, screen, channel, x, y, w, h);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="ChannelRectSyncSGIX(Display*, int, int, All)"/>
-            public static unsafe int ChannelRectSyncSGIX(ref Display display, int screen, int channel, All synctype)
-            {
-                int returnValue;
-                fixed (Display* display_ptr = &display)
-                {
-                    returnValue = ChannelRectSyncSGIX(display_ptr, screen, channel, synctype);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="ChooseFBConfigSGIX(Display*, int, int*, int*)"/>
-            public static unsafe GLXFBConfigSGIX* ChooseFBConfigSGIX(ref Display dpy, int screen, ref int attrib_list, ref int nelements)
+            /// <inheritdoc cref="ChooseFBConfigSGIX(DisplayPtr, int, int*, int*)"/>
+            public static unsafe GLXFBConfigSGIX* ChooseFBConfigSGIX(DisplayPtr dpy, int screen, ref int attrib_list, ref int nelements)
             {
                 GLXFBConfigSGIX* returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* attrib_list_ptr = &attrib_list)
                 fixed (int* nelements_ptr = &nelements)
                 {
-                    returnValue = ChooseFBConfigSGIX(dpy_ptr, screen, attrib_list_ptr, nelements_ptr);
+                    returnValue = ChooseFBConfigSGIX(dpy, screen, attrib_list_ptr, nelements_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="CreateContextWithConfigSGIX(Display*, GLXFBConfigSGIX, int, GLXContext, bool)"/>
-            public static unsafe GLXContext CreateContextWithConfigSGIX(ref Display dpy, GLXFBConfigSGIX config, int render_type, GLXContext share_list, bool direct)
-            {
-                GLXContext returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = CreateContextWithConfigSGIX(dpy_ptr, config, render_type, share_list, direct);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="CreateGLXPbufferSGIX(Display*, GLXFBConfigSGIX, uint, uint, int*)"/>
-            public static unsafe GLXPbufferSGIX CreateGLXPbufferSGIX(ref Display dpy, GLXFBConfigSGIX config, uint width, uint height, ref int attrib_list)
+            /// <inheritdoc cref="CreateGLXPbufferSGIX(DisplayPtr, GLXFBConfigSGIX, uint, uint, int*)"/>
+            public static unsafe GLXPbufferSGIX CreateGLXPbufferSGIX(DisplayPtr dpy, GLXFBConfigSGIX config, uint width, uint height, ref int attrib_list)
             {
                 GLXPbufferSGIX returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* attrib_list_ptr = &attrib_list)
                 {
-                    returnValue = CreateGLXPbufferSGIX(dpy_ptr, config, width, height, attrib_list_ptr);
+                    returnValue = CreateGLXPbufferSGIX(dpy, config, width, height, attrib_list_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="CreateGLXPixmapWithConfigSGIX(Display*, GLXFBConfigSGIX, Pixmap)"/>
-            public static unsafe GLXPixmap CreateGLXPixmapWithConfigSGIX(ref Display dpy, GLXFBConfigSGIX config, Pixmap pixmap)
-            {
-                GLXPixmap returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = CreateGLXPixmapWithConfigSGIX(dpy_ptr, config, pixmap);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="DestroyGLXPbufferSGIX(Display*, GLXPbufferSGIX)"/>
-            public static unsafe void DestroyGLXPbufferSGIX(ref Display dpy, GLXPbufferSGIX pbuf)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    DestroyGLXPbufferSGIX(dpy_ptr, pbuf);
-                }
-            }
-            /// <inheritdoc cref="DestroyHyperpipeConfigSGIX(Display*, int)"/>
-            public static unsafe int DestroyHyperpipeConfigSGIX(ref Display dpy, int hpId)
+            /// <inheritdoc cref="GetFBConfigAttribSGIX(DisplayPtr, GLXFBConfigSGIX, int, int*)"/>
+            public static unsafe int GetFBConfigAttribSGIX(DisplayPtr dpy, GLXFBConfigSGIX config, int attribute, ref int value)
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = DestroyHyperpipeConfigSGIX(dpy_ptr, hpId);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="GetFBConfigAttribSGIX(Display*, GLXFBConfigSGIX, int, int*)"/>
-            public static unsafe int GetFBConfigAttribSGIX(ref Display dpy, GLXFBConfigSGIX config, int attribute, ref int value)
-            {
-                int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* value_ptr = &value)
                 {
-                    returnValue = GetFBConfigAttribSGIX(dpy_ptr, config, attribute, value_ptr);
+                    returnValue = GetFBConfigAttribSGIX(dpy, config, attribute, value_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="GetFBConfigFromVisualSGIX(Display*, XVisualInfo*)"/>
-            public static unsafe GLXFBConfigSGIX GetFBConfigFromVisualSGIX(ref Display dpy, ref XVisualInfo vis)
+            /// <inheritdoc cref="GetSelectedEventSGIX(DisplayPtr, GLXDrawable, ulong*)"/>
+            public static unsafe void GetSelectedEventSGIX(DisplayPtr dpy, GLXDrawable drawable, ref ulong mask)
             {
-                GLXFBConfigSGIX returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                fixed (XVisualInfo* vis_ptr = &vis)
-                {
-                    returnValue = GetFBConfigFromVisualSGIX(dpy_ptr, vis_ptr);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="GetSelectedEventSGIX(Display*, GLXDrawable, ulong*)"/>
-            public static unsafe void GetSelectedEventSGIX(ref Display dpy, GLXDrawable drawable, ref ulong mask)
-            {
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (ulong* mask_ptr = &mask)
                 {
-                    GetSelectedEventSGIX(dpy_ptr, drawable, mask_ptr);
+                    GetSelectedEventSGIX(dpy, drawable, mask_ptr);
                 }
             }
-            /// <inheritdoc cref="GetVisualFromFBConfigSGIX(Display*, GLXFBConfigSGIX)"/>
-            public static unsafe XVisualInfo* GetVisualFromFBConfigSGIX(ref Display dpy, GLXFBConfigSGIX config)
-            {
-                XVisualInfo* returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    returnValue = GetVisualFromFBConfigSGIX(dpy_ptr, config);
-                }
-                return returnValue;
-            }
-            /// <inheritdoc cref="HyperpipeAttribSGIX(Display*, int, int, int, void*)"/>
-            public static unsafe int HyperpipeAttribSGIX(ref Display dpy, int timeSlice, int attrib, int size, IntPtr attribList)
+            /// <inheritdoc cref="HyperpipeAttribSGIX(DisplayPtr, int, int, int, void*)"/>
+            public static unsafe int HyperpipeAttribSGIX(DisplayPtr dpy, int timeSlice, int attrib, int size, IntPtr attribList)
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    void* attribList_vptr = (void*)attribList;
-                    returnValue = HyperpipeAttribSGIX(dpy_ptr, timeSlice, attrib, size, attribList_vptr);
-                }
+                void* attribList_vptr = (void*)attribList;
+                returnValue = HyperpipeAttribSGIX(dpy, timeSlice, attrib, size, attribList_vptr);
                 return returnValue;
             }
-            /// <inheritdoc cref="HyperpipeAttribSGIX(Display*, int, int, int, void*)"/>
-            public static unsafe int HyperpipeAttribSGIX<T1>(ref Display dpy, int timeSlice, int attrib, int size, ref T1 attribList)
+            /// <inheritdoc cref="HyperpipeAttribSGIX(DisplayPtr, int, int, int, void*)"/>
+            public static unsafe int HyperpipeAttribSGIX<T1>(DisplayPtr dpy, int timeSlice, int attrib, int size, ref T1 attribList)
                 where T1 : unmanaged
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (void* attribList_ptr = &attribList)
                 {
-                    returnValue = HyperpipeAttribSGIX(dpy_ptr, timeSlice, attrib, size, attribList_ptr);
+                    returnValue = HyperpipeAttribSGIX(dpy, timeSlice, attrib, size, attribList_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="HyperpipeConfigSGIX(Display*, int, int, GLXHyperpipeConfigSGIX*, int*)"/>
-            public static unsafe int HyperpipeConfigSGIX(ref Display dpy, int networkId, int npipes, ref GLXHyperpipeConfigSGIX cfg, ref int hpId)
+            /// <inheritdoc cref="HyperpipeConfigSGIX(DisplayPtr, int, int, GLXHyperpipeConfigSGIX*, int*)"/>
+            public static unsafe int HyperpipeConfigSGIX(DisplayPtr dpy, int networkId, int npipes, ref GLXHyperpipeConfigSGIX cfg, ref int hpId)
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (GLXHyperpipeConfigSGIX* cfg_ptr = &cfg)
                 fixed (int* hpId_ptr = &hpId)
                 {
-                    returnValue = HyperpipeConfigSGIX(dpy_ptr, networkId, npipes, cfg_ptr, hpId_ptr);
+                    returnValue = HyperpipeConfigSGIX(dpy, networkId, npipes, cfg_ptr, hpId_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="JoinSwapGroupSGIX(Display*, GLXDrawable, GLXDrawable)"/>
-            public static unsafe void JoinSwapGroupSGIX(ref Display dpy, GLXDrawable drawable, GLXDrawable member)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    JoinSwapGroupSGIX(dpy_ptr, drawable, member);
-                }
-            }
-            /// <inheritdoc cref="QueryChannelDeltasSGIX(Display*, int, int, int*, int*, int*, int*)"/>
-            public static unsafe int QueryChannelDeltasSGIX(ref Display display, int screen, int channel, ref int x, ref int y, ref int w, ref int h)
+            /// <inheritdoc cref="QueryChannelDeltasSGIX(DisplayPtr, int, int, int*, int*, int*, int*)"/>
+            public static unsafe int QueryChannelDeltasSGIX(DisplayPtr display, int screen, int channel, ref int x, ref int y, ref int w, ref int h)
             {
                 int returnValue;
-                fixed (Display* display_ptr = &display)
                 fixed (int* x_ptr = &x)
                 fixed (int* y_ptr = &y)
                 fixed (int* w_ptr = &w)
                 fixed (int* h_ptr = &h)
                 {
-                    returnValue = QueryChannelDeltasSGIX(display_ptr, screen, channel, x_ptr, y_ptr, w_ptr, h_ptr);
+                    returnValue = QueryChannelDeltasSGIX(display, screen, channel, x_ptr, y_ptr, w_ptr, h_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="QueryChannelRectSGIX(Display*, int, int, int*, int*, int*, int*)"/>
-            public static unsafe int QueryChannelRectSGIX(ref Display display, int screen, int channel, ref int dx, ref int dy, ref int dw, ref int dh)
+            /// <inheritdoc cref="QueryChannelRectSGIX(DisplayPtr, int, int, int*, int*, int*, int*)"/>
+            public static unsafe int QueryChannelRectSGIX(DisplayPtr display, int screen, int channel, ref int dx, ref int dy, ref int dw, ref int dh)
             {
                 int returnValue;
-                fixed (Display* display_ptr = &display)
                 fixed (int* dx_ptr = &dx)
                 fixed (int* dy_ptr = &dy)
                 fixed (int* dw_ptr = &dw)
                 fixed (int* dh_ptr = &dh)
                 {
-                    returnValue = QueryChannelRectSGIX(display_ptr, screen, channel, dx_ptr, dy_ptr, dw_ptr, dh_ptr);
+                    returnValue = QueryChannelRectSGIX(display, screen, channel, dx_ptr, dy_ptr, dw_ptr, dh_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="QueryGLXPbufferSGIX(Display*, GLXPbufferSGIX, int, uint*)"/>
-            public static unsafe void QueryGLXPbufferSGIX(ref Display dpy, GLXPbufferSGIX pbuf, int attribute, ref uint value)
+            /// <inheritdoc cref="QueryGLXPbufferSGIX(DisplayPtr, GLXPbufferSGIX, int, uint*)"/>
+            public static unsafe void QueryGLXPbufferSGIX(DisplayPtr dpy, GLXPbufferSGIX pbuf, int attribute, ref uint value)
             {
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (uint* value_ptr = &value)
                 {
-                    QueryGLXPbufferSGIX(dpy_ptr, pbuf, attribute, value_ptr);
+                    QueryGLXPbufferSGIX(dpy, pbuf, attribute, value_ptr);
                 }
             }
-            /// <inheritdoc cref="QueryHyperpipeAttribSGIX(Display*, int, int, int, void*)"/>
-            public static unsafe int QueryHyperpipeAttribSGIX(ref Display dpy, int timeSlice, int attrib, int size, IntPtr returnAttribList)
+            /// <inheritdoc cref="QueryHyperpipeAttribSGIX(DisplayPtr, int, int, int, void*)"/>
+            public static unsafe int QueryHyperpipeAttribSGIX(DisplayPtr dpy, int timeSlice, int attrib, int size, IntPtr returnAttribList)
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    void* returnAttribList_vptr = (void*)returnAttribList;
-                    returnValue = QueryHyperpipeAttribSGIX(dpy_ptr, timeSlice, attrib, size, returnAttribList_vptr);
-                }
+                void* returnAttribList_vptr = (void*)returnAttribList;
+                returnValue = QueryHyperpipeAttribSGIX(dpy, timeSlice, attrib, size, returnAttribList_vptr);
                 return returnValue;
             }
-            /// <inheritdoc cref="QueryHyperpipeAttribSGIX(Display*, int, int, int, void*)"/>
-            public static unsafe int QueryHyperpipeAttribSGIX<T1>(ref Display dpy, int timeSlice, int attrib, int size, ref T1 returnAttribList)
+            /// <inheritdoc cref="QueryHyperpipeAttribSGIX(DisplayPtr, int, int, int, void*)"/>
+            public static unsafe int QueryHyperpipeAttribSGIX<T1>(DisplayPtr dpy, int timeSlice, int attrib, int size, ref T1 returnAttribList)
                 where T1 : unmanaged
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (void* returnAttribList_ptr = &returnAttribList)
                 {
-                    returnValue = QueryHyperpipeAttribSGIX(dpy_ptr, timeSlice, attrib, size, returnAttribList_ptr);
+                    returnValue = QueryHyperpipeAttribSGIX(dpy, timeSlice, attrib, size, returnAttribList_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="QueryHyperpipeBestAttribSGIX(Display*, int, int, int, void*, void*)"/>
-            public static unsafe int QueryHyperpipeBestAttribSGIX(ref Display dpy, int timeSlice, int attrib, int size, IntPtr attribList, IntPtr returnAttribList)
+            /// <inheritdoc cref="QueryHyperpipeBestAttribSGIX(DisplayPtr, int, int, int, void*, void*)"/>
+            public static unsafe int QueryHyperpipeBestAttribSGIX(DisplayPtr dpy, int timeSlice, int attrib, int size, IntPtr attribList, IntPtr returnAttribList)
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    void* attribList_vptr = (void*)attribList;
-                    void* returnAttribList_vptr = (void*)returnAttribList;
-                    returnValue = QueryHyperpipeBestAttribSGIX(dpy_ptr, timeSlice, attrib, size, attribList_vptr, returnAttribList_vptr);
-                }
+                void* attribList_vptr = (void*)attribList;
+                void* returnAttribList_vptr = (void*)returnAttribList;
+                returnValue = QueryHyperpipeBestAttribSGIX(dpy, timeSlice, attrib, size, attribList_vptr, returnAttribList_vptr);
                 return returnValue;
             }
-            /// <inheritdoc cref="QueryHyperpipeBestAttribSGIX(Display*, int, int, int, void*, void*)"/>
-            public static unsafe int QueryHyperpipeBestAttribSGIX<T1, T2>(ref Display dpy, int timeSlice, int attrib, int size, ref T1 attribList, ref T2 returnAttribList)
+            /// <inheritdoc cref="QueryHyperpipeBestAttribSGIX(DisplayPtr, int, int, int, void*, void*)"/>
+            public static unsafe int QueryHyperpipeBestAttribSGIX<T1, T2>(DisplayPtr dpy, int timeSlice, int attrib, int size, ref T1 attribList, ref T2 returnAttribList)
                 where T1 : unmanaged
                 where T2 : unmanaged
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (void* attribList_ptr = &attribList)
                 fixed (void* returnAttribList_ptr = &returnAttribList)
                 {
-                    returnValue = QueryHyperpipeBestAttribSGIX(dpy_ptr, timeSlice, attrib, size, attribList_ptr, returnAttribList_ptr);
+                    returnValue = QueryHyperpipeBestAttribSGIX(dpy, timeSlice, attrib, size, attribList_ptr, returnAttribList_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="QueryHyperpipeConfigSGIX(Display*, int, int*)"/>
-            public static unsafe GLXHyperpipeConfigSGIX* QueryHyperpipeConfigSGIX(ref Display dpy, int hpId, ref int npipes)
+            /// <inheritdoc cref="QueryHyperpipeConfigSGIX(DisplayPtr, int, int*)"/>
+            public static unsafe GLXHyperpipeConfigSGIX* QueryHyperpipeConfigSGIX(DisplayPtr dpy, int hpId, ref int npipes)
             {
                 GLXHyperpipeConfigSGIX* returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* npipes_ptr = &npipes)
                 {
-                    returnValue = QueryHyperpipeConfigSGIX(dpy_ptr, hpId, npipes_ptr);
+                    returnValue = QueryHyperpipeConfigSGIX(dpy, hpId, npipes_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="QueryHyperpipeNetworkSGIX(Display*, int*)"/>
-            public static unsafe GLXHyperpipeNetworkSGIX* QueryHyperpipeNetworkSGIX(ref Display dpy, ref int npipes)
+            /// <inheritdoc cref="QueryHyperpipeNetworkSGIX(DisplayPtr, int*)"/>
+            public static unsafe GLXHyperpipeNetworkSGIX* QueryHyperpipeNetworkSGIX(DisplayPtr dpy, ref int npipes)
             {
                 GLXHyperpipeNetworkSGIX* returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* npipes_ptr = &npipes)
                 {
-                    returnValue = QueryHyperpipeNetworkSGIX(dpy_ptr, npipes_ptr);
+                    returnValue = QueryHyperpipeNetworkSGIX(dpy, npipes_ptr);
                 }
                 return returnValue;
             }
-            /// <inheritdoc cref="QueryMaxSwapBarriersSGIX(Display*, int, int*)"/>
-            public static unsafe bool QueryMaxSwapBarriersSGIX(ref Display dpy, int screen, ref int max)
+            /// <inheritdoc cref="QueryMaxSwapBarriersSGIX(DisplayPtr, int, int*)"/>
+            public static unsafe bool QueryMaxSwapBarriersSGIX(DisplayPtr dpy, int screen, ref int max)
             {
                 bool returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (int* max_ptr = &max)
                 {
-                    returnValue = QueryMaxSwapBarriersSGIX(dpy_ptr, screen, max_ptr);
+                    returnValue = QueryMaxSwapBarriersSGIX(dpy, screen, max_ptr);
                 }
                 return returnValue;
-            }
-            /// <inheritdoc cref="SelectEventSGIX(Display*, GLXDrawable, ulong)"/>
-            public static unsafe void SelectEventSGIX(ref Display dpy, GLXDrawable drawable, ulong mask)
-            {
-                fixed (Display* dpy_ptr = &dpy)
-                {
-                    SelectEventSGIX(dpy_ptr, drawable, mask);
-                }
             }
         }
         public static unsafe partial class SUN
         {
-            /// <inheritdoc cref="GetTransparentIndexSUN(Display*, Window, Window, ulong*)"/>
-            public static unsafe int GetTransparentIndexSUN(ref Display dpy, Window overlay, Window underlay, ref ulong pTransparentIndex)
+            /// <inheritdoc cref="GetTransparentIndexSUN(DisplayPtr, Window, Window, ulong*)"/>
+            public static unsafe int GetTransparentIndexSUN(DisplayPtr dpy, Window overlay, Window underlay, ref ulong pTransparentIndex)
             {
                 int returnValue;
-                fixed (Display* dpy_ptr = &dpy)
                 fixed (ulong* pTransparentIndex_ptr = &pTransparentIndex)
                 {
-                    returnValue = GetTransparentIndexSUN(dpy_ptr, overlay, underlay, pTransparentIndex_ptr);
+                    returnValue = GetTransparentIndexSUN(dpy, overlay, underlay, pTransparentIndex_ptr);
                 }
                 return returnValue;
             }

--- a/src/OpenTK.Graphics/Glx/GLX.Overloads.cs
+++ b/src/OpenTK.Graphics/Glx/GLX.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGL.Compatibility

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGL.Compatibility

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/Compatibility/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/OpenTK.Graphics/OpenGL/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGL/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGL

--- a/src/OpenTK.Graphics/OpenGL/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGL/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGL

--- a/src/OpenTK.Graphics/OpenGL/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/OpenGL/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGL/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/OpenTK.Graphics/OpenGLES1/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGLES1

--- a/src/OpenTK.Graphics/OpenGLES1/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGLES1

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES1/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/OpenTK.Graphics/OpenGLES2/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGLES2/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGLES2

--- a/src/OpenTK.Graphics/OpenGLES2/Enums.cs
+++ b/src/OpenTK.Graphics/OpenGLES2/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.OpenGLES2

--- a/src/OpenTK.Graphics/OpenGLES2/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGLES2/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/OpenGLES2/GL.Native.cs
+++ b/src/OpenTK.Graphics/OpenGLES2/GL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/OpenGLES2/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES2/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/OpenTK.Graphics/OpenGLES2/GL.Overloads.cs
+++ b/src/OpenTK.Graphics/OpenGLES2/GL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/OpenTK.Graphics/Types.cs
+++ b/src/OpenTK.Graphics/Types.cs
@@ -45,18 +45,50 @@ namespace OpenTK.Graphics
     namespace Glx
     {
         /// <summary>
-        /// Opaque struct for X11 display.
+        /// Opaque struct pointer for X11 <c>Display*</c>.
         /// </summary>
-        public struct Display { }
-
-        public struct DisplayPtr {
+        public struct DisplayPtr
+        {
+            /// <summary>
+            /// The underlying pointer value.
+            /// </summary>
             public IntPtr Value;
+
+            /// <summary>
+            /// Constructs a new <c>Display*</c> wrapper struct from a <c>Display</c> pointer.
+            /// </summary>
+            /// <param name="value">The display pointer.</param>
+            public DisplayPtr(IntPtr value)
+            {
+                Value = value;
+            }
+
+            public static explicit operator IntPtr(DisplayPtr handle) => handle.Value;
+            public static explicit operator DisplayPtr(IntPtr ptr) => new DisplayPtr(ptr);
         }
 
         /// <summary>
-        /// Opaque struct for X11 screen.
+        /// Opaque struct pointer for X11 <c>Screen*</c>.
         /// </summary>
-        public struct Screen { }
+        public struct ScreenPtr
+        {
+            /// <summary>
+            /// The underlying pointer value.
+            /// </summary>
+            public IntPtr Value;
+
+            /// <summary>
+            /// Constructs a new <c>Screen*</c> wrapper struct from a <c>Screen</c> pointer.
+            /// </summary>
+            /// <param name="value">The screen pointer.</param>
+            public ScreenPtr(IntPtr value)
+            {
+                Value = value;
+            }
+
+            public static explicit operator IntPtr(ScreenPtr handle) => handle.Value;
+            public static explicit operator ScreenPtr(IntPtr ptr) => new ScreenPtr(ptr);
+        }
 
         /// <summary>
         /// An X11 window handle.
@@ -151,9 +183,27 @@ namespace OpenTK.Graphics
         }
 
         /// <summary>
-        /// Opaque struct for X11 XVisualInfo.
+        /// Opaque struct pointer for X11 <c>XVisualInfo*</c>.
         /// </summary>
-        public struct XVisualInfo { }
+        public struct XVisualInfoPtr 
+        {
+            /// <summary>
+            /// The underlying pointer value.
+            /// </summary>
+            public IntPtr Value;
+
+            /// <summary>
+            /// Constructs a new <c>XVisualInfo*</c> wrapper struct from a <c>XVisualInfo</c> pointer.
+            /// </summary>
+            /// <param name="value">The screen pointer.</param>
+            public XVisualInfoPtr(IntPtr value)
+            {
+                Value = value;
+            }
+
+            public static explicit operator IntPtr(XVisualInfoPtr handle) => handle.Value;
+            public static explicit operator XVisualInfoPtr(IntPtr ptr) => new XVisualInfoPtr(ptr);
+        }
 
         /// <summary>
         /// A GLX GLXFBConfigID handle.

--- a/src/OpenTK.Graphics/WGL.Pointers.cs
+++ b/src/OpenTK.Graphics/WGL.Pointers.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:58 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/WGL.Pointers.cs
+++ b/src/OpenTK.Graphics/WGL.Pointers.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;
@@ -13,7 +13,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int ChoosePixelFormat_Lazy(IntPtr hDc, PixelFormatDescriptor* pPfd)
         {
-            _ChoosePixelFormat_fnptr = (delegate* unmanaged<IntPtr, PixelFormatDescriptor*, int>)GLLoader.BindingsContext.GetProcAddress("ChoosePixelFormat");
+            _ChoosePixelFormat_fnptr = (delegate* unmanaged<IntPtr, PixelFormatDescriptor*, int>)WGLLoader.BindingsContext.GetProcAddress("ChoosePixelFormat");
             return _ChoosePixelFormat_fnptr(hDc, pPfd);
         }
         
@@ -22,7 +22,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int DescribePixelFormat_Lazy(IntPtr hdc, int ipfd, uint cjpfd, PixelFormatDescriptor* ppfd)
         {
-            _DescribePixelFormat_fnptr = (delegate* unmanaged<IntPtr, int, uint, PixelFormatDescriptor*, int>)GLLoader.BindingsContext.GetProcAddress("DescribePixelFormat");
+            _DescribePixelFormat_fnptr = (delegate* unmanaged<IntPtr, int, uint, PixelFormatDescriptor*, int>)WGLLoader.BindingsContext.GetProcAddress("DescribePixelFormat");
             return _DescribePixelFormat_fnptr(hdc, ipfd, cjpfd, ppfd);
         }
         
@@ -31,7 +31,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static uint GetEnhMetaFilePixelFormat_Lazy(IntPtr hemf, uint cbBuffer, PixelFormatDescriptor* ppfd)
         {
-            _GetEnhMetaFilePixelFormat_fnptr = (delegate* unmanaged<IntPtr, uint, PixelFormatDescriptor*, uint>)GLLoader.BindingsContext.GetProcAddress("GetEnhMetaFilePixelFormat");
+            _GetEnhMetaFilePixelFormat_fnptr = (delegate* unmanaged<IntPtr, uint, PixelFormatDescriptor*, uint>)WGLLoader.BindingsContext.GetProcAddress("GetEnhMetaFilePixelFormat");
             return _GetEnhMetaFilePixelFormat_fnptr(hemf, cbBuffer, ppfd);
         }
         
@@ -40,7 +40,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int GetPixelFormat_Lazy(IntPtr hdc)
         {
-            _GetPixelFormat_fnptr = (delegate* unmanaged<IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("GetPixelFormat");
+            _GetPixelFormat_fnptr = (delegate* unmanaged<IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("GetPixelFormat");
             return _GetPixelFormat_fnptr(hdc);
         }
         
@@ -49,7 +49,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int SetPixelFormat_Lazy(IntPtr hdc, int ipfd, PixelFormatDescriptor* ppfd)
         {
-            _SetPixelFormat_fnptr = (delegate* unmanaged<IntPtr, int, PixelFormatDescriptor*, int>)GLLoader.BindingsContext.GetProcAddress("SetPixelFormat");
+            _SetPixelFormat_fnptr = (delegate* unmanaged<IntPtr, int, PixelFormatDescriptor*, int>)WGLLoader.BindingsContext.GetProcAddress("SetPixelFormat");
             return _SetPixelFormat_fnptr(hdc, ipfd, ppfd);
         }
         
@@ -58,7 +58,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int SwapBuffers_Lazy(IntPtr hdc)
         {
-            _SwapBuffers_fnptr = (delegate* unmanaged<IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("SwapBuffers");
+            _SwapBuffers_fnptr = (delegate* unmanaged<IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("SwapBuffers");
             return _SwapBuffers_fnptr(hdc);
         }
         
@@ -67,7 +67,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static void* wglAllocateMemoryNV_Lazy(int size, float readfreq, float writefreq, float priority)
         {
-            _wglAllocateMemoryNV_fnptr = (delegate* unmanaged<int, float, float, float, void*>)GLLoader.BindingsContext.GetProcAddress("wglAllocateMemoryNV");
+            _wglAllocateMemoryNV_fnptr = (delegate* unmanaged<int, float, float, float, void*>)WGLLoader.BindingsContext.GetProcAddress("wglAllocateMemoryNV");
             return _wglAllocateMemoryNV_fnptr(size, readfreq, writefreq, priority);
         }
         
@@ -76,7 +76,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglAssociateImageBufferEventsI3D_Lazy(IntPtr hDC, IntPtr* pEvent, IntPtr* pAddress, uint* pSize, uint count)
         {
-            _wglAssociateImageBufferEventsI3D_fnptr = (delegate* unmanaged<IntPtr, IntPtr*, IntPtr*, uint*, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglAssociateImageBufferEventsI3D");
+            _wglAssociateImageBufferEventsI3D_fnptr = (delegate* unmanaged<IntPtr, IntPtr*, IntPtr*, uint*, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglAssociateImageBufferEventsI3D");
             return _wglAssociateImageBufferEventsI3D_fnptr(hDC, pEvent, pAddress, pSize, count);
         }
         
@@ -85,7 +85,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglBeginFrameTrackingI3D_Lazy()
         {
-            _wglBeginFrameTrackingI3D_fnptr = (delegate* unmanaged<int>)GLLoader.BindingsContext.GetProcAddress("wglBeginFrameTrackingI3D");
+            _wglBeginFrameTrackingI3D_fnptr = (delegate* unmanaged<int>)WGLLoader.BindingsContext.GetProcAddress("wglBeginFrameTrackingI3D");
             return _wglBeginFrameTrackingI3D_fnptr();
         }
         
@@ -94,7 +94,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static byte wglBindDisplayColorTableEXT_Lazy(ushort id)
         {
-            _wglBindDisplayColorTableEXT_fnptr = (delegate* unmanaged<ushort, byte>)GLLoader.BindingsContext.GetProcAddress("wglBindDisplayColorTableEXT");
+            _wglBindDisplayColorTableEXT_fnptr = (delegate* unmanaged<ushort, byte>)WGLLoader.BindingsContext.GetProcAddress("wglBindDisplayColorTableEXT");
             return _wglBindDisplayColorTableEXT_fnptr(id);
         }
         
@@ -103,7 +103,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglBindSwapBarrierNV_Lazy(uint group, uint barrier)
         {
-            _wglBindSwapBarrierNV_fnptr = (delegate* unmanaged<uint, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglBindSwapBarrierNV");
+            _wglBindSwapBarrierNV_fnptr = (delegate* unmanaged<uint, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglBindSwapBarrierNV");
             return _wglBindSwapBarrierNV_fnptr(group, barrier);
         }
         
@@ -112,7 +112,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglBindTexImageARB_Lazy(IntPtr hPbuffer, int iBuffer)
         {
-            _wglBindTexImageARB_fnptr = (delegate* unmanaged<IntPtr, int, int>)GLLoader.BindingsContext.GetProcAddress("wglBindTexImageARB");
+            _wglBindTexImageARB_fnptr = (delegate* unmanaged<IntPtr, int, int>)WGLLoader.BindingsContext.GetProcAddress("wglBindTexImageARB");
             return _wglBindTexImageARB_fnptr(hPbuffer, iBuffer);
         }
         
@@ -121,7 +121,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglBindVideoCaptureDeviceNV_Lazy(uint uVideoSlot, IntPtr hDevice)
         {
-            _wglBindVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<uint, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglBindVideoCaptureDeviceNV");
+            _wglBindVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<uint, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglBindVideoCaptureDeviceNV");
             return _wglBindVideoCaptureDeviceNV_fnptr(uVideoSlot, hDevice);
         }
         
@@ -130,7 +130,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglBindVideoDeviceNV_Lazy(IntPtr hDc, uint uVideoSlot, IntPtr hVideoDevice, int* piAttribList)
         {
-            _wglBindVideoDeviceNV_fnptr = (delegate* unmanaged<IntPtr, uint, IntPtr, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglBindVideoDeviceNV");
+            _wglBindVideoDeviceNV_fnptr = (delegate* unmanaged<IntPtr, uint, IntPtr, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglBindVideoDeviceNV");
             return _wglBindVideoDeviceNV_fnptr(hDc, uVideoSlot, hVideoDevice, piAttribList);
         }
         
@@ -139,7 +139,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglBindVideoImageNV_Lazy(IntPtr hVideoDevice, IntPtr hPbuffer, int iVideoBuffer)
         {
-            _wglBindVideoImageNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int, int>)GLLoader.BindingsContext.GetProcAddress("wglBindVideoImageNV");
+            _wglBindVideoImageNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int, int>)WGLLoader.BindingsContext.GetProcAddress("wglBindVideoImageNV");
             return _wglBindVideoImageNV_fnptr(hVideoDevice, hPbuffer, iVideoBuffer);
         }
         
@@ -148,7 +148,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static void wglBlitContextFramebufferAMD_Lazy(IntPtr dstCtx, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, uint mask, uint filter)
         {
-            _wglBlitContextFramebufferAMD_fnptr = (delegate* unmanaged<IntPtr, int, int, int, int, int, int, int, int, uint, uint, void>)GLLoader.BindingsContext.GetProcAddress("wglBlitContextFramebufferAMD");
+            _wglBlitContextFramebufferAMD_fnptr = (delegate* unmanaged<IntPtr, int, int, int, int, int, int, int, int, uint, uint, void>)WGLLoader.BindingsContext.GetProcAddress("wglBlitContextFramebufferAMD");
             _wglBlitContextFramebufferAMD_fnptr(dstCtx, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
         }
         
@@ -157,7 +157,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglChoosePixelFormatARB_Lazy(IntPtr hdc, int* piAttribIList, float* pfAttribFList, uint nMaxFormats, int* piFormats, uint* nNumFormats)
         {
-            _wglChoosePixelFormatARB_fnptr = (delegate* unmanaged<IntPtr, int*, float*, uint, int*, uint*, int>)GLLoader.BindingsContext.GetProcAddress("wglChoosePixelFormatARB");
+            _wglChoosePixelFormatARB_fnptr = (delegate* unmanaged<IntPtr, int*, float*, uint, int*, uint*, int>)WGLLoader.BindingsContext.GetProcAddress("wglChoosePixelFormatARB");
             return _wglChoosePixelFormatARB_fnptr(hdc, piAttribIList, pfAttribFList, nMaxFormats, piFormats, nNumFormats);
         }
         
@@ -166,7 +166,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglChoosePixelFormatEXT_Lazy(IntPtr hdc, int* piAttribIList, float* pfAttribFList, uint nMaxFormats, int* piFormats, uint* nNumFormats)
         {
-            _wglChoosePixelFormatEXT_fnptr = (delegate* unmanaged<IntPtr, int*, float*, uint, int*, uint*, int>)GLLoader.BindingsContext.GetProcAddress("wglChoosePixelFormatEXT");
+            _wglChoosePixelFormatEXT_fnptr = (delegate* unmanaged<IntPtr, int*, float*, uint, int*, uint*, int>)WGLLoader.BindingsContext.GetProcAddress("wglChoosePixelFormatEXT");
             return _wglChoosePixelFormatEXT_fnptr(hdc, piAttribIList, pfAttribFList, nMaxFormats, piFormats, nNumFormats);
         }
         
@@ -175,7 +175,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglCopyContext_Lazy(IntPtr hglrcSrc, IntPtr hglrcDst, uint mask)
         {
-            _wglCopyContext_fnptr = (delegate* unmanaged<IntPtr, IntPtr, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglCopyContext");
+            _wglCopyContext_fnptr = (delegate* unmanaged<IntPtr, IntPtr, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglCopyContext");
             return _wglCopyContext_fnptr(hglrcSrc, hglrcDst, mask);
         }
         
@@ -184,7 +184,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglCopyImageSubDataNV_Lazy(IntPtr hSrcRC, uint srcName, uint srcTarget, int srcLevel, int srcX, int srcY, int srcZ, IntPtr hDstRC, uint dstName, uint dstTarget, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth)
         {
-            _wglCopyImageSubDataNV_fnptr = (delegate* unmanaged<IntPtr, uint, uint, int, int, int, int, IntPtr, uint, uint, int, int, int, int, int, int, int, int>)GLLoader.BindingsContext.GetProcAddress("wglCopyImageSubDataNV");
+            _wglCopyImageSubDataNV_fnptr = (delegate* unmanaged<IntPtr, uint, uint, int, int, int, int, IntPtr, uint, uint, int, int, int, int, int, int, int, int>)WGLLoader.BindingsContext.GetProcAddress("wglCopyImageSubDataNV");
             return _wglCopyImageSubDataNV_fnptr(hSrcRC, srcName, srcTarget, srcLevel, srcX, srcY, srcZ, hDstRC, dstName, dstTarget, dstLevel, dstX, dstY, dstZ, width, height, depth);
         }
         
@@ -193,7 +193,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglCreateAffinityDCNV_Lazy(IntPtr* phGpuList)
         {
-            _wglCreateAffinityDCNV_fnptr = (delegate* unmanaged<IntPtr*, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglCreateAffinityDCNV");
+            _wglCreateAffinityDCNV_fnptr = (delegate* unmanaged<IntPtr*, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglCreateAffinityDCNV");
             return _wglCreateAffinityDCNV_fnptr(phGpuList);
         }
         
@@ -202,7 +202,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglCreateAssociatedContextAMD_Lazy(uint id)
         {
-            _wglCreateAssociatedContextAMD_fnptr = (delegate* unmanaged<uint, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglCreateAssociatedContextAMD");
+            _wglCreateAssociatedContextAMD_fnptr = (delegate* unmanaged<uint, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglCreateAssociatedContextAMD");
             return _wglCreateAssociatedContextAMD_fnptr(id);
         }
         
@@ -211,7 +211,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglCreateAssociatedContextAttribsAMD_Lazy(uint id, IntPtr hShareContext, int* attribList)
         {
-            _wglCreateAssociatedContextAttribsAMD_fnptr = (delegate* unmanaged<uint, IntPtr, int*, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglCreateAssociatedContextAttribsAMD");
+            _wglCreateAssociatedContextAttribsAMD_fnptr = (delegate* unmanaged<uint, IntPtr, int*, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglCreateAssociatedContextAttribsAMD");
             return _wglCreateAssociatedContextAttribsAMD_fnptr(id, hShareContext, attribList);
         }
         
@@ -220,7 +220,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglCreateBufferRegionARB_Lazy(IntPtr hDC, int iLayerPlane, uint uType)
         {
-            _wglCreateBufferRegionARB_fnptr = (delegate* unmanaged<IntPtr, int, uint, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglCreateBufferRegionARB");
+            _wglCreateBufferRegionARB_fnptr = (delegate* unmanaged<IntPtr, int, uint, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglCreateBufferRegionARB");
             return _wglCreateBufferRegionARB_fnptr(hDC, iLayerPlane, uType);
         }
         
@@ -229,7 +229,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglCreateContext_Lazy(IntPtr hDc)
         {
-            _wglCreateContext_fnptr = (delegate* unmanaged<IntPtr, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglCreateContext");
+            _wglCreateContext_fnptr = (delegate* unmanaged<IntPtr, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglCreateContext");
             return _wglCreateContext_fnptr(hDc);
         }
         
@@ -238,7 +238,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglCreateContextAttribsARB_Lazy(IntPtr hDC, IntPtr hShareContext, int* attribList)
         {
-            _wglCreateContextAttribsARB_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int*, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglCreateContextAttribsARB");
+            _wglCreateContextAttribsARB_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int*, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglCreateContextAttribsARB");
             return _wglCreateContextAttribsARB_fnptr(hDC, hShareContext, attribList);
         }
         
@@ -247,7 +247,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static byte wglCreateDisplayColorTableEXT_Lazy(ushort id)
         {
-            _wglCreateDisplayColorTableEXT_fnptr = (delegate* unmanaged<ushort, byte>)GLLoader.BindingsContext.GetProcAddress("wglCreateDisplayColorTableEXT");
+            _wglCreateDisplayColorTableEXT_fnptr = (delegate* unmanaged<ushort, byte>)WGLLoader.BindingsContext.GetProcAddress("wglCreateDisplayColorTableEXT");
             return _wglCreateDisplayColorTableEXT_fnptr(id);
         }
         
@@ -256,7 +256,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglCreateImageBufferI3D_Lazy(IntPtr hDC, uint dwSize, uint uFlags)
         {
-            _wglCreateImageBufferI3D_fnptr = (delegate* unmanaged<IntPtr, uint, uint, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglCreateImageBufferI3D");
+            _wglCreateImageBufferI3D_fnptr = (delegate* unmanaged<IntPtr, uint, uint, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglCreateImageBufferI3D");
             return _wglCreateImageBufferI3D_fnptr(hDC, dwSize, uFlags);
         }
         
@@ -265,7 +265,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglCreateLayerContext_Lazy(IntPtr hDc, int level)
         {
-            _wglCreateLayerContext_fnptr = (delegate* unmanaged<IntPtr, int, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglCreateLayerContext");
+            _wglCreateLayerContext_fnptr = (delegate* unmanaged<IntPtr, int, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglCreateLayerContext");
             return _wglCreateLayerContext_fnptr(hDc, level);
         }
         
@@ -274,7 +274,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglCreatePbufferARB_Lazy(IntPtr hDC, int iPixelFormat, int iWidth, int iHeight, int* piAttribList)
         {
-            _wglCreatePbufferARB_fnptr = (delegate* unmanaged<IntPtr, int, int, int, int*, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglCreatePbufferARB");
+            _wglCreatePbufferARB_fnptr = (delegate* unmanaged<IntPtr, int, int, int, int*, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglCreatePbufferARB");
             return _wglCreatePbufferARB_fnptr(hDC, iPixelFormat, iWidth, iHeight, piAttribList);
         }
         
@@ -283,7 +283,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglCreatePbufferEXT_Lazy(IntPtr hDC, int iPixelFormat, int iWidth, int iHeight, int* piAttribList)
         {
-            _wglCreatePbufferEXT_fnptr = (delegate* unmanaged<IntPtr, int, int, int, int*, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglCreatePbufferEXT");
+            _wglCreatePbufferEXT_fnptr = (delegate* unmanaged<IntPtr, int, int, int, int*, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglCreatePbufferEXT");
             return _wglCreatePbufferEXT_fnptr(hDC, iPixelFormat, iWidth, iHeight, piAttribList);
         }
         
@@ -292,7 +292,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDelayBeforeSwapNV_Lazy(IntPtr hDC, float seconds)
         {
-            _wglDelayBeforeSwapNV_fnptr = (delegate* unmanaged<IntPtr, float, int>)GLLoader.BindingsContext.GetProcAddress("wglDelayBeforeSwapNV");
+            _wglDelayBeforeSwapNV_fnptr = (delegate* unmanaged<IntPtr, float, int>)WGLLoader.BindingsContext.GetProcAddress("wglDelayBeforeSwapNV");
             return _wglDelayBeforeSwapNV_fnptr(hDC, seconds);
         }
         
@@ -301,7 +301,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDeleteAssociatedContextAMD_Lazy(IntPtr hglrc)
         {
-            _wglDeleteAssociatedContextAMD_fnptr = (delegate* unmanaged<IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglDeleteAssociatedContextAMD");
+            _wglDeleteAssociatedContextAMD_fnptr = (delegate* unmanaged<IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglDeleteAssociatedContextAMD");
             return _wglDeleteAssociatedContextAMD_fnptr(hglrc);
         }
         
@@ -310,7 +310,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static void wglDeleteBufferRegionARB_Lazy(IntPtr hRegion)
         {
-            _wglDeleteBufferRegionARB_fnptr = (delegate* unmanaged<IntPtr, void>)GLLoader.BindingsContext.GetProcAddress("wglDeleteBufferRegionARB");
+            _wglDeleteBufferRegionARB_fnptr = (delegate* unmanaged<IntPtr, void>)WGLLoader.BindingsContext.GetProcAddress("wglDeleteBufferRegionARB");
             _wglDeleteBufferRegionARB_fnptr(hRegion);
         }
         
@@ -319,7 +319,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDeleteContext_Lazy(IntPtr oldContext)
         {
-            _wglDeleteContext_fnptr = (delegate* unmanaged<IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglDeleteContext");
+            _wglDeleteContext_fnptr = (delegate* unmanaged<IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglDeleteContext");
             return _wglDeleteContext_fnptr(oldContext);
         }
         
@@ -328,7 +328,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDeleteDCNV_Lazy(IntPtr hdc)
         {
-            _wglDeleteDCNV_fnptr = (delegate* unmanaged<IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglDeleteDCNV");
+            _wglDeleteDCNV_fnptr = (delegate* unmanaged<IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglDeleteDCNV");
             return _wglDeleteDCNV_fnptr(hdc);
         }
         
@@ -337,7 +337,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDescribeLayerPlane_Lazy(IntPtr hDc, int pixelFormat, int layerPlane, uint nBytes, LayerPlaneDescriptor* plpd)
         {
-            _wglDescribeLayerPlane_fnptr = (delegate* unmanaged<IntPtr, int, int, uint, LayerPlaneDescriptor*, int>)GLLoader.BindingsContext.GetProcAddress("wglDescribeLayerPlane");
+            _wglDescribeLayerPlane_fnptr = (delegate* unmanaged<IntPtr, int, int, uint, LayerPlaneDescriptor*, int>)WGLLoader.BindingsContext.GetProcAddress("wglDescribeLayerPlane");
             return _wglDescribeLayerPlane_fnptr(hDc, pixelFormat, layerPlane, nBytes, plpd);
         }
         
@@ -346,7 +346,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static void wglDestroyDisplayColorTableEXT_Lazy(ushort id)
         {
-            _wglDestroyDisplayColorTableEXT_fnptr = (delegate* unmanaged<ushort, void>)GLLoader.BindingsContext.GetProcAddress("wglDestroyDisplayColorTableEXT");
+            _wglDestroyDisplayColorTableEXT_fnptr = (delegate* unmanaged<ushort, void>)WGLLoader.BindingsContext.GetProcAddress("wglDestroyDisplayColorTableEXT");
             _wglDestroyDisplayColorTableEXT_fnptr(id);
         }
         
@@ -355,7 +355,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDestroyImageBufferI3D_Lazy(IntPtr hDC, IntPtr pAddress)
         {
-            _wglDestroyImageBufferI3D_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglDestroyImageBufferI3D");
+            _wglDestroyImageBufferI3D_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglDestroyImageBufferI3D");
             return _wglDestroyImageBufferI3D_fnptr(hDC, pAddress);
         }
         
@@ -364,7 +364,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDestroyPbufferARB_Lazy(IntPtr hPbuffer)
         {
-            _wglDestroyPbufferARB_fnptr = (delegate* unmanaged<IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglDestroyPbufferARB");
+            _wglDestroyPbufferARB_fnptr = (delegate* unmanaged<IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglDestroyPbufferARB");
             return _wglDestroyPbufferARB_fnptr(hPbuffer);
         }
         
@@ -373,7 +373,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDestroyPbufferEXT_Lazy(IntPtr hPbuffer)
         {
-            _wglDestroyPbufferEXT_fnptr = (delegate* unmanaged<IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglDestroyPbufferEXT");
+            _wglDestroyPbufferEXT_fnptr = (delegate* unmanaged<IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglDestroyPbufferEXT");
             return _wglDestroyPbufferEXT_fnptr(hPbuffer);
         }
         
@@ -382,7 +382,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDisableFrameLockI3D_Lazy()
         {
-            _wglDisableFrameLockI3D_fnptr = (delegate* unmanaged<int>)GLLoader.BindingsContext.GetProcAddress("wglDisableFrameLockI3D");
+            _wglDisableFrameLockI3D_fnptr = (delegate* unmanaged<int>)WGLLoader.BindingsContext.GetProcAddress("wglDisableFrameLockI3D");
             return _wglDisableFrameLockI3D_fnptr();
         }
         
@@ -391,7 +391,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDisableGenlockI3D_Lazy(IntPtr hDC)
         {
-            _wglDisableGenlockI3D_fnptr = (delegate* unmanaged<IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglDisableGenlockI3D");
+            _wglDisableGenlockI3D_fnptr = (delegate* unmanaged<IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglDisableGenlockI3D");
             return _wglDisableGenlockI3D_fnptr(hDC);
         }
         
@@ -400,7 +400,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDXCloseDeviceNV_Lazy(IntPtr hDevice)
         {
-            _wglDXCloseDeviceNV_fnptr = (delegate* unmanaged<IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglDXCloseDeviceNV");
+            _wglDXCloseDeviceNV_fnptr = (delegate* unmanaged<IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglDXCloseDeviceNV");
             return _wglDXCloseDeviceNV_fnptr(hDevice);
         }
         
@@ -409,7 +409,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDXLockObjectsNV_Lazy(IntPtr hDevice, int count, IntPtr* hObjects)
         {
-            _wglDXLockObjectsNV_fnptr = (delegate* unmanaged<IntPtr, int, IntPtr*, int>)GLLoader.BindingsContext.GetProcAddress("wglDXLockObjectsNV");
+            _wglDXLockObjectsNV_fnptr = (delegate* unmanaged<IntPtr, int, IntPtr*, int>)WGLLoader.BindingsContext.GetProcAddress("wglDXLockObjectsNV");
             return _wglDXLockObjectsNV_fnptr(hDevice, count, hObjects);
         }
         
@@ -418,7 +418,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDXObjectAccessNV_Lazy(IntPtr hObject, uint access)
         {
-            _wglDXObjectAccessNV_fnptr = (delegate* unmanaged<IntPtr, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglDXObjectAccessNV");
+            _wglDXObjectAccessNV_fnptr = (delegate* unmanaged<IntPtr, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglDXObjectAccessNV");
             return _wglDXObjectAccessNV_fnptr(hObject, access);
         }
         
@@ -427,7 +427,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglDXOpenDeviceNV_Lazy(void* dxDevice)
         {
-            _wglDXOpenDeviceNV_fnptr = (delegate* unmanaged<void*, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglDXOpenDeviceNV");
+            _wglDXOpenDeviceNV_fnptr = (delegate* unmanaged<void*, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglDXOpenDeviceNV");
             return _wglDXOpenDeviceNV_fnptr(dxDevice);
         }
         
@@ -436,7 +436,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglDXRegisterObjectNV_Lazy(IntPtr hDevice, void* dxObject, uint name, uint type, uint access)
         {
-            _wglDXRegisterObjectNV_fnptr = (delegate* unmanaged<IntPtr, void*, uint, uint, uint, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglDXRegisterObjectNV");
+            _wglDXRegisterObjectNV_fnptr = (delegate* unmanaged<IntPtr, void*, uint, uint, uint, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglDXRegisterObjectNV");
             return _wglDXRegisterObjectNV_fnptr(hDevice, dxObject, name, type, access);
         }
         
@@ -445,7 +445,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDXSetResourceShareHandleNV_Lazy(void* dxObject, IntPtr shareHandle)
         {
-            _wglDXSetResourceShareHandleNV_fnptr = (delegate* unmanaged<void*, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglDXSetResourceShareHandleNV");
+            _wglDXSetResourceShareHandleNV_fnptr = (delegate* unmanaged<void*, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglDXSetResourceShareHandleNV");
             return _wglDXSetResourceShareHandleNV_fnptr(dxObject, shareHandle);
         }
         
@@ -454,7 +454,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDXUnlockObjectsNV_Lazy(IntPtr hDevice, int count, IntPtr* hObjects)
         {
-            _wglDXUnlockObjectsNV_fnptr = (delegate* unmanaged<IntPtr, int, IntPtr*, int>)GLLoader.BindingsContext.GetProcAddress("wglDXUnlockObjectsNV");
+            _wglDXUnlockObjectsNV_fnptr = (delegate* unmanaged<IntPtr, int, IntPtr*, int>)WGLLoader.BindingsContext.GetProcAddress("wglDXUnlockObjectsNV");
             return _wglDXUnlockObjectsNV_fnptr(hDevice, count, hObjects);
         }
         
@@ -463,7 +463,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglDXUnregisterObjectNV_Lazy(IntPtr hDevice, IntPtr hObject)
         {
-            _wglDXUnregisterObjectNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglDXUnregisterObjectNV");
+            _wglDXUnregisterObjectNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglDXUnregisterObjectNV");
             return _wglDXUnregisterObjectNV_fnptr(hDevice, hObject);
         }
         
@@ -472,7 +472,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglEnableFrameLockI3D_Lazy()
         {
-            _wglEnableFrameLockI3D_fnptr = (delegate* unmanaged<int>)GLLoader.BindingsContext.GetProcAddress("wglEnableFrameLockI3D");
+            _wglEnableFrameLockI3D_fnptr = (delegate* unmanaged<int>)WGLLoader.BindingsContext.GetProcAddress("wglEnableFrameLockI3D");
             return _wglEnableFrameLockI3D_fnptr();
         }
         
@@ -481,7 +481,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglEnableGenlockI3D_Lazy(IntPtr hDC)
         {
-            _wglEnableGenlockI3D_fnptr = (delegate* unmanaged<IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglEnableGenlockI3D");
+            _wglEnableGenlockI3D_fnptr = (delegate* unmanaged<IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglEnableGenlockI3D");
             return _wglEnableGenlockI3D_fnptr(hDC);
         }
         
@@ -490,7 +490,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglEndFrameTrackingI3D_Lazy()
         {
-            _wglEndFrameTrackingI3D_fnptr = (delegate* unmanaged<int>)GLLoader.BindingsContext.GetProcAddress("wglEndFrameTrackingI3D");
+            _wglEndFrameTrackingI3D_fnptr = (delegate* unmanaged<int>)WGLLoader.BindingsContext.GetProcAddress("wglEndFrameTrackingI3D");
             return _wglEndFrameTrackingI3D_fnptr();
         }
         
@@ -499,7 +499,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static uint wglEnumerateVideoCaptureDevicesNV_Lazy(IntPtr hDc, IntPtr* phDeviceList)
         {
-            _wglEnumerateVideoCaptureDevicesNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr*, uint>)GLLoader.BindingsContext.GetProcAddress("wglEnumerateVideoCaptureDevicesNV");
+            _wglEnumerateVideoCaptureDevicesNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr*, uint>)WGLLoader.BindingsContext.GetProcAddress("wglEnumerateVideoCaptureDevicesNV");
             return _wglEnumerateVideoCaptureDevicesNV_fnptr(hDc, phDeviceList);
         }
         
@@ -508,7 +508,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglEnumerateVideoDevicesNV_Lazy(IntPtr hDc, IntPtr* phDeviceList)
         {
-            _wglEnumerateVideoDevicesNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr*, int>)GLLoader.BindingsContext.GetProcAddress("wglEnumerateVideoDevicesNV");
+            _wglEnumerateVideoDevicesNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr*, int>)WGLLoader.BindingsContext.GetProcAddress("wglEnumerateVideoDevicesNV");
             return _wglEnumerateVideoDevicesNV_fnptr(hDc, phDeviceList);
         }
         
@@ -517,7 +517,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglEnumGpuDevicesNV_Lazy(IntPtr hGpu, uint iDeviceIndex, _GPU_DEVICE* lpGpuDevice)
         {
-            _wglEnumGpuDevicesNV_fnptr = (delegate* unmanaged<IntPtr, uint, _GPU_DEVICE*, int>)GLLoader.BindingsContext.GetProcAddress("wglEnumGpuDevicesNV");
+            _wglEnumGpuDevicesNV_fnptr = (delegate* unmanaged<IntPtr, uint, _GPU_DEVICE*, int>)WGLLoader.BindingsContext.GetProcAddress("wglEnumGpuDevicesNV");
             return _wglEnumGpuDevicesNV_fnptr(hGpu, iDeviceIndex, lpGpuDevice);
         }
         
@@ -526,7 +526,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglEnumGpusFromAffinityDCNV_Lazy(IntPtr hAffinityDC, uint iGpuIndex, IntPtr* hGpu)
         {
-            _wglEnumGpusFromAffinityDCNV_fnptr = (delegate* unmanaged<IntPtr, uint, IntPtr*, int>)GLLoader.BindingsContext.GetProcAddress("wglEnumGpusFromAffinityDCNV");
+            _wglEnumGpusFromAffinityDCNV_fnptr = (delegate* unmanaged<IntPtr, uint, IntPtr*, int>)WGLLoader.BindingsContext.GetProcAddress("wglEnumGpusFromAffinityDCNV");
             return _wglEnumGpusFromAffinityDCNV_fnptr(hAffinityDC, iGpuIndex, hGpu);
         }
         
@@ -535,7 +535,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglEnumGpusNV_Lazy(uint iGpuIndex, IntPtr* phGpu)
         {
-            _wglEnumGpusNV_fnptr = (delegate* unmanaged<uint, IntPtr*, int>)GLLoader.BindingsContext.GetProcAddress("wglEnumGpusNV");
+            _wglEnumGpusNV_fnptr = (delegate* unmanaged<uint, IntPtr*, int>)WGLLoader.BindingsContext.GetProcAddress("wglEnumGpusNV");
             return _wglEnumGpusNV_fnptr(iGpuIndex, phGpu);
         }
         
@@ -544,7 +544,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static void wglFreeMemoryNV_Lazy(void* pointer)
         {
-            _wglFreeMemoryNV_fnptr = (delegate* unmanaged<void*, void>)GLLoader.BindingsContext.GetProcAddress("wglFreeMemoryNV");
+            _wglFreeMemoryNV_fnptr = (delegate* unmanaged<void*, void>)WGLLoader.BindingsContext.GetProcAddress("wglFreeMemoryNV");
             _wglFreeMemoryNV_fnptr(pointer);
         }
         
@@ -553,7 +553,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGenlockSampleRateI3D_Lazy(IntPtr hDC, uint uRate)
         {
-            _wglGenlockSampleRateI3D_fnptr = (delegate* unmanaged<IntPtr, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglGenlockSampleRateI3D");
+            _wglGenlockSampleRateI3D_fnptr = (delegate* unmanaged<IntPtr, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglGenlockSampleRateI3D");
             return _wglGenlockSampleRateI3D_fnptr(hDC, uRate);
         }
         
@@ -562,7 +562,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGenlockSourceDelayI3D_Lazy(IntPtr hDC, uint uDelay)
         {
-            _wglGenlockSourceDelayI3D_fnptr = (delegate* unmanaged<IntPtr, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglGenlockSourceDelayI3D");
+            _wglGenlockSourceDelayI3D_fnptr = (delegate* unmanaged<IntPtr, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglGenlockSourceDelayI3D");
             return _wglGenlockSourceDelayI3D_fnptr(hDC, uDelay);
         }
         
@@ -571,7 +571,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGenlockSourceEdgeI3D_Lazy(IntPtr hDC, uint uEdge)
         {
-            _wglGenlockSourceEdgeI3D_fnptr = (delegate* unmanaged<IntPtr, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglGenlockSourceEdgeI3D");
+            _wglGenlockSourceEdgeI3D_fnptr = (delegate* unmanaged<IntPtr, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglGenlockSourceEdgeI3D");
             return _wglGenlockSourceEdgeI3D_fnptr(hDC, uEdge);
         }
         
@@ -580,7 +580,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGenlockSourceI3D_Lazy(IntPtr hDC, uint uSource)
         {
-            _wglGenlockSourceI3D_fnptr = (delegate* unmanaged<IntPtr, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglGenlockSourceI3D");
+            _wglGenlockSourceI3D_fnptr = (delegate* unmanaged<IntPtr, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglGenlockSourceI3D");
             return _wglGenlockSourceI3D_fnptr(hDC, uSource);
         }
         
@@ -589,7 +589,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static uint wglGetContextGPUIDAMD_Lazy(IntPtr hglrc)
         {
-            _wglGetContextGPUIDAMD_fnptr = (delegate* unmanaged<IntPtr, uint>)GLLoader.BindingsContext.GetProcAddress("wglGetContextGPUIDAMD");
+            _wglGetContextGPUIDAMD_fnptr = (delegate* unmanaged<IntPtr, uint>)WGLLoader.BindingsContext.GetProcAddress("wglGetContextGPUIDAMD");
             return _wglGetContextGPUIDAMD_fnptr(hglrc);
         }
         
@@ -598,7 +598,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglGetCurrentAssociatedContextAMD_Lazy()
         {
-            _wglGetCurrentAssociatedContextAMD_fnptr = (delegate* unmanaged<IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglGetCurrentAssociatedContextAMD");
+            _wglGetCurrentAssociatedContextAMD_fnptr = (delegate* unmanaged<IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglGetCurrentAssociatedContextAMD");
             return _wglGetCurrentAssociatedContextAMD_fnptr();
         }
         
@@ -607,7 +607,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglGetCurrentContext_Lazy()
         {
-            _wglGetCurrentContext_fnptr = (delegate* unmanaged<IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglGetCurrentContext");
+            _wglGetCurrentContext_fnptr = (delegate* unmanaged<IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglGetCurrentContext");
             return _wglGetCurrentContext_fnptr();
         }
         
@@ -616,7 +616,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglGetCurrentDC_Lazy()
         {
-            _wglGetCurrentDC_fnptr = (delegate* unmanaged<IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglGetCurrentDC");
+            _wglGetCurrentDC_fnptr = (delegate* unmanaged<IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglGetCurrentDC");
             return _wglGetCurrentDC_fnptr();
         }
         
@@ -625,7 +625,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglGetCurrentReadDCARB_Lazy()
         {
-            _wglGetCurrentReadDCARB_fnptr = (delegate* unmanaged<IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglGetCurrentReadDCARB");
+            _wglGetCurrentReadDCARB_fnptr = (delegate* unmanaged<IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglGetCurrentReadDCARB");
             return _wglGetCurrentReadDCARB_fnptr();
         }
         
@@ -634,7 +634,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglGetCurrentReadDCEXT_Lazy()
         {
-            _wglGetCurrentReadDCEXT_fnptr = (delegate* unmanaged<IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglGetCurrentReadDCEXT");
+            _wglGetCurrentReadDCEXT_fnptr = (delegate* unmanaged<IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglGetCurrentReadDCEXT");
             return _wglGetCurrentReadDCEXT_fnptr();
         }
         
@@ -643,7 +643,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetDigitalVideoParametersI3D_Lazy(IntPtr hDC, int iAttribute, int* piValue)
         {
-            _wglGetDigitalVideoParametersI3D_fnptr = (delegate* unmanaged<IntPtr, int, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetDigitalVideoParametersI3D");
+            _wglGetDigitalVideoParametersI3D_fnptr = (delegate* unmanaged<IntPtr, int, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetDigitalVideoParametersI3D");
             return _wglGetDigitalVideoParametersI3D_fnptr(hDC, iAttribute, piValue);
         }
         
@@ -652,7 +652,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static byte* wglGetExtensionsStringARB_Lazy(IntPtr hdc)
         {
-            _wglGetExtensionsStringARB_fnptr = (delegate* unmanaged<IntPtr, byte*>)GLLoader.BindingsContext.GetProcAddress("wglGetExtensionsStringARB");
+            _wglGetExtensionsStringARB_fnptr = (delegate* unmanaged<IntPtr, byte*>)WGLLoader.BindingsContext.GetProcAddress("wglGetExtensionsStringARB");
             return _wglGetExtensionsStringARB_fnptr(hdc);
         }
         
@@ -661,7 +661,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static byte* wglGetExtensionsStringEXT_Lazy()
         {
-            _wglGetExtensionsStringEXT_fnptr = (delegate* unmanaged<byte*>)GLLoader.BindingsContext.GetProcAddress("wglGetExtensionsStringEXT");
+            _wglGetExtensionsStringEXT_fnptr = (delegate* unmanaged<byte*>)WGLLoader.BindingsContext.GetProcAddress("wglGetExtensionsStringEXT");
             return _wglGetExtensionsStringEXT_fnptr();
         }
         
@@ -670,7 +670,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetFrameUsageI3D_Lazy(float* pUsage)
         {
-            _wglGetFrameUsageI3D_fnptr = (delegate* unmanaged<float*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetFrameUsageI3D");
+            _wglGetFrameUsageI3D_fnptr = (delegate* unmanaged<float*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetFrameUsageI3D");
             return _wglGetFrameUsageI3D_fnptr(pUsage);
         }
         
@@ -679,7 +679,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetGammaTableI3D_Lazy(IntPtr hDC, int iEntries, ushort* puRed, ushort* puGreen, ushort* puBlue)
         {
-            _wglGetGammaTableI3D_fnptr = (delegate* unmanaged<IntPtr, int, ushort*, ushort*, ushort*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetGammaTableI3D");
+            _wglGetGammaTableI3D_fnptr = (delegate* unmanaged<IntPtr, int, ushort*, ushort*, ushort*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetGammaTableI3D");
             return _wglGetGammaTableI3D_fnptr(hDC, iEntries, puRed, puGreen, puBlue);
         }
         
@@ -688,7 +688,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetGammaTableParametersI3D_Lazy(IntPtr hDC, int iAttribute, int* piValue)
         {
-            _wglGetGammaTableParametersI3D_fnptr = (delegate* unmanaged<IntPtr, int, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetGammaTableParametersI3D");
+            _wglGetGammaTableParametersI3D_fnptr = (delegate* unmanaged<IntPtr, int, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetGammaTableParametersI3D");
             return _wglGetGammaTableParametersI3D_fnptr(hDC, iAttribute, piValue);
         }
         
@@ -697,7 +697,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetGenlockSampleRateI3D_Lazy(IntPtr hDC, uint* uRate)
         {
-            _wglGetGenlockSampleRateI3D_fnptr = (delegate* unmanaged<IntPtr, uint*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetGenlockSampleRateI3D");
+            _wglGetGenlockSampleRateI3D_fnptr = (delegate* unmanaged<IntPtr, uint*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetGenlockSampleRateI3D");
             return _wglGetGenlockSampleRateI3D_fnptr(hDC, uRate);
         }
         
@@ -706,7 +706,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetGenlockSourceDelayI3D_Lazy(IntPtr hDC, uint* uDelay)
         {
-            _wglGetGenlockSourceDelayI3D_fnptr = (delegate* unmanaged<IntPtr, uint*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetGenlockSourceDelayI3D");
+            _wglGetGenlockSourceDelayI3D_fnptr = (delegate* unmanaged<IntPtr, uint*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetGenlockSourceDelayI3D");
             return _wglGetGenlockSourceDelayI3D_fnptr(hDC, uDelay);
         }
         
@@ -715,7 +715,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetGenlockSourceEdgeI3D_Lazy(IntPtr hDC, uint* uEdge)
         {
-            _wglGetGenlockSourceEdgeI3D_fnptr = (delegate* unmanaged<IntPtr, uint*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetGenlockSourceEdgeI3D");
+            _wglGetGenlockSourceEdgeI3D_fnptr = (delegate* unmanaged<IntPtr, uint*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetGenlockSourceEdgeI3D");
             return _wglGetGenlockSourceEdgeI3D_fnptr(hDC, uEdge);
         }
         
@@ -724,7 +724,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetGenlockSourceI3D_Lazy(IntPtr hDC, uint* uSource)
         {
-            _wglGetGenlockSourceI3D_fnptr = (delegate* unmanaged<IntPtr, uint*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetGenlockSourceI3D");
+            _wglGetGenlockSourceI3D_fnptr = (delegate* unmanaged<IntPtr, uint*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetGenlockSourceI3D");
             return _wglGetGenlockSourceI3D_fnptr(hDC, uSource);
         }
         
@@ -733,7 +733,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static uint wglGetGPUIDsAMD_Lazy(uint maxCount, uint* ids)
         {
-            _wglGetGPUIDsAMD_fnptr = (delegate* unmanaged<uint, uint*, uint>)GLLoader.BindingsContext.GetProcAddress("wglGetGPUIDsAMD");
+            _wglGetGPUIDsAMD_fnptr = (delegate* unmanaged<uint, uint*, uint>)WGLLoader.BindingsContext.GetProcAddress("wglGetGPUIDsAMD");
             return _wglGetGPUIDsAMD_fnptr(maxCount, ids);
         }
         
@@ -742,7 +742,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetGPUInfoAMD_Lazy(uint id, int property, uint dataType, uint size, void* data)
         {
-            _wglGetGPUInfoAMD_fnptr = (delegate* unmanaged<uint, int, uint, uint, void*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetGPUInfoAMD");
+            _wglGetGPUInfoAMD_fnptr = (delegate* unmanaged<uint, int, uint, uint, void*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetGPUInfoAMD");
             return _wglGetGPUInfoAMD_fnptr(id, property, dataType, size, data);
         }
         
@@ -751,7 +751,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetLayerPaletteEntries_Lazy(IntPtr hdc, int iLayerPlane, int iStart, int cEntries, uint* pcr)
         {
-            _wglGetLayerPaletteEntries_fnptr = (delegate* unmanaged<IntPtr, int, int, int, uint*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetLayerPaletteEntries");
+            _wglGetLayerPaletteEntries_fnptr = (delegate* unmanaged<IntPtr, int, int, int, uint*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetLayerPaletteEntries");
             return _wglGetLayerPaletteEntries_fnptr(hdc, iLayerPlane, iStart, cEntries, pcr);
         }
         
@@ -760,7 +760,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetMscRateOML_Lazy(IntPtr hdc, int* numerator, int* denominator)
         {
-            _wglGetMscRateOML_fnptr = (delegate* unmanaged<IntPtr, int*, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetMscRateOML");
+            _wglGetMscRateOML_fnptr = (delegate* unmanaged<IntPtr, int*, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetMscRateOML");
             return _wglGetMscRateOML_fnptr(hdc, numerator, denominator);
         }
         
@@ -769,7 +769,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglGetPbufferDCARB_Lazy(IntPtr hPbuffer)
         {
-            _wglGetPbufferDCARB_fnptr = (delegate* unmanaged<IntPtr, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglGetPbufferDCARB");
+            _wglGetPbufferDCARB_fnptr = (delegate* unmanaged<IntPtr, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglGetPbufferDCARB");
             return _wglGetPbufferDCARB_fnptr(hPbuffer);
         }
         
@@ -778,7 +778,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static IntPtr wglGetPbufferDCEXT_Lazy(IntPtr hPbuffer)
         {
-            _wglGetPbufferDCEXT_fnptr = (delegate* unmanaged<IntPtr, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglGetPbufferDCEXT");
+            _wglGetPbufferDCEXT_fnptr = (delegate* unmanaged<IntPtr, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglGetPbufferDCEXT");
             return _wglGetPbufferDCEXT_fnptr(hPbuffer);
         }
         
@@ -787,7 +787,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetPixelFormatAttribfvARB_Lazy(IntPtr hdc, int iPixelFormat, int iLayerPlane, uint nAttributes, int* piAttributes, float* pfValues)
         {
-            _wglGetPixelFormatAttribfvARB_fnptr = (delegate* unmanaged<IntPtr, int, int, uint, int*, float*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetPixelFormatAttribfvARB");
+            _wglGetPixelFormatAttribfvARB_fnptr = (delegate* unmanaged<IntPtr, int, int, uint, int*, float*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetPixelFormatAttribfvARB");
             return _wglGetPixelFormatAttribfvARB_fnptr(hdc, iPixelFormat, iLayerPlane, nAttributes, piAttributes, pfValues);
         }
         
@@ -796,7 +796,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetPixelFormatAttribfvEXT_Lazy(IntPtr hdc, int iPixelFormat, int iLayerPlane, uint nAttributes, int* piAttributes, float* pfValues)
         {
-            _wglGetPixelFormatAttribfvEXT_fnptr = (delegate* unmanaged<IntPtr, int, int, uint, int*, float*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetPixelFormatAttribfvEXT");
+            _wglGetPixelFormatAttribfvEXT_fnptr = (delegate* unmanaged<IntPtr, int, int, uint, int*, float*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetPixelFormatAttribfvEXT");
             return _wglGetPixelFormatAttribfvEXT_fnptr(hdc, iPixelFormat, iLayerPlane, nAttributes, piAttributes, pfValues);
         }
         
@@ -805,7 +805,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetPixelFormatAttribivARB_Lazy(IntPtr hdc, int iPixelFormat, int iLayerPlane, uint nAttributes, int* piAttributes, int* piValues)
         {
-            _wglGetPixelFormatAttribivARB_fnptr = (delegate* unmanaged<IntPtr, int, int, uint, int*, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetPixelFormatAttribivARB");
+            _wglGetPixelFormatAttribivARB_fnptr = (delegate* unmanaged<IntPtr, int, int, uint, int*, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetPixelFormatAttribivARB");
             return _wglGetPixelFormatAttribivARB_fnptr(hdc, iPixelFormat, iLayerPlane, nAttributes, piAttributes, piValues);
         }
         
@@ -814,16 +814,16 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetPixelFormatAttribivEXT_Lazy(IntPtr hdc, int iPixelFormat, int iLayerPlane, uint nAttributes, int* piAttributes, int* piValues)
         {
-            _wglGetPixelFormatAttribivEXT_fnptr = (delegate* unmanaged<IntPtr, int, int, uint, int*, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetPixelFormatAttribivEXT");
+            _wglGetPixelFormatAttribivEXT_fnptr = (delegate* unmanaged<IntPtr, int, int, uint, int*, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetPixelFormatAttribivEXT");
             return _wglGetPixelFormatAttribivEXT_fnptr(hdc, iPixelFormat, iLayerPlane, nAttributes, piAttributes, piValues);
         }
         
         /// <summary><b>[entry point: <c>wglGetProcAddress</c>]</b></summary>
-        public static delegate* unmanaged<char*, IntPtr> _wglGetProcAddress_fnptr = &wglGetProcAddress_Lazy;
+        public static delegate* unmanaged<byte*, IntPtr> _wglGetProcAddress_fnptr = &wglGetProcAddress_Lazy;
         [UnmanagedCallersOnly]
-        private static IntPtr wglGetProcAddress_Lazy(char* lpszProc)
+        private static IntPtr wglGetProcAddress_Lazy(byte* lpszProc)
         {
-            _wglGetProcAddress_fnptr = (delegate* unmanaged<char*, IntPtr>)GLLoader.BindingsContext.GetProcAddress("wglGetProcAddress");
+            _wglGetProcAddress_fnptr = (delegate* unmanaged<byte*, IntPtr>)WGLLoader.BindingsContext.GetProcAddress("wglGetProcAddress");
             return _wglGetProcAddress_fnptr(lpszProc);
         }
         
@@ -832,7 +832,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetSwapIntervalEXT_Lazy()
         {
-            _wglGetSwapIntervalEXT_fnptr = (delegate* unmanaged<int>)GLLoader.BindingsContext.GetProcAddress("wglGetSwapIntervalEXT");
+            _wglGetSwapIntervalEXT_fnptr = (delegate* unmanaged<int>)WGLLoader.BindingsContext.GetProcAddress("wglGetSwapIntervalEXT");
             return _wglGetSwapIntervalEXT_fnptr();
         }
         
@@ -841,7 +841,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetSyncValuesOML_Lazy(IntPtr hdc, long* ust, long* msc, long* sbc)
         {
-            _wglGetSyncValuesOML_fnptr = (delegate* unmanaged<IntPtr, long*, long*, long*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetSyncValuesOML");
+            _wglGetSyncValuesOML_fnptr = (delegate* unmanaged<IntPtr, long*, long*, long*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetSyncValuesOML");
             return _wglGetSyncValuesOML_fnptr(hdc, ust, msc, sbc);
         }
         
@@ -850,7 +850,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetVideoDeviceNV_Lazy(IntPtr hDC, int numDevices, IntPtr* hVideoDevice)
         {
-            _wglGetVideoDeviceNV_fnptr = (delegate* unmanaged<IntPtr, int, IntPtr*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetVideoDeviceNV");
+            _wglGetVideoDeviceNV_fnptr = (delegate* unmanaged<IntPtr, int, IntPtr*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetVideoDeviceNV");
             return _wglGetVideoDeviceNV_fnptr(hDC, numDevices, hVideoDevice);
         }
         
@@ -859,7 +859,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglGetVideoInfoNV_Lazy(IntPtr hpVideoDevice, ulong* pulCounterOutputPbuffer, ulong* pulCounterOutputVideo)
         {
-            _wglGetVideoInfoNV_fnptr = (delegate* unmanaged<IntPtr, ulong*, ulong*, int>)GLLoader.BindingsContext.GetProcAddress("wglGetVideoInfoNV");
+            _wglGetVideoInfoNV_fnptr = (delegate* unmanaged<IntPtr, ulong*, ulong*, int>)WGLLoader.BindingsContext.GetProcAddress("wglGetVideoInfoNV");
             return _wglGetVideoInfoNV_fnptr(hpVideoDevice, pulCounterOutputPbuffer, pulCounterOutputVideo);
         }
         
@@ -868,7 +868,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglIsEnabledFrameLockI3D_Lazy(int* pFlag)
         {
-            _wglIsEnabledFrameLockI3D_fnptr = (delegate* unmanaged<int*, int>)GLLoader.BindingsContext.GetProcAddress("wglIsEnabledFrameLockI3D");
+            _wglIsEnabledFrameLockI3D_fnptr = (delegate* unmanaged<int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglIsEnabledFrameLockI3D");
             return _wglIsEnabledFrameLockI3D_fnptr(pFlag);
         }
         
@@ -877,7 +877,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglIsEnabledGenlockI3D_Lazy(IntPtr hDC, int* pFlag)
         {
-            _wglIsEnabledGenlockI3D_fnptr = (delegate* unmanaged<IntPtr, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglIsEnabledGenlockI3D");
+            _wglIsEnabledGenlockI3D_fnptr = (delegate* unmanaged<IntPtr, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglIsEnabledGenlockI3D");
             return _wglIsEnabledGenlockI3D_fnptr(hDC, pFlag);
         }
         
@@ -886,7 +886,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglJoinSwapGroupNV_Lazy(IntPtr hDC, uint group)
         {
-            _wglJoinSwapGroupNV_fnptr = (delegate* unmanaged<IntPtr, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglJoinSwapGroupNV");
+            _wglJoinSwapGroupNV_fnptr = (delegate* unmanaged<IntPtr, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglJoinSwapGroupNV");
             return _wglJoinSwapGroupNV_fnptr(hDC, group);
         }
         
@@ -895,7 +895,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static byte wglLoadDisplayColorTableEXT_Lazy(ushort* table, uint length)
         {
-            _wglLoadDisplayColorTableEXT_fnptr = (delegate* unmanaged<ushort*, uint, byte>)GLLoader.BindingsContext.GetProcAddress("wglLoadDisplayColorTableEXT");
+            _wglLoadDisplayColorTableEXT_fnptr = (delegate* unmanaged<ushort*, uint, byte>)WGLLoader.BindingsContext.GetProcAddress("wglLoadDisplayColorTableEXT");
             return _wglLoadDisplayColorTableEXT_fnptr(table, length);
         }
         
@@ -904,7 +904,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglLockVideoCaptureDeviceNV_Lazy(IntPtr hDc, IntPtr hDevice)
         {
-            _wglLockVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglLockVideoCaptureDeviceNV");
+            _wglLockVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglLockVideoCaptureDeviceNV");
             return _wglLockVideoCaptureDeviceNV_fnptr(hDc, hDevice);
         }
         
@@ -913,7 +913,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglMakeAssociatedContextCurrentAMD_Lazy(IntPtr hglrc)
         {
-            _wglMakeAssociatedContextCurrentAMD_fnptr = (delegate* unmanaged<IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglMakeAssociatedContextCurrentAMD");
+            _wglMakeAssociatedContextCurrentAMD_fnptr = (delegate* unmanaged<IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglMakeAssociatedContextCurrentAMD");
             return _wglMakeAssociatedContextCurrentAMD_fnptr(hglrc);
         }
         
@@ -922,7 +922,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglMakeContextCurrentARB_Lazy(IntPtr hDrawDC, IntPtr hReadDC, IntPtr hglrc)
         {
-            _wglMakeContextCurrentARB_fnptr = (delegate* unmanaged<IntPtr, IntPtr, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglMakeContextCurrentARB");
+            _wglMakeContextCurrentARB_fnptr = (delegate* unmanaged<IntPtr, IntPtr, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglMakeContextCurrentARB");
             return _wglMakeContextCurrentARB_fnptr(hDrawDC, hReadDC, hglrc);
         }
         
@@ -931,7 +931,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglMakeContextCurrentEXT_Lazy(IntPtr hDrawDC, IntPtr hReadDC, IntPtr hglrc)
         {
-            _wglMakeContextCurrentEXT_fnptr = (delegate* unmanaged<IntPtr, IntPtr, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglMakeContextCurrentEXT");
+            _wglMakeContextCurrentEXT_fnptr = (delegate* unmanaged<IntPtr, IntPtr, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglMakeContextCurrentEXT");
             return _wglMakeContextCurrentEXT_fnptr(hDrawDC, hReadDC, hglrc);
         }
         
@@ -940,7 +940,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglMakeCurrent_Lazy(IntPtr hDc, IntPtr newContext)
         {
-            _wglMakeCurrent_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglMakeCurrent");
+            _wglMakeCurrent_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglMakeCurrent");
             return _wglMakeCurrent_fnptr(hDc, newContext);
         }
         
@@ -949,7 +949,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglQueryCurrentContextNV_Lazy(int iAttribute, int* piValue)
         {
-            _wglQueryCurrentContextNV_fnptr = (delegate* unmanaged<int, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglQueryCurrentContextNV");
+            _wglQueryCurrentContextNV_fnptr = (delegate* unmanaged<int, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglQueryCurrentContextNV");
             return _wglQueryCurrentContextNV_fnptr(iAttribute, piValue);
         }
         
@@ -958,7 +958,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglQueryFrameCountNV_Lazy(IntPtr hDC, uint* count)
         {
-            _wglQueryFrameCountNV_fnptr = (delegate* unmanaged<IntPtr, uint*, int>)GLLoader.BindingsContext.GetProcAddress("wglQueryFrameCountNV");
+            _wglQueryFrameCountNV_fnptr = (delegate* unmanaged<IntPtr, uint*, int>)WGLLoader.BindingsContext.GetProcAddress("wglQueryFrameCountNV");
             return _wglQueryFrameCountNV_fnptr(hDC, count);
         }
         
@@ -967,7 +967,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglQueryFrameLockMasterI3D_Lazy(int* pFlag)
         {
-            _wglQueryFrameLockMasterI3D_fnptr = (delegate* unmanaged<int*, int>)GLLoader.BindingsContext.GetProcAddress("wglQueryFrameLockMasterI3D");
+            _wglQueryFrameLockMasterI3D_fnptr = (delegate* unmanaged<int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglQueryFrameLockMasterI3D");
             return _wglQueryFrameLockMasterI3D_fnptr(pFlag);
         }
         
@@ -976,7 +976,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglQueryFrameTrackingI3D_Lazy(uint* pFrameCount, uint* pMissedFrames, float* pLastMissedUsage)
         {
-            _wglQueryFrameTrackingI3D_fnptr = (delegate* unmanaged<uint*, uint*, float*, int>)GLLoader.BindingsContext.GetProcAddress("wglQueryFrameTrackingI3D");
+            _wglQueryFrameTrackingI3D_fnptr = (delegate* unmanaged<uint*, uint*, float*, int>)WGLLoader.BindingsContext.GetProcAddress("wglQueryFrameTrackingI3D");
             return _wglQueryFrameTrackingI3D_fnptr(pFrameCount, pMissedFrames, pLastMissedUsage);
         }
         
@@ -985,7 +985,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglQueryGenlockMaxSourceDelayI3D_Lazy(IntPtr hDC, uint* uMaxLineDelay, uint* uMaxPixelDelay)
         {
-            _wglQueryGenlockMaxSourceDelayI3D_fnptr = (delegate* unmanaged<IntPtr, uint*, uint*, int>)GLLoader.BindingsContext.GetProcAddress("wglQueryGenlockMaxSourceDelayI3D");
+            _wglQueryGenlockMaxSourceDelayI3D_fnptr = (delegate* unmanaged<IntPtr, uint*, uint*, int>)WGLLoader.BindingsContext.GetProcAddress("wglQueryGenlockMaxSourceDelayI3D");
             return _wglQueryGenlockMaxSourceDelayI3D_fnptr(hDC, uMaxLineDelay, uMaxPixelDelay);
         }
         
@@ -994,7 +994,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglQueryMaxSwapGroupsNV_Lazy(IntPtr hDC, uint* maxGroups, uint* maxBarriers)
         {
-            _wglQueryMaxSwapGroupsNV_fnptr = (delegate* unmanaged<IntPtr, uint*, uint*, int>)GLLoader.BindingsContext.GetProcAddress("wglQueryMaxSwapGroupsNV");
+            _wglQueryMaxSwapGroupsNV_fnptr = (delegate* unmanaged<IntPtr, uint*, uint*, int>)WGLLoader.BindingsContext.GetProcAddress("wglQueryMaxSwapGroupsNV");
             return _wglQueryMaxSwapGroupsNV_fnptr(hDC, maxGroups, maxBarriers);
         }
         
@@ -1003,7 +1003,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglQueryPbufferARB_Lazy(IntPtr hPbuffer, int iAttribute, int* piValue)
         {
-            _wglQueryPbufferARB_fnptr = (delegate* unmanaged<IntPtr, int, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglQueryPbufferARB");
+            _wglQueryPbufferARB_fnptr = (delegate* unmanaged<IntPtr, int, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglQueryPbufferARB");
             return _wglQueryPbufferARB_fnptr(hPbuffer, iAttribute, piValue);
         }
         
@@ -1012,7 +1012,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglQueryPbufferEXT_Lazy(IntPtr hPbuffer, int iAttribute, int* piValue)
         {
-            _wglQueryPbufferEXT_fnptr = (delegate* unmanaged<IntPtr, int, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglQueryPbufferEXT");
+            _wglQueryPbufferEXT_fnptr = (delegate* unmanaged<IntPtr, int, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglQueryPbufferEXT");
             return _wglQueryPbufferEXT_fnptr(hPbuffer, iAttribute, piValue);
         }
         
@@ -1021,7 +1021,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglQuerySwapGroupNV_Lazy(IntPtr hDC, uint* group, uint* barrier)
         {
-            _wglQuerySwapGroupNV_fnptr = (delegate* unmanaged<IntPtr, uint*, uint*, int>)GLLoader.BindingsContext.GetProcAddress("wglQuerySwapGroupNV");
+            _wglQuerySwapGroupNV_fnptr = (delegate* unmanaged<IntPtr, uint*, uint*, int>)WGLLoader.BindingsContext.GetProcAddress("wglQuerySwapGroupNV");
             return _wglQuerySwapGroupNV_fnptr(hDC, group, barrier);
         }
         
@@ -1030,7 +1030,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglQueryVideoCaptureDeviceNV_Lazy(IntPtr hDc, IntPtr hDevice, int iAttribute, int* piValue)
         {
-            _wglQueryVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglQueryVideoCaptureDeviceNV");
+            _wglQueryVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglQueryVideoCaptureDeviceNV");
             return _wglQueryVideoCaptureDeviceNV_fnptr(hDc, hDevice, iAttribute, piValue);
         }
         
@@ -1039,7 +1039,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglRealizeLayerPalette_Lazy(IntPtr hdc, int iLayerPlane, int bRealize)
         {
-            _wglRealizeLayerPalette_fnptr = (delegate* unmanaged<IntPtr, int, int, int>)GLLoader.BindingsContext.GetProcAddress("wglRealizeLayerPalette");
+            _wglRealizeLayerPalette_fnptr = (delegate* unmanaged<IntPtr, int, int, int>)WGLLoader.BindingsContext.GetProcAddress("wglRealizeLayerPalette");
             return _wglRealizeLayerPalette_fnptr(hdc, iLayerPlane, bRealize);
         }
         
@@ -1048,7 +1048,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglReleaseImageBufferEventsI3D_Lazy(IntPtr hDC, IntPtr* pAddress, uint count)
         {
-            _wglReleaseImageBufferEventsI3D_fnptr = (delegate* unmanaged<IntPtr, IntPtr*, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglReleaseImageBufferEventsI3D");
+            _wglReleaseImageBufferEventsI3D_fnptr = (delegate* unmanaged<IntPtr, IntPtr*, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglReleaseImageBufferEventsI3D");
             return _wglReleaseImageBufferEventsI3D_fnptr(hDC, pAddress, count);
         }
         
@@ -1057,7 +1057,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglReleasePbufferDCARB_Lazy(IntPtr hPbuffer, IntPtr hDC)
         {
-            _wglReleasePbufferDCARB_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglReleasePbufferDCARB");
+            _wglReleasePbufferDCARB_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglReleasePbufferDCARB");
             return _wglReleasePbufferDCARB_fnptr(hPbuffer, hDC);
         }
         
@@ -1066,7 +1066,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglReleasePbufferDCEXT_Lazy(IntPtr hPbuffer, IntPtr hDC)
         {
-            _wglReleasePbufferDCEXT_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglReleasePbufferDCEXT");
+            _wglReleasePbufferDCEXT_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglReleasePbufferDCEXT");
             return _wglReleasePbufferDCEXT_fnptr(hPbuffer, hDC);
         }
         
@@ -1075,7 +1075,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglReleaseTexImageARB_Lazy(IntPtr hPbuffer, int iBuffer)
         {
-            _wglReleaseTexImageARB_fnptr = (delegate* unmanaged<IntPtr, int, int>)GLLoader.BindingsContext.GetProcAddress("wglReleaseTexImageARB");
+            _wglReleaseTexImageARB_fnptr = (delegate* unmanaged<IntPtr, int, int>)WGLLoader.BindingsContext.GetProcAddress("wglReleaseTexImageARB");
             return _wglReleaseTexImageARB_fnptr(hPbuffer, iBuffer);
         }
         
@@ -1084,7 +1084,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglReleaseVideoCaptureDeviceNV_Lazy(IntPtr hDc, IntPtr hDevice)
         {
-            _wglReleaseVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglReleaseVideoCaptureDeviceNV");
+            _wglReleaseVideoCaptureDeviceNV_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglReleaseVideoCaptureDeviceNV");
             return _wglReleaseVideoCaptureDeviceNV_fnptr(hDc, hDevice);
         }
         
@@ -1093,7 +1093,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglReleaseVideoDeviceNV_Lazy(IntPtr hVideoDevice)
         {
-            _wglReleaseVideoDeviceNV_fnptr = (delegate* unmanaged<IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglReleaseVideoDeviceNV");
+            _wglReleaseVideoDeviceNV_fnptr = (delegate* unmanaged<IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglReleaseVideoDeviceNV");
             return _wglReleaseVideoDeviceNV_fnptr(hVideoDevice);
         }
         
@@ -1102,7 +1102,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglReleaseVideoImageNV_Lazy(IntPtr hPbuffer, int iVideoBuffer)
         {
-            _wglReleaseVideoImageNV_fnptr = (delegate* unmanaged<IntPtr, int, int>)GLLoader.BindingsContext.GetProcAddress("wglReleaseVideoImageNV");
+            _wglReleaseVideoImageNV_fnptr = (delegate* unmanaged<IntPtr, int, int>)WGLLoader.BindingsContext.GetProcAddress("wglReleaseVideoImageNV");
             return _wglReleaseVideoImageNV_fnptr(hPbuffer, iVideoBuffer);
         }
         
@@ -1111,7 +1111,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglResetFrameCountNV_Lazy(IntPtr hDC)
         {
-            _wglResetFrameCountNV_fnptr = (delegate* unmanaged<IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglResetFrameCountNV");
+            _wglResetFrameCountNV_fnptr = (delegate* unmanaged<IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglResetFrameCountNV");
             return _wglResetFrameCountNV_fnptr(hDC);
         }
         
@@ -1120,7 +1120,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglRestoreBufferRegionARB_Lazy(IntPtr hRegion, int x, int y, int width, int height, int xSrc, int ySrc)
         {
-            _wglRestoreBufferRegionARB_fnptr = (delegate* unmanaged<IntPtr, int, int, int, int, int, int, int>)GLLoader.BindingsContext.GetProcAddress("wglRestoreBufferRegionARB");
+            _wglRestoreBufferRegionARB_fnptr = (delegate* unmanaged<IntPtr, int, int, int, int, int, int, int>)WGLLoader.BindingsContext.GetProcAddress("wglRestoreBufferRegionARB");
             return _wglRestoreBufferRegionARB_fnptr(hRegion, x, y, width, height, xSrc, ySrc);
         }
         
@@ -1129,7 +1129,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglSaveBufferRegionARB_Lazy(IntPtr hRegion, int x, int y, int width, int height)
         {
-            _wglSaveBufferRegionARB_fnptr = (delegate* unmanaged<IntPtr, int, int, int, int, int>)GLLoader.BindingsContext.GetProcAddress("wglSaveBufferRegionARB");
+            _wglSaveBufferRegionARB_fnptr = (delegate* unmanaged<IntPtr, int, int, int, int, int>)WGLLoader.BindingsContext.GetProcAddress("wglSaveBufferRegionARB");
             return _wglSaveBufferRegionARB_fnptr(hRegion, x, y, width, height);
         }
         
@@ -1138,7 +1138,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglSendPbufferToVideoNV_Lazy(IntPtr hPbuffer, int iBufferType, ulong* pulCounterPbuffer, int bBlock)
         {
-            _wglSendPbufferToVideoNV_fnptr = (delegate* unmanaged<IntPtr, int, ulong*, int, int>)GLLoader.BindingsContext.GetProcAddress("wglSendPbufferToVideoNV");
+            _wglSendPbufferToVideoNV_fnptr = (delegate* unmanaged<IntPtr, int, ulong*, int, int>)WGLLoader.BindingsContext.GetProcAddress("wglSendPbufferToVideoNV");
             return _wglSendPbufferToVideoNV_fnptr(hPbuffer, iBufferType, pulCounterPbuffer, bBlock);
         }
         
@@ -1147,7 +1147,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglSetDigitalVideoParametersI3D_Lazy(IntPtr hDC, int iAttribute, int* piValue)
         {
-            _wglSetDigitalVideoParametersI3D_fnptr = (delegate* unmanaged<IntPtr, int, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglSetDigitalVideoParametersI3D");
+            _wglSetDigitalVideoParametersI3D_fnptr = (delegate* unmanaged<IntPtr, int, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglSetDigitalVideoParametersI3D");
             return _wglSetDigitalVideoParametersI3D_fnptr(hDC, iAttribute, piValue);
         }
         
@@ -1156,7 +1156,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglSetGammaTableI3D_Lazy(IntPtr hDC, int iEntries, ushort* puRed, ushort* puGreen, ushort* puBlue)
         {
-            _wglSetGammaTableI3D_fnptr = (delegate* unmanaged<IntPtr, int, ushort*, ushort*, ushort*, int>)GLLoader.BindingsContext.GetProcAddress("wglSetGammaTableI3D");
+            _wglSetGammaTableI3D_fnptr = (delegate* unmanaged<IntPtr, int, ushort*, ushort*, ushort*, int>)WGLLoader.BindingsContext.GetProcAddress("wglSetGammaTableI3D");
             return _wglSetGammaTableI3D_fnptr(hDC, iEntries, puRed, puGreen, puBlue);
         }
         
@@ -1165,7 +1165,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglSetGammaTableParametersI3D_Lazy(IntPtr hDC, int iAttribute, int* piValue)
         {
-            _wglSetGammaTableParametersI3D_fnptr = (delegate* unmanaged<IntPtr, int, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglSetGammaTableParametersI3D");
+            _wglSetGammaTableParametersI3D_fnptr = (delegate* unmanaged<IntPtr, int, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglSetGammaTableParametersI3D");
             return _wglSetGammaTableParametersI3D_fnptr(hDC, iAttribute, piValue);
         }
         
@@ -1174,7 +1174,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglSetLayerPaletteEntries_Lazy(IntPtr hdc, int iLayerPlane, int iStart, int cEntries, uint* pcr)
         {
-            _wglSetLayerPaletteEntries_fnptr = (delegate* unmanaged<IntPtr, int, int, int, uint*, int>)GLLoader.BindingsContext.GetProcAddress("wglSetLayerPaletteEntries");
+            _wglSetLayerPaletteEntries_fnptr = (delegate* unmanaged<IntPtr, int, int, int, uint*, int>)WGLLoader.BindingsContext.GetProcAddress("wglSetLayerPaletteEntries");
             return _wglSetLayerPaletteEntries_fnptr(hdc, iLayerPlane, iStart, cEntries, pcr);
         }
         
@@ -1183,7 +1183,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglSetPbufferAttribARB_Lazy(IntPtr hPbuffer, int* piAttribList)
         {
-            _wglSetPbufferAttribARB_fnptr = (delegate* unmanaged<IntPtr, int*, int>)GLLoader.BindingsContext.GetProcAddress("wglSetPbufferAttribARB");
+            _wglSetPbufferAttribARB_fnptr = (delegate* unmanaged<IntPtr, int*, int>)WGLLoader.BindingsContext.GetProcAddress("wglSetPbufferAttribARB");
             return _wglSetPbufferAttribARB_fnptr(hPbuffer, piAttribList);
         }
         
@@ -1192,7 +1192,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglSetStereoEmitterState3DL_Lazy(IntPtr hDC, uint uState)
         {
-            _wglSetStereoEmitterState3DL_fnptr = (delegate* unmanaged<IntPtr, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglSetStereoEmitterState3DL");
+            _wglSetStereoEmitterState3DL_fnptr = (delegate* unmanaged<IntPtr, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglSetStereoEmitterState3DL");
             return _wglSetStereoEmitterState3DL_fnptr(hDC, uState);
         }
         
@@ -1201,7 +1201,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglShareLists_Lazy(IntPtr hrcSrvShare, IntPtr hrcSrvSource)
         {
-            _wglShareLists_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglShareLists");
+            _wglShareLists_fnptr = (delegate* unmanaged<IntPtr, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglShareLists");
             return _wglShareLists_fnptr(hrcSrvShare, hrcSrvSource);
         }
         
@@ -1210,7 +1210,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static long wglSwapBuffersMscOML_Lazy(IntPtr hdc, long target_msc, long divisor, long remainder)
         {
-            _wglSwapBuffersMscOML_fnptr = (delegate* unmanaged<IntPtr, long, long, long, long>)GLLoader.BindingsContext.GetProcAddress("wglSwapBuffersMscOML");
+            _wglSwapBuffersMscOML_fnptr = (delegate* unmanaged<IntPtr, long, long, long, long>)WGLLoader.BindingsContext.GetProcAddress("wglSwapBuffersMscOML");
             return _wglSwapBuffersMscOML_fnptr(hdc, target_msc, divisor, remainder);
         }
         
@@ -1219,7 +1219,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglSwapIntervalEXT_Lazy(int interval)
         {
-            _wglSwapIntervalEXT_fnptr = (delegate* unmanaged<int, int>)GLLoader.BindingsContext.GetProcAddress("wglSwapIntervalEXT");
+            _wglSwapIntervalEXT_fnptr = (delegate* unmanaged<int, int>)WGLLoader.BindingsContext.GetProcAddress("wglSwapIntervalEXT");
             return _wglSwapIntervalEXT_fnptr(interval);
         }
         
@@ -1228,7 +1228,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglSwapLayerBuffers_Lazy(IntPtr hdc, uint fuFlags)
         {
-            _wglSwapLayerBuffers_fnptr = (delegate* unmanaged<IntPtr, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglSwapLayerBuffers");
+            _wglSwapLayerBuffers_fnptr = (delegate* unmanaged<IntPtr, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglSwapLayerBuffers");
             return _wglSwapLayerBuffers_fnptr(hdc, fuFlags);
         }
         
@@ -1237,7 +1237,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static long wglSwapLayerBuffersMscOML_Lazy(IntPtr hdc, int fuPlanes, long target_msc, long divisor, long remainder)
         {
-            _wglSwapLayerBuffersMscOML_fnptr = (delegate* unmanaged<IntPtr, int, long, long, long, long>)GLLoader.BindingsContext.GetProcAddress("wglSwapLayerBuffersMscOML");
+            _wglSwapLayerBuffersMscOML_fnptr = (delegate* unmanaged<IntPtr, int, long, long, long, long>)WGLLoader.BindingsContext.GetProcAddress("wglSwapLayerBuffersMscOML");
             return _wglSwapLayerBuffersMscOML_fnptr(hdc, fuPlanes, target_msc, divisor, remainder);
         }
         
@@ -1246,7 +1246,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglUseFontBitmaps_Lazy(IntPtr hDC, uint first, uint count, uint listBase)
         {
-            _wglUseFontBitmaps_fnptr = (delegate* unmanaged<IntPtr, uint, uint, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglUseFontBitmaps");
+            _wglUseFontBitmaps_fnptr = (delegate* unmanaged<IntPtr, uint, uint, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglUseFontBitmaps");
             return _wglUseFontBitmaps_fnptr(hDC, first, count, listBase);
         }
         
@@ -1255,7 +1255,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglUseFontBitmapsA_Lazy(IntPtr hDC, uint first, uint count, uint listBase)
         {
-            _wglUseFontBitmapsA_fnptr = (delegate* unmanaged<IntPtr, uint, uint, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglUseFontBitmapsA");
+            _wglUseFontBitmapsA_fnptr = (delegate* unmanaged<IntPtr, uint, uint, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglUseFontBitmapsA");
             return _wglUseFontBitmapsA_fnptr(hDC, first, count, listBase);
         }
         
@@ -1264,7 +1264,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglUseFontBitmapsW_Lazy(IntPtr hDC, uint first, uint count, uint listBase)
         {
-            _wglUseFontBitmapsW_fnptr = (delegate* unmanaged<IntPtr, uint, uint, uint, int>)GLLoader.BindingsContext.GetProcAddress("wglUseFontBitmapsW");
+            _wglUseFontBitmapsW_fnptr = (delegate* unmanaged<IntPtr, uint, uint, uint, int>)WGLLoader.BindingsContext.GetProcAddress("wglUseFontBitmapsW");
             return _wglUseFontBitmapsW_fnptr(hDC, first, count, listBase);
         }
         
@@ -1273,7 +1273,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglUseFontOutlines_Lazy(IntPtr hDC, uint first, uint count, uint listBase, float deviation, float extrusion, int format, IntPtr lpgmf)
         {
-            _wglUseFontOutlines_fnptr = (delegate* unmanaged<IntPtr, uint, uint, uint, float, float, int, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglUseFontOutlines");
+            _wglUseFontOutlines_fnptr = (delegate* unmanaged<IntPtr, uint, uint, uint, float, float, int, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglUseFontOutlines");
             return _wglUseFontOutlines_fnptr(hDC, first, count, listBase, deviation, extrusion, format, lpgmf);
         }
         
@@ -1282,7 +1282,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglUseFontOutlinesA_Lazy(IntPtr hDC, uint first, uint count, uint listBase, float deviation, float extrusion, int format, IntPtr lpgmf)
         {
-            _wglUseFontOutlinesA_fnptr = (delegate* unmanaged<IntPtr, uint, uint, uint, float, float, int, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglUseFontOutlinesA");
+            _wglUseFontOutlinesA_fnptr = (delegate* unmanaged<IntPtr, uint, uint, uint, float, float, int, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglUseFontOutlinesA");
             return _wglUseFontOutlinesA_fnptr(hDC, first, count, listBase, deviation, extrusion, format, lpgmf);
         }
         
@@ -1291,7 +1291,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglUseFontOutlinesW_Lazy(IntPtr hDC, uint first, uint count, uint listBase, float deviation, float extrusion, int format, IntPtr lpgmf)
         {
-            _wglUseFontOutlinesW_fnptr = (delegate* unmanaged<IntPtr, uint, uint, uint, float, float, int, IntPtr, int>)GLLoader.BindingsContext.GetProcAddress("wglUseFontOutlinesW");
+            _wglUseFontOutlinesW_fnptr = (delegate* unmanaged<IntPtr, uint, uint, uint, float, float, int, IntPtr, int>)WGLLoader.BindingsContext.GetProcAddress("wglUseFontOutlinesW");
             return _wglUseFontOutlinesW_fnptr(hDC, first, count, listBase, deviation, extrusion, format, lpgmf);
         }
         
@@ -1300,7 +1300,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglWaitForMscOML_Lazy(IntPtr hdc, long target_msc, long divisor, long remainder, long* ust, long* msc, long* sbc)
         {
-            _wglWaitForMscOML_fnptr = (delegate* unmanaged<IntPtr, long, long, long, long*, long*, long*, int>)GLLoader.BindingsContext.GetProcAddress("wglWaitForMscOML");
+            _wglWaitForMscOML_fnptr = (delegate* unmanaged<IntPtr, long, long, long, long*, long*, long*, int>)WGLLoader.BindingsContext.GetProcAddress("wglWaitForMscOML");
             return _wglWaitForMscOML_fnptr(hdc, target_msc, divisor, remainder, ust, msc, sbc);
         }
         
@@ -1309,7 +1309,7 @@ namespace OpenTK.Graphics.Wgl
         [UnmanagedCallersOnly]
         private static int wglWaitForSbcOML_Lazy(IntPtr hdc, long target_sbc, long* ust, long* msc, long* sbc)
         {
-            _wglWaitForSbcOML_fnptr = (delegate* unmanaged<IntPtr, long, long*, long*, long*, int>)GLLoader.BindingsContext.GetProcAddress("wglWaitForSbcOML");
+            _wglWaitForSbcOML_fnptr = (delegate* unmanaged<IntPtr, long, long*, long*, long*, int>)WGLLoader.BindingsContext.GetProcAddress("wglWaitForSbcOML");
             return _wglWaitForSbcOML_fnptr(hdc, target_sbc, ust, msc, sbc);
         }
         

--- a/src/OpenTK.Graphics/WGLLoader.cs
+++ b/src/OpenTK.Graphics/WGLLoader.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenTK.Graphics
+{
+    public static class WGLLoader
+    {
+        public static class BindingsContext
+        {
+            // FIXME: Extend this to be able to use wglGetProcAddress?
+            // Alternatively allow for user provided bindings contexts to be used...
+            // - Noggin_bops 2024-03-06
+            public static IntPtr GetProcAddress(string procName)
+            {
+                if (NativeLibrary.TryGetExport(WGLHandle, procName, out IntPtr ret) == false)
+                {
+                    ret = wglGetProcAddress(procName);
+                }
+                return ret;
+            } 
+        }
+
+        private static readonly IntPtr WGLHandle = NativeLibrary.Load("opengl32.dll");
+
+        [DllImport("opengl32.dll", EntryPoint = "wglGetProcAddress", SetLastError = true)]
+        internal static extern IntPtr wglGetProcAddress([MarshalAs(UnmanagedType.LPStr)] string procName);
+    }
+}

--- a/src/OpenTK.Graphics/Wgl/Enums.cs
+++ b/src/OpenTK.Graphics/Wgl/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.Wgl

--- a/src/OpenTK.Graphics/Wgl/Enums.cs
+++ b/src/OpenTK.Graphics/Wgl/Enums.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 
 namespace OpenTK.Graphics.Wgl

--- a/src/OpenTK.Graphics/Wgl/WGL.Native.cs
+++ b/src/OpenTK.Graphics/Wgl/WGL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;
@@ -46,7 +46,7 @@ namespace OpenTK.Graphics.Wgl
         public static int GetPixelFormat(IntPtr hdc) => WglPointers._GetPixelFormat_fnptr(hdc);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>wglGetProcAddress</c>]</b><br/>  </summary>
-        public static IntPtr GetProcAddress(char* lpszProc) => WglPointers._wglGetProcAddress_fnptr(lpszProc);
+        public static IntPtr GetProcAddress(byte* lpszProc) => WglPointers._wglGetProcAddress_fnptr(lpszProc);
         
         /// <summary> <b>[requires: v1.0]</b> <b>[entry point: <c>wglMakeCurrent</c>]</b><br/>  </summary>
         public static int MakeCurrent_(IntPtr hDc, IntPtr newContext) => WglPointers._wglMakeCurrent_fnptr(hDc, newContext);

--- a/src/OpenTK.Graphics/Wgl/WGL.Native.cs
+++ b/src/OpenTK.Graphics/Wgl/WGL.Native.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics;

--- a/src/OpenTK.Graphics/Wgl/WGL.Overloads.cs
+++ b/src/OpenTK.Graphics/Wgl/WGL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 16:25:59 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -187,11 +187,11 @@ namespace OpenTK.Graphics.Wgl
             }
             return returnValue;
         }
-        /// <inheritdoc cref="GetProcAddress(char*)"/>
+        /// <inheritdoc cref="GetProcAddress(byte*)"/>
         public static unsafe IntPtr GetProcAddress(string lpszProc)
         {
             IntPtr returnValue;
-            char* lpszProc_ptr = (char*)Marshal.StringToCoTaskMemAuto(lpszProc);
+            byte* lpszProc_ptr = (byte*)Marshal.StringToCoTaskMemUTF8(lpszProc);
             returnValue = GetProcAddress(lpszProc_ptr);
             Marshal.FreeCoTaskMem((IntPtr)lpszProc_ptr);
             return returnValue;

--- a/src/OpenTK.Graphics/Wgl/WGL.Overloads.cs
+++ b/src/OpenTK.Graphics/Wgl/WGL.Overloads.cs
@@ -1,4 +1,4 @@
-// This file is auto generated, do not edit. Generated: 2024-03-06 18:33:30 GMT+01:00
+// This file is auto generated, do not edit. Generated: 2024-03-07 16:51:59 GMT+01:00
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/OpenTK.Platform.Native/Windows/OpenGLComponent.cs
+++ b/src/OpenTK.Platform.Native/Windows/OpenGLComponent.cs
@@ -121,7 +121,7 @@ namespace OpenTK.Platform.Native.Windows
             unsafe
             {
                 Wgl._GetExtensionsStringARB__fnptr = (delegate* unmanaged<IntPtr, byte*>)Wgl.GetProcAddress("wglGetExtensionsStringARB");
-
+                
                 Wgl._GetPixelFormatAttribivARB__fnptr = (delegate* unmanaged<IntPtr, int, int, uint, int*, int*, int>)Wgl.GetProcAddress("wglGetPixelFormatAttribivARB");
 
                 Wgl._ChoosePixelFormatARB__fnptr = (delegate* unmanaged<IntPtr, int*, float*, uint, int*, uint*, int>)Wgl.GetProcAddress("wglChoosePixelFormatARB");

--- a/tests/OpenTK.Backends.Tests/ImGuiController.cs
+++ b/tests/OpenTK.Backends.Tests/ImGuiController.cs
@@ -111,14 +111,14 @@ namespace OpenTK.Backends.Tests
             LabelObject(ObjectIdentifier.VertexArray, _vertexArray, "VAO: ImGui");
 
             _vertexBuffer = GL.GenBuffer();
-            GL.BindBuffer(BufferTargetARB.ArrayBuffer, _vertexBuffer);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _vertexBuffer);
             LabelObject(ObjectIdentifier.Buffer, _vertexBuffer, "VBO: ImGui");
-            GL.BufferData(BufferTargetARB.ArrayBuffer, _vertexBufferSize, IntPtr.Zero, BufferUsageARB.DynamicDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, _vertexBufferSize, IntPtr.Zero, BufferUsage.DynamicDraw);
 
             _indexBuffer = GL.GenBuffer();
-            GL.BindBuffer(BufferTargetARB.ElementArrayBuffer, _indexBuffer);
+            GL.BindBuffer(BufferTarget.ElementArrayBuffer, _indexBuffer);
             LabelObject(ObjectIdentifier.Buffer, _indexBuffer, "EBO: ImGui");
-            GL.BufferData(BufferTargetARB.ElementArrayBuffer, _indexBufferSize, IntPtr.Zero, BufferUsageARB.DynamicDraw);
+            GL.BufferData(BufferTarget.ElementArrayBuffer, _indexBufferSize, IntPtr.Zero, BufferUsage.DynamicDraw);
 
             RecreateFontDeviceTexture();
 
@@ -209,7 +209,7 @@ void main()
             GL.EnableVertexAttribArray(2);
 
             GL.BindVertexArray(prevVAO);
-            GL.BindBuffer(BufferTargetARB.ArrayBuffer, prevArrayBuffer);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, prevArrayBuffer);
 
             CheckGLError("End of ImGui setup");
         }
@@ -403,7 +403,7 @@ void main()
             // Bind the element buffer (thru the VAO) so that we can resize it.
             GL.BindVertexArray(_vertexArray);
             // Bind the vertex buffer so that we can resize it.
-            GL.BindBuffer(BufferTargetARB.ArrayBuffer, _vertexBuffer);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _vertexBuffer);
             for (int i = 0; i < draw_data.CmdListsCount; i++)
             {
                 ImDrawListPtr cmd_list = draw_data.CmdListsRange[i];
@@ -413,7 +413,7 @@ void main()
                 {
                     int newSize = (int)Math.Max(_vertexBufferSize * 1.5f, vertexSize);
 
-                    GL.BufferData(BufferTargetARB.ArrayBuffer, newSize, IntPtr.Zero, BufferUsageARB.DynamicDraw);
+                    GL.BufferData(BufferTarget.ArrayBuffer, newSize, IntPtr.Zero, BufferUsage.DynamicDraw);
                     _vertexBufferSize = newSize;
 
                     Console.WriteLine($"Resized dear imgui vertex buffer to new size {_vertexBufferSize}");
@@ -423,7 +423,7 @@ void main()
                 if (indexSize > _indexBufferSize)
                 {
                     int newSize = (int)Math.Max(_indexBufferSize * 1.5f, indexSize);
-                    GL.BufferData(BufferTargetARB.ElementArrayBuffer, newSize, IntPtr.Zero, BufferUsageARB.DynamicDraw);
+                    GL.BufferData(BufferTarget.ElementArrayBuffer, newSize, IntPtr.Zero, BufferUsage.DynamicDraw);
                     _indexBufferSize = newSize;
 
                     Console.WriteLine($"Resized dear imgui index buffer to new size {_indexBufferSize}");
@@ -452,7 +452,7 @@ void main()
 
             GL.Enable(EnableCap.Blend);
             GL.Enable(EnableCap.ScissorTest);
-            GL.BlendEquation(BlendEquationModeEXT.FuncAdd);
+            GL.BlendEquation(BlendEquationMode.FuncAdd);
             GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
             GL.Disable(EnableCap.CullFace);
             GL.Disable(EnableCap.DepthTest);
@@ -462,10 +462,10 @@ void main()
             {
                 ImDrawListPtr cmd_list = draw_data.CmdListsRange[n];
 
-                GL.BufferSubData(BufferTargetARB.ArrayBuffer, IntPtr.Zero, cmd_list.VtxBuffer.Size * Unsafe.SizeOf<ImDrawVert>(), cmd_list.VtxBuffer.Data);
+                GL.BufferSubData(BufferTarget.ArrayBuffer, IntPtr.Zero, cmd_list.VtxBuffer.Size * Unsafe.SizeOf<ImDrawVert>(), cmd_list.VtxBuffer.Data);
                 CheckGLError($"Data Vert {n}");
 
-                GL.BufferSubData(BufferTargetARB.ElementArrayBuffer, IntPtr.Zero, cmd_list.IdxBuffer.Size * sizeof(ushort), cmd_list.IdxBuffer.Data);
+                GL.BufferSubData(BufferTarget.ElementArrayBuffer, IntPtr.Zero, cmd_list.IdxBuffer.Size * sizeof(ushort), cmd_list.IdxBuffer.Data);
                 CheckGLError($"Data Idx {n}");
 
                 for (int cmd_i = 0; cmd_i < cmd_list.CmdBuffer.Size; cmd_i++)
@@ -508,8 +508,8 @@ void main()
             GL.UseProgram(prevProgram);
             GL.BindVertexArray(prevVAO);
             GL.Scissor(prevScissorBox[0], prevScissorBox[1], prevScissorBox[2], prevScissorBox[3]);
-            GL.BindBuffer(BufferTargetARB.ArrayBuffer, prevArrayBuffer);
-            GL.BlendEquationSeparate((BlendEquationModeEXT)prevBlendEquationRgb, (BlendEquationModeEXT)prevBlendEquationAlpha);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, prevArrayBuffer);
+            GL.BlendEquationSeparate((BlendEquationMode)prevBlendEquationRgb, (BlendEquationMode)prevBlendEquationAlpha);
             GL.BlendFuncSeparate(
                 (BlendingFactor)prevBlendFuncSrcRgb,
                 (BlendingFactor)prevBlendFuncDstRgb,
@@ -565,7 +565,7 @@ void main()
             GL.LinkProgram(program);
 
             int success = 0;
-            GL.GetProgrami(program, ProgramPropertyARB.LinkStatus, ref success);
+            GL.GetProgrami(program, ProgramProperty.LinkStatus, ref success);
             if (success == 0)
             {
                 GL.GetProgramInfoLog(program, out string info);

--- a/tests/OpenTK.Backends.Tests/OpenTK.Backends.Tests.csproj
+++ b/tests/OpenTK.Backends.Tests/OpenTK.Backends.Tests.csproj
@@ -7,7 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Uncomment this if not using the .res resource file. -->
     <!--<ApplicationIcon>Resources\opentk_logo_small.ico</ApplicationIcon>-->
-    <Win32Resource>icons.res</Win32Resource>
+    <!--<Win32Resource>icons.res</Win32Resource>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/OpenTK.Backends.Tests/TestApps/ColorTriangle.cs
+++ b/tests/OpenTK.Backends.Tests/TestApps/ColorTriangle.cs
@@ -141,10 +141,10 @@ void main()
             if (KHRDebugAvailable) GL.ObjectLabel(ObjectIdentifier.VertexArray, (uint)VAO, -1, "VAO: Color Triangle");
 
             VBO = GL.GenBuffer();
-            GL.BindBuffer(BufferTargetARB.ArrayBuffer, VBO);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, VBO);
             if (KHRDebugAvailable) GL.ObjectLabel(ObjectIdentifier.Buffer, (uint)VBO, -1, "VBO: Color Triangle");
 
-            GL.BufferData(BufferTargetARB.ArrayBuffer, Vertices, BufferUsageARB.StaticDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, Vertices, BufferUsage.StaticDraw);
 
             GL.EnableVertexAttribArray(0);
             GL.VertexAttribPointer(0, 2, VertexAttribPointerType.Float, false, Unsafe.SizeOf<Vertex>(), 0);
@@ -182,7 +182,7 @@ void main()
                 GL.AttachShader(program, fragment);
 
                 GL.LinkProgram(program);
-                GL.GetProgrami(program, ProgramPropertyARB.LinkStatus, ref status);
+                GL.GetProgrami(program, ProgramProperty.LinkStatus, ref status);
                 if (status == 0)
                 {
                     GL.GetProgramInfoLog(program, out string info);
@@ -214,7 +214,7 @@ void main()
         public void Deinitialize()
         {
             GL.BindVertexArray(0);
-            GL.BindBuffer(BufferTargetARB.ArrayBuffer, 0);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
             GL.UseProgram(0);
 
             GL.DeleteVertexArray(VAO);


### PR DESCRIPTION
### Purpose of this PR

Modifies the generator to generate different load calls for GL, WGL and GLX so we can load their entry points separately.
Fixes #1665

### Testing status

WGL and GLX loading has been fixed and could now be used in PAL2 instead of using the handwritten WGL bindings.