### PR TITLE
Update bindings to latest updates from gl.xml

### DIFF
--- a/src/Generator.Bind/ES/ES2Generator.cs
+++ b/src/Generator.Bind/ES/ES2Generator.cs
@@ -20,6 +20,7 @@ namespace Bind.ES
                 Settings.DefaultDocPath, "ES20");
 
             Settings.OverridesFiles.Add("GL2/overrides.xml");
+            Settings.OverridesFiles.Add("GL2/compatibility 4.8.2.xml");
 
             Profile = "gles2";
             Version = "2.0";

--- a/src/Generator.Bind/ES/ES31Generator.cs
+++ b/src/Generator.Bind/ES/ES31Generator.cs
@@ -21,6 +21,7 @@ namespace Bind.ES
 
             Settings.OverridesFiles.Add("GL2/overrides.xml");
             Settings.OverridesFiles.Add("GL2/ES/3.1");
+            Settings.OverridesFiles.Add("GL2/compatibility 4.8.2.xml");
 
             Profile = "gles2";
             Version = "2.0|3.0|3.1";

--- a/src/Generator.Bind/ES/ES3Generator.cs
+++ b/src/Generator.Bind/ES/ES3Generator.cs
@@ -20,6 +20,7 @@ namespace Bind.ES
                 Settings.DefaultDocPath, "ES30");
 
             Settings.OverridesFiles.Add("GL2/overrides.xml");
+            Settings.OverridesFiles.Add("GL2/compatibility 4.8.2.xml");
 
             Profile = "gles2"; // The 3.0 spec reuses the gles2 apiname
             Version = "2.0|3.0";

--- a/src/Generator.Bind/ES/ESGenerator.cs
+++ b/src/Generator.Bind/ES/ESGenerator.cs
@@ -21,6 +21,7 @@ namespace Bind.ES
 
             Settings.OverridesFiles.Add("GL2/overrides.xml");
             Settings.OverridesFiles.Add("GL2/ES/1.1/");
+            Settings.OverridesFiles.Add("GL2/compatibility 4.8.2.xml");
 
             // Khronos releases a combined 1.0+1.1 specification,
             // so we cannot distinguish between the two.

--- a/src/Generator.Bind/FuncProcessor.cs
+++ b/src/Generator.Bind/FuncProcessor.cs
@@ -527,7 +527,13 @@ namespace Bind
                             switch (node.Name)
                             {
                                 case "type":
-                                    d.Parameters[i].CurrentType = (string)node.TypedValue;
+                                    string type = (string)node.TypedValue;
+                                    // If the replacement type has a pointer we replace the entire type
+                                    // if the type doesn't we just replace the underlying type of the pointer.
+                                    // - 2024-03-26 Noggin_bops
+                                    if (type.Contains("*"))
+                                        d.Parameters[i].Pointer = 0;
+                                    d.Parameters[i].CurrentType = type;
                                     break;
                                 case "name":
                                     d.Parameters[i].Name = (string)node.TypedValue;
@@ -561,6 +567,11 @@ namespace Bind
                 XPathNavigator return_override = function_override.SelectSingleNode("returns");
                 if (return_override != null)
                 {
+                    // If the replacement type has a pointer we replace the entire type
+                    // if the type doesn't we just replace the underlying type of the pointer.
+                    // - 2024-03-26 Noggin_bops
+                    if (return_override.Value.Contains("*"))
+                        d.ReturnType.Pointer = 0;
                     d.ReturnType.CurrentType = return_override.Value;
 
                     // If we replaced something with String we want to remove the pointer from the return type.
@@ -588,11 +599,6 @@ namespace Bind
             string apiname, string apiversion)
         {
             ApplyReturnTypeReplacement(d, function_override);
-
-            if (d.Name.Contains("GetString"))
-            {
-                ;
-            }
 
             TranslateType(d.ReturnType, function_override, nav, enum_processor, enums, d.Category, apiname);
 

--- a/src/Generator.Bind/FuncProcessor.cs
+++ b/src/Generator.Bind/FuncProcessor.cs
@@ -562,6 +562,13 @@ namespace Bind
                 if (return_override != null)
                 {
                     d.ReturnType.CurrentType = return_override.Value;
+
+                    // If we replaced something with String we want to remove the pointer from the return type.
+                    // - 2024-03-24 Noggin_bops
+                    if (return_override.Value == "String")
+                    {
+                        d.ReturnType.Pointer--;
+                    }
                 }
             }
         }
@@ -581,6 +588,11 @@ namespace Bind
             string apiname, string apiversion)
         {
             ApplyReturnTypeReplacement(d, function_override);
+
+            if (d.Name.Contains("GetString"))
+            {
+                ;
+            }
 
             TranslateType(d.ReturnType, function_override, nav, enum_processor, enums, d.Category, apiname);
 

--- a/src/Generator.Bind/GL2/GL2Generator.cs
+++ b/src/Generator.Bind/GL2/GL2Generator.cs
@@ -51,6 +51,7 @@ namespace Bind.GL2
 
             Settings.OverridesFiles.Add("GL2/overrides.xml");
             Settings.OverridesFiles.Add("GL2/GL/");
+            Settings.OverridesFiles.Add("GL2/compatibility 4.8.2.xml");
 
             //Settings.DefaultCompatibility |=
             //    Settings.Legacy.UseDllImports | Settings.Legacy.UseWindowsCompatibleGL;

--- a/src/Generator.Bind/GL2/GL4Generator.cs
+++ b/src/Generator.Bind/GL2/GL4Generator.cs
@@ -43,6 +43,7 @@ namespace Bind.GL2
 
             Settings.OverridesFiles.Add("GL2/overrides.xml");
             Settings.OverridesFiles.Add("GL2/GL/");
+            Settings.OverridesFiles.Add("GL2/compatibility 4.8.2.xml");
 
             Profile = "glcore";
 

--- a/src/Generator.Bind/Specifications/ES20/overrides.xml
+++ b/src/Generator.Bind/Specifications/ES20/overrides.xml
@@ -229,6 +229,7 @@
     </function>
 
     <function name="GetString" extension="Core" version="2.0">
+      <returns>String</returns>
       <param name="name"><type>StringName</type></param> 
     </function>
 

--- a/src/Generator.Bind/Specifications/GL2/compatibility 4.8.2.xml
+++ b/src/Generator.Bind/Specifications/GL2/compatibility 4.8.2.xml
@@ -1,0 +1,6598 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- This file is mostly generated using https://github.com/NogginBops/dotnet-api-diff -->
+<signatures>
+  <add name="gl">
+    <enum name="CheckFramebufferStatusTarget">
+      <token name="DRAW_FRAMEBUFFER" value="0x8CA9" />
+      <token name="READ_FRAMEBUFFER" value="0x8CA8" />
+      <token name="FRAMEBUFFER" value="0x8D40" />
+    </enum>
+    <enum name="ColorMaterialFace">
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT" value="0x0404" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="ColorTableParameterPNameSGI">
+      <token name="COLOR_TABLE_BIAS" value="0x80D7" />
+      <token name="COLOR_TABLE_BIAS_SGI" value="0x80D7" />
+      <token name="COLOR_TABLE_SCALE" value="0x80D6" />
+      <token name="COLOR_TABLE_SCALE_SGI" value="0x80D6" />
+    </enum>
+    <enum name="ConvolutionParameterEXT">
+      <token name="CONVOLUTION_BORDER_MODE" value="0x8013" />
+      <token name="CONVOLUTION_BORDER_MODE_EXT" value="0x8013" />
+      <token name="CONVOLUTION_FILTER_BIAS" value="0x8015" />
+      <token name="CONVOLUTION_FILTER_BIAS_EXT" value="0x8015" />
+      <token name="CONVOLUTION_FILTER_SCALE" value="0x8014" />
+      <token name="CONVOLUTION_FILTER_SCALE_EXT" value="0x8014" />
+    </enum>
+    <enum name="CullFaceMode">
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT" value="0x0404" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="DataType" />
+    <enum name="FragmentOpATI">
+      <token name="MOV_ATI" value="0x8961" />
+      <token name="ADD_ATI" value="0x8963" />
+      <token name="MUL_ATI" value="0x8964" />
+      <token name="SUB_ATI" value="0x8965" />
+      <token name="DOT3_ATI" value="0x8966" />
+      <token name="DOT4_ATI" value="0x8967" />
+      <token name="MAD_ATI" value="0x8968" />
+      <token name="LERP_ATI" value="0x8969" />
+      <token name="CND_ATI" value="0x896A" />
+      <token name="CND0_ATI" value="0x896B" />
+      <token name="DOT2_ADD_ATI" value="0x896C" />
+    </enum>
+    <enum name="FramebufferFetchNoncoherent">
+      <token name="FRAMEBUFFER_FETCH_NONCOHERENT_QCOM" value="0x96A2" />
+    </enum>
+    <enum name="GetColorTableParameterPNameSGI">
+      <token name="COLOR_TABLE_ALPHA_SIZE_SGI" value="0x80DD" />
+      <token name="COLOR_TABLE_BIAS_SGI" value="0x80D7" />
+      <token name="COLOR_TABLE_BLUE_SIZE_SGI" value="0x80DC" />
+      <token name="COLOR_TABLE_FORMAT_SGI" value="0x80D8" />
+      <token name="COLOR_TABLE_GREEN_SIZE_SGI" value="0x80DB" />
+      <token name="COLOR_TABLE_INTENSITY_SIZE_SGI" value="0x80DF" />
+      <token name="COLOR_TABLE_LUMINANCE_SIZE_SGI" value="0x80DE" />
+      <token name="COLOR_TABLE_RED_SIZE_SGI" value="0x80DA" />
+      <token name="COLOR_TABLE_SCALE_SGI" value="0x80D6" />
+      <token name="COLOR_TABLE_WIDTH_SGI" value="0x80D9" />
+      <token name="COLOR_TABLE_BIAS" value="0x80D7" />
+      <token name="COLOR_TABLE_SCALE" value="0x80D6" />
+      <token name="COLOR_TABLE_FORMAT" value="0x80D8" />
+      <token name="COLOR_TABLE_WIDTH" value="0x80D9" />
+      <token name="COLOR_TABLE_RED_SIZE" value="0x80DA" />
+      <token name="COLOR_TABLE_GREEN_SIZE" value="0x80DB" />
+      <token name="COLOR_TABLE_BLUE_SIZE" value="0x80DC" />
+      <token name="COLOR_TABLE_ALPHA_SIZE" value="0x80DD" />
+      <token name="COLOR_TABLE_LUMINANCE_SIZE" value="0x80DE" />
+      <token name="COLOR_TABLE_INTENSITY_SIZE" value="0x80DF" />
+    </enum>
+    <enum name="GetConvolutionParameter">
+      <token name="CONVOLUTION_BORDER_MODE_EXT" value="0x8013" />
+      <token name="CONVOLUTION_FILTER_BIAS_EXT" value="0x8015" />
+      <token name="CONVOLUTION_FILTER_SCALE_EXT" value="0x8014" />
+      <token name="CONVOLUTION_FORMAT_EXT" value="0x8017" />
+      <token name="CONVOLUTION_HEIGHT_EXT" value="0x8019" />
+      <token name="CONVOLUTION_WIDTH_EXT" value="0x8018" />
+      <token name="MAX_CONVOLUTION_HEIGHT_EXT" value="0x801B" />
+      <token name="MAX_CONVOLUTION_WIDTH_EXT" value="0x801A" />
+      <token name="CONVOLUTION_BORDER_MODE" value="0x8013" />
+      <token name="CONVOLUTION_BORDER_COLOR" value="0x8154" />
+      <token name="CONVOLUTION_FILTER_SCALE" value="0x8014" />
+      <token name="CONVOLUTION_FILTER_BIAS" value="0x8015" />
+      <token name="CONVOLUTION_FORMAT" value="0x8017" />
+      <token name="CONVOLUTION_WIDTH" value="0x8018" />
+      <token name="CONVOLUTION_HEIGHT" value="0x8019" />
+      <token name="MAX_CONVOLUTION_WIDTH" value="0x801A" />
+      <token name="MAX_CONVOLUTION_HEIGHT" value="0x801B" />
+    </enum>
+    <enum name="GetPixelMap">
+      <token name="PIXEL_MAP_A_TO_A" value="0x0C79" deprecated="3.2" />
+      <token name="PIXEL_MAP_B_TO_B" value="0x0C78" deprecated="3.2" />
+      <token name="PIXEL_MAP_G_TO_G" value="0x0C77" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_A" value="0x0C75" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_B" value="0x0C74" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_G" value="0x0C73" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_I" value="0x0C70" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_R" value="0x0C72" deprecated="3.2" />
+      <token name="PIXEL_MAP_R_TO_R" value="0x0C76" deprecated="3.2" />
+      <token name="PIXEL_MAP_S_TO_S" value="0x0C71" deprecated="3.2" />
+    </enum>
+    <enum name="MapBufferUsageMask">
+      <token name="CLIENT_STORAGE_BIT" value="0x0200" />
+      <token name="CLIENT_STORAGE_BIT_EXT" value="0x0200" />
+      <token name="DYNAMIC_STORAGE_BIT" value="0x0100" />
+      <token name="DYNAMIC_STORAGE_BIT_EXT" value="0x0100" />
+      <token name="MAP_COHERENT_BIT" value="0x0080" />
+      <token name="MAP_COHERENT_BIT_EXT" value="0x0080" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT" value="0x0010" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT_EXT" value="0x0010" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT" value="0x0008" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT_EXT" value="0x0008" />
+      <token name="MAP_INVALIDATE_RANGE_BIT" value="0x0004" />
+      <token name="MAP_INVALIDATE_RANGE_BIT_EXT" value="0x0004" />
+      <token name="MAP_PERSISTENT_BIT" value="0x0040" />
+      <token name="MAP_PERSISTENT_BIT_EXT" value="0x0040" />
+      <token name="MAP_READ_BIT" value="0x0001" />
+      <token name="MAP_READ_BIT_EXT" value="0x0001" />
+      <token name="MAP_UNSYNCHRONIZED_BIT" value="0x0020" />
+      <token name="MAP_UNSYNCHRONIZED_BIT_EXT" value="0x0020" />
+      <token name="MAP_WRITE_BIT" value="0x0002" />
+      <token name="MAP_WRITE_BIT_EXT" value="0x0002" />
+      <token name="SPARSE_STORAGE_BIT_ARB" value="0x0400" />
+      <token name="LGPU_SEPARATE_STORAGE_BIT_NVX" value="0x0800" />
+      <token name="PER_GPU_STORAGE_BIT_NV" value="0x0800" />
+    </enum>
+    <enum name="MaterialFace">
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT" value="0x0404" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="PixelTexGenMode">
+      <token name="LUMINANCE" value="0x1909" />
+      <token name="LUMINANCE_ALPHA" value="0x190A" />
+      <token name="NONE" value="0" />
+      <token name="PIXEL_TEX_GEN_ALPHA_LS_SGIX" value="0x8189" />
+      <token name="PIXEL_TEX_GEN_ALPHA_MS_SGIX" value="0x818A" />
+      <token name="PIXEL_TEX_GEN_ALPHA_NO_REPLACE_SGIX" value="0x8188" />
+      <token name="PIXEL_TEX_GEN_ALPHA_REPLACE_SGIX" value="0x8187" />
+      <token name="RGB" value="0x1907" />
+      <token name="RGBA" value="0x1908" />
+    </enum>
+    <enum name="PointParameterNameSGIS">
+      <token name="DISTANCE_ATTENUATION_EXT" value="0x8129" />
+      <token name="DISTANCE_ATTENUATION_SGIS" value="0x8129" />
+      <token name="POINT_DISTANCE_ATTENUATION" value="0x8129" deprecated="3.2" />
+      <token name="POINT_DISTANCE_ATTENUATION_ARB" value="0x8129" />
+      <token name="POINT_FADE_THRESHOLD_SIZE" value="0x8128" />
+      <token name="POINT_FADE_THRESHOLD_SIZE_ARB" value="0x8128" />
+      <token name="POINT_FADE_THRESHOLD_SIZE_EXT" value="0x8128" />
+      <token name="POINT_FADE_THRESHOLD_SIZE_SGIS" value="0x8128" />
+      <token name="POINT_SIZE_MAX" value="0x8127" deprecated="3.2" />
+      <token name="POINT_SIZE_MAX_ARB" value="0x8127" />
+      <token name="POINT_SIZE_MAX_EXT" value="0x8127" />
+      <token name="POINT_SIZE_MAX_SGIS" value="0x8127" />
+      <token name="POINT_SIZE_MIN" value="0x8126" deprecated="3.2" />
+      <token name="POINT_SIZE_MIN_ARB" value="0x8126" />
+      <token name="POINT_SIZE_MIN_EXT" value="0x8126" />
+      <token name="POINT_SIZE_MIN_SGIS" value="0x8126" />
+    </enum>
+    <!-- FIXME: How should we handle this? -->
+    <enum name="SamplerParameter">
+      <token name="TextureWrapS" value = "0x2802" />
+      <token name="TextureWrapT" value = "0x2803" />
+      <token name="TextureWrapR" value = "0x8072" />
+      <token name="TextureMinFilter" value = "0x2801" />
+      <token name="TextureMagFilter" value = "0x2800" />
+      <token name="TextureBorderColor" value = "0x1004" />
+      <token name="TextureMinLod" value = "0x813A" />
+      <token name="TextureMaxLod" value = "0x813B" />
+      <token name="TextureLodBias" value = "0x8501" />
+      <token name="TextureCompareMode" value = "0x884C" />
+      <token name="TextureCompareFunc" value = "0x884D" />
+      <token name="TextureMaxAnisotropyExt" value = "0x84FE" />
+    </enum>
+    <enum name="SamplerParameterName">
+      <token name="TEXTURE_WRAP_S" value="0x2802" />
+      <token name="TEXTURE_WRAP_T" value="0x2803" />
+      <token name="TEXTURE_WRAP_R" value="0x8072" />
+      <token name="TEXTURE_MIN_FILTER" value="0x2801" />
+      <token name="TEXTURE_MAG_FILTER" value="0x2800" />
+      <token name="TEXTURE_BORDER_COLOR" value="0x1004" />
+      <token name="TEXTURE_MIN_LOD" value="0x813A" />
+      <token name="TEXTURE_MAX_LOD" value="0x813B" />
+      <token name="TEXTURE_COMPARE_MODE" value="0x884C" />
+      <token name="TEXTURE_COMPARE_FUNC" value="0x884D" />
+    </enum>
+    <enum name="StencilFaceDirection">
+      <token name="FRONT" value="0x0404" />
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="TextureFilterFuncSGIS">
+      <token name="FILTER4_SGIS" value="0x8146" />
+    </enum>
+    <enum name="TypeEnum">
+      <token name="QUERY_WAIT" value="0x8E13" />
+      <token name="QUERY_NO_WAIT" value="0x8E14" />
+      <token name="QUERY_BY_REGION_WAIT" value="0x8E15" />
+      <token name="QUERY_BY_REGION_NO_WAIT" value="0x8E16" />
+    </enum>
+    <enum name="VertexBufferObjectParameter">
+      <token name="BUFFER_ACCESS" value="0x88BB" />
+      <token name="BUFFER_ACCESS_FLAGS" value="0x911F" />
+      <token name="BUFFER_IMMUTABLE_STORAGE" value="0x821F" />
+      <token name="BUFFER_MAPPED" value="0x88BC" />
+      <token name="BUFFER_MAP_LENGTH" value="0x9120" />
+      <token name="BUFFER_MAP_OFFSET" value="0x9121" />
+      <token name="BUFFER_SIZE" value="0x8764" />
+      <token name="BUFFER_STORAGE_FLAGS" value="0x8220" />
+      <token name="BUFFER_USAGE" value="0x8765" />
+    </enum>
+    <enum name="BufferAccessMask">
+      <token name="MAP_COHERENT_BIT" value="0x0080" />
+      <token name="MAP_COHERENT_BIT_EXT" value="0x0080" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT" value="0x0010" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT_EXT" value="0x0010" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT" value="0x0008" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT_EXT" value="0x0008" />
+      <token name="MAP_INVALIDATE_RANGE_BIT" value="0x0004" />
+      <token name="MAP_INVALIDATE_RANGE_BIT_EXT" value="0x0004" />
+      <token name="MAP_PERSISTENT_BIT" value="0x0040" />
+      <token name="MAP_PERSISTENT_BIT_EXT" value="0x0040" />
+      <token name="MAP_READ_BIT" value="0x0001" />
+      <token name="MAP_READ_BIT_EXT" value="0x0001" />
+      <token name="MAP_UNSYNCHRONIZED_BIT" value="0x0020" />
+      <token name="MAP_UNSYNCHRONIZED_BIT_EXT" value="0x0020" />
+      <token name="MAP_WRITE_BIT" value="0x0002" />
+      <token name="MAP_WRITE_BIT_EXT" value="0x0002" />
+    </enum>
+  </add>
+  <add name="glcore">
+    <enum name="CheckFramebufferStatusTarget">
+      <token name="DRAW_FRAMEBUFFER" value="0x8CA9" />
+      <token name="READ_FRAMEBUFFER" value="0x8CA8" />
+      <token name="FRAMEBUFFER" value="0x8D40" />
+    </enum>
+    <enum name="ColorMaterialFace">
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT" value="0x0404" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="ColorTableParameterPNameSGI">
+      <token name="COLOR_TABLE_BIAS" value="0x80D7" />
+      <token name="COLOR_TABLE_BIAS_SGI" value="0x80D7" />
+      <token name="COLOR_TABLE_SCALE" value="0x80D6" />
+      <token name="COLOR_TABLE_SCALE_SGI" value="0x80D6" />
+    </enum>
+    <enum name="ConvolutionParameterEXT">
+      <token name="CONVOLUTION_BORDER_MODE" value="0x8013" />
+      <token name="CONVOLUTION_BORDER_MODE_EXT" value="0x8013" />
+      <token name="CONVOLUTION_FILTER_BIAS" value="0x8015" />
+      <token name="CONVOLUTION_FILTER_BIAS_EXT" value="0x8015" />
+      <token name="CONVOLUTION_FILTER_SCALE" value="0x8014" />
+      <token name="CONVOLUTION_FILTER_SCALE_EXT" value="0x8014" />
+    </enum>
+    <enum name="CullFaceMode">
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT" value="0x0404" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="DataType" />
+    <enum name="FragmentOpATI">
+      <token name="MOV_ATI" value="0x8961" />
+      <token name="ADD_ATI" value="0x8963" />
+      <token name="MUL_ATI" value="0x8964" />
+      <token name="SUB_ATI" value="0x8965" />
+      <token name="DOT3_ATI" value="0x8966" />
+      <token name="DOT4_ATI" value="0x8967" />
+      <token name="MAD_ATI" value="0x8968" />
+      <token name="LERP_ATI" value="0x8969" />
+      <token name="CND_ATI" value="0x896A" />
+      <token name="CND0_ATI" value="0x896B" />
+      <token name="DOT2_ADD_ATI" value="0x896C" />
+    </enum>
+    <enum name="FramebufferFetchNoncoherent">
+      <token name="FRAMEBUFFER_FETCH_NONCOHERENT_QCOM" value="0x96A2" />
+    </enum>
+    <enum name="GetColorTableParameterPNameSGI">
+      <token name="COLOR_TABLE_ALPHA_SIZE_SGI" value="0x80DD" />
+      <token name="COLOR_TABLE_BIAS_SGI" value="0x80D7" />
+      <token name="COLOR_TABLE_BLUE_SIZE_SGI" value="0x80DC" />
+      <token name="COLOR_TABLE_FORMAT_SGI" value="0x80D8" />
+      <token name="COLOR_TABLE_GREEN_SIZE_SGI" value="0x80DB" />
+      <token name="COLOR_TABLE_INTENSITY_SIZE_SGI" value="0x80DF" />
+      <token name="COLOR_TABLE_LUMINANCE_SIZE_SGI" value="0x80DE" />
+      <token name="COLOR_TABLE_RED_SIZE_SGI" value="0x80DA" />
+      <token name="COLOR_TABLE_SCALE_SGI" value="0x80D6" />
+      <token name="COLOR_TABLE_WIDTH_SGI" value="0x80D9" />
+      <token name="COLOR_TABLE_BIAS" value="0x80D7" />
+      <token name="COLOR_TABLE_SCALE" value="0x80D6" />
+      <token name="COLOR_TABLE_FORMAT" value="0x80D8" />
+      <token name="COLOR_TABLE_WIDTH" value="0x80D9" />
+      <token name="COLOR_TABLE_RED_SIZE" value="0x80DA" />
+      <token name="COLOR_TABLE_GREEN_SIZE" value="0x80DB" />
+      <token name="COLOR_TABLE_BLUE_SIZE" value="0x80DC" />
+      <token name="COLOR_TABLE_ALPHA_SIZE" value="0x80DD" />
+      <token name="COLOR_TABLE_LUMINANCE_SIZE" value="0x80DE" />
+      <token name="COLOR_TABLE_INTENSITY_SIZE" value="0x80DF" />
+    </enum>
+    <enum name="GetConvolutionParameter">
+      <token name="CONVOLUTION_BORDER_MODE_EXT" value="0x8013" />
+      <token name="CONVOLUTION_FILTER_BIAS_EXT" value="0x8015" />
+      <token name="CONVOLUTION_FILTER_SCALE_EXT" value="0x8014" />
+      <token name="CONVOLUTION_FORMAT_EXT" value="0x8017" />
+      <token name="CONVOLUTION_HEIGHT_EXT" value="0x8019" />
+      <token name="CONVOLUTION_WIDTH_EXT" value="0x8018" />
+      <token name="MAX_CONVOLUTION_HEIGHT_EXT" value="0x801B" />
+      <token name="MAX_CONVOLUTION_WIDTH_EXT" value="0x801A" />
+      <token name="CONVOLUTION_BORDER_MODE" value="0x8013" />
+      <token name="CONVOLUTION_BORDER_COLOR" value="0x8154" />
+      <token name="CONVOLUTION_FILTER_SCALE" value="0x8014" />
+      <token name="CONVOLUTION_FILTER_BIAS" value="0x8015" />
+      <token name="CONVOLUTION_FORMAT" value="0x8017" />
+      <token name="CONVOLUTION_WIDTH" value="0x8018" />
+      <token name="CONVOLUTION_HEIGHT" value="0x8019" />
+      <token name="MAX_CONVOLUTION_WIDTH" value="0x801A" />
+      <token name="MAX_CONVOLUTION_HEIGHT" value="0x801B" />
+    </enum>
+    <enum name="GetPixelMap" />
+    <enum name="MapBufferUsageMask">
+      <token name="CLIENT_STORAGE_BIT" value="0x0200" />
+      <token name="CLIENT_STORAGE_BIT_EXT" value="0x0200" />
+      <token name="DYNAMIC_STORAGE_BIT" value="0x0100" />
+      <token name="DYNAMIC_STORAGE_BIT_EXT" value="0x0100" />
+      <token name="MAP_COHERENT_BIT" value="0x0080" />
+      <token name="MAP_COHERENT_BIT_EXT" value="0x0080" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT" value="0x0010" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT_EXT" value="0x0010" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT" value="0x0008" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT_EXT" value="0x0008" />
+      <token name="MAP_INVALIDATE_RANGE_BIT" value="0x0004" />
+      <token name="MAP_INVALIDATE_RANGE_BIT_EXT" value="0x0004" />
+      <token name="MAP_PERSISTENT_BIT" value="0x0040" />
+      <token name="MAP_PERSISTENT_BIT_EXT" value="0x0040" />
+      <token name="MAP_READ_BIT" value="0x0001" />
+      <token name="MAP_READ_BIT_EXT" value="0x0001" />
+      <token name="MAP_UNSYNCHRONIZED_BIT" value="0x0020" />
+      <token name="MAP_UNSYNCHRONIZED_BIT_EXT" value="0x0020" />
+      <token name="MAP_WRITE_BIT" value="0x0002" />
+      <token name="MAP_WRITE_BIT_EXT" value="0x0002" />
+      <token name="SPARSE_STORAGE_BIT_ARB" value="0x0400" />
+      <token name="LGPU_SEPARATE_STORAGE_BIT_NVX" value="0x0800" />
+      <token name="PER_GPU_STORAGE_BIT_NV" value="0x0800" />
+    </enum>
+    <enum name="MaterialFace">
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT" value="0x0404" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="PixelTexGenMode">
+      <token name="LUMINANCE" value="0x1909" />
+      <token name="LUMINANCE_ALPHA" value="0x190A" />
+      <token name="NONE" value="0" />
+      <token name="PIXEL_TEX_GEN_ALPHA_LS_SGIX" value="0x8189" />
+      <token name="PIXEL_TEX_GEN_ALPHA_MS_SGIX" value="0x818A" />
+      <token name="PIXEL_TEX_GEN_ALPHA_NO_REPLACE_SGIX" value="0x8188" />
+      <token name="PIXEL_TEX_GEN_ALPHA_REPLACE_SGIX" value="0x8187" />
+      <token name="RGB" value="0x1907" />
+      <token name="RGBA" value="0x1908" />
+    </enum>
+    <enum name="PointParameterNameSGIS">
+      <token name="DISTANCE_ATTENUATION_EXT" value="0x8129" />
+      <token name="DISTANCE_ATTENUATION_SGIS" value="0x8129" />
+      <token name="POINT_DISTANCE_ATTENUATION_ARB" value="0x8129" />
+      <token name="POINT_FADE_THRESHOLD_SIZE" value="0x8128" />
+      <token name="POINT_FADE_THRESHOLD_SIZE_ARB" value="0x8128" />
+      <token name="POINT_FADE_THRESHOLD_SIZE_EXT" value="0x8128" />
+      <token name="POINT_FADE_THRESHOLD_SIZE_SGIS" value="0x8128" />
+      <token name="POINT_SIZE_MAX_ARB" value="0x8127" />
+      <token name="POINT_SIZE_MAX_EXT" value="0x8127" />
+      <token name="POINT_SIZE_MAX_SGIS" value="0x8127" />
+      <token name="POINT_SIZE_MIN_ARB" value="0x8126" />
+      <token name="POINT_SIZE_MIN_EXT" value="0x8126" />
+      <token name="POINT_SIZE_MIN_SGIS" value="0x8126" />
+    </enum>
+    <enum name="SamplerParameterName">
+      <token name="TEXTURE_WRAP_S" value="0x2802" />
+      <token name="TEXTURE_WRAP_T" value="0x2803" />
+      <token name="TEXTURE_WRAP_R" value="0x8072" />
+      <token name="TEXTURE_MIN_FILTER" value="0x2801" />
+      <token name="TEXTURE_MAG_FILTER" value="0x2800" />
+      <token name="TEXTURE_BORDER_COLOR" value="0x1004" />
+      <token name="TEXTURE_MIN_LOD" value="0x813A" />
+      <token name="TEXTURE_MAX_LOD" value="0x813B" />
+      <token name="TEXTURE_COMPARE_MODE" value="0x884C" />
+      <token name="TEXTURE_COMPARE_FUNC" value="0x884D" />
+    </enum>
+    <enum name="StencilFaceDirection">
+      <token name="FRONT" value="0x0404" />
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="TextureFilterFuncSGIS">
+      <token name="FILTER4_SGIS" value="0x8146" />
+    </enum>
+    <enum name="TypeEnum">
+      <token name="QUERY_WAIT" value="0x8E13" />
+      <token name="QUERY_NO_WAIT" value="0x8E14" />
+      <token name="QUERY_BY_REGION_WAIT" value="0x8E15" />
+      <token name="QUERY_BY_REGION_NO_WAIT" value="0x8E16" />
+    </enum>
+    <enum name="VertexBufferObjectParameter">
+      <token name="BUFFER_ACCESS" value="0x88BB" />
+      <token name="BUFFER_ACCESS_FLAGS" value="0x911F" />
+      <token name="BUFFER_IMMUTABLE_STORAGE" value="0x821F" />
+      <token name="BUFFER_MAPPED" value="0x88BC" />
+      <token name="BUFFER_MAP_LENGTH" value="0x9120" />
+      <token name="BUFFER_MAP_OFFSET" value="0x9121" />
+      <token name="BUFFER_SIZE" value="0x8764" />
+      <token name="BUFFER_STORAGE_FLAGS" value="0x8220" />
+      <token name="BUFFER_USAGE" value="0x8765" />
+    </enum>
+    <enum name="BufferAccessMask">
+      <token name="MAP_COHERENT_BIT" value="0x0080" />
+      <token name="MAP_COHERENT_BIT_EXT" value="0x0080" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT" value="0x0010" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT_EXT" value="0x0010" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT" value="0x0008" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT_EXT" value="0x0008" />
+      <token name="MAP_INVALIDATE_RANGE_BIT" value="0x0004" />
+      <token name="MAP_INVALIDATE_RANGE_BIT_EXT" value="0x0004" />
+      <token name="MAP_PERSISTENT_BIT" value="0x0040" />
+      <token name="MAP_PERSISTENT_BIT_EXT" value="0x0040" />
+      <token name="MAP_READ_BIT" value="0x0001" />
+      <token name="MAP_READ_BIT_EXT" value="0x0001" />
+      <token name="MAP_UNSYNCHRONIZED_BIT" value="0x0020" />
+      <token name="MAP_UNSYNCHRONIZED_BIT_EXT" value="0x0020" />
+      <token name="MAP_WRITE_BIT" value="0x0002" />
+      <token name="MAP_WRITE_BIT_EXT" value="0x0002" />
+    </enum>
+  </add>
+  <add name="gles1">
+    <enum name="CheckFramebufferStatusTarget">
+      <token name="DRAW_FRAMEBUFFER" value="0x8CA9" />
+      <token name="READ_FRAMEBUFFER" value="0x8CA8" />
+      <token name="FRAMEBUFFER" value="0x8D40" />
+    </enum>
+    <enum name="ColorMaterialFace">
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT" value="0x0404" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="ColorTableParameterPNameSGI">
+      <token name="COLOR_TABLE_BIAS" value="0x80D7" />
+      <token name="COLOR_TABLE_BIAS_SGI" value="0x80D7" />
+      <token name="COLOR_TABLE_SCALE" value="0x80D6" />
+      <token name="COLOR_TABLE_SCALE_SGI" value="0x80D6" />
+    </enum>
+    <enum name="ConvolutionParameterEXT">
+      <token name="CONVOLUTION_BORDER_MODE" value="0x8013" />
+      <token name="CONVOLUTION_BORDER_MODE_EXT" value="0x8013" />
+      <token name="CONVOLUTION_FILTER_BIAS" value="0x8015" />
+      <token name="CONVOLUTION_FILTER_BIAS_EXT" value="0x8015" />
+      <token name="CONVOLUTION_FILTER_SCALE" value="0x8014" />
+      <token name="CONVOLUTION_FILTER_SCALE_EXT" value="0x8014" />
+    </enum>
+    <enum name="CullFaceMode">
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT" value="0x0404" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="DataType" />
+    <enum name="FragmentOpATI">
+      <token name="MOV_ATI" value="0x8961" />
+      <token name="ADD_ATI" value="0x8963" />
+      <token name="MUL_ATI" value="0x8964" />
+      <token name="SUB_ATI" value="0x8965" />
+      <token name="DOT3_ATI" value="0x8966" />
+      <token name="DOT4_ATI" value="0x8967" />
+      <token name="MAD_ATI" value="0x8968" />
+      <token name="LERP_ATI" value="0x8969" />
+      <token name="CND_ATI" value="0x896A" />
+      <token name="CND0_ATI" value="0x896B" />
+      <token name="DOT2_ADD_ATI" value="0x896C" />
+    </enum>
+    <enum name="FramebufferFetchNoncoherent">
+      <token name="FRAMEBUFFER_FETCH_NONCOHERENT_QCOM" value="0x96A2" />
+    </enum>
+    <enum name="GetColorTableParameterPNameSGI">
+      <token name="COLOR_TABLE_ALPHA_SIZE_SGI" value="0x80DD" />
+      <token name="COLOR_TABLE_BIAS_SGI" value="0x80D7" />
+      <token name="COLOR_TABLE_BLUE_SIZE_SGI" value="0x80DC" />
+      <token name="COLOR_TABLE_FORMAT_SGI" value="0x80D8" />
+      <token name="COLOR_TABLE_GREEN_SIZE_SGI" value="0x80DB" />
+      <token name="COLOR_TABLE_INTENSITY_SIZE_SGI" value="0x80DF" />
+      <token name="COLOR_TABLE_LUMINANCE_SIZE_SGI" value="0x80DE" />
+      <token name="COLOR_TABLE_RED_SIZE_SGI" value="0x80DA" />
+      <token name="COLOR_TABLE_SCALE_SGI" value="0x80D6" />
+      <token name="COLOR_TABLE_WIDTH_SGI" value="0x80D9" />
+      <token name="COLOR_TABLE_BIAS" value="0x80D7" />
+      <token name="COLOR_TABLE_SCALE" value="0x80D6" />
+      <token name="COLOR_TABLE_FORMAT" value="0x80D8" />
+      <token name="COLOR_TABLE_WIDTH" value="0x80D9" />
+      <token name="COLOR_TABLE_RED_SIZE" value="0x80DA" />
+      <token name="COLOR_TABLE_GREEN_SIZE" value="0x80DB" />
+      <token name="COLOR_TABLE_BLUE_SIZE" value="0x80DC" />
+      <token name="COLOR_TABLE_ALPHA_SIZE" value="0x80DD" />
+      <token name="COLOR_TABLE_LUMINANCE_SIZE" value="0x80DE" />
+      <token name="COLOR_TABLE_INTENSITY_SIZE" value="0x80DF" />
+    </enum>
+    <enum name="GetConvolutionParameter">
+      <token name="CONVOLUTION_BORDER_MODE_EXT" value="0x8013" />
+      <token name="CONVOLUTION_FILTER_BIAS_EXT" value="0x8015" />
+      <token name="CONVOLUTION_FILTER_SCALE_EXT" value="0x8014" />
+      <token name="CONVOLUTION_FORMAT_EXT" value="0x8017" />
+      <token name="CONVOLUTION_HEIGHT_EXT" value="0x8019" />
+      <token name="CONVOLUTION_WIDTH_EXT" value="0x8018" />
+      <token name="MAX_CONVOLUTION_HEIGHT_EXT" value="0x801B" />
+      <token name="MAX_CONVOLUTION_WIDTH_EXT" value="0x801A" />
+      <token name="CONVOLUTION_BORDER_MODE" value="0x8013" />
+      <token name="CONVOLUTION_BORDER_COLOR" value="0x8154" />
+      <token name="CONVOLUTION_FILTER_SCALE" value="0x8014" />
+      <token name="CONVOLUTION_FILTER_BIAS" value="0x8015" />
+      <token name="CONVOLUTION_FORMAT" value="0x8017" />
+      <token name="CONVOLUTION_WIDTH" value="0x8018" />
+      <token name="CONVOLUTION_HEIGHT" value="0x8019" />
+      <token name="MAX_CONVOLUTION_WIDTH" value="0x801A" />
+      <token name="MAX_CONVOLUTION_HEIGHT" value="0x801B" />
+    </enum>
+    <enum name="GetPixelMap">
+      <token name="PIXEL_MAP_A_TO_A" value="0x0C79" deprecated="3.2" />
+      <token name="PIXEL_MAP_B_TO_B" value="0x0C78" deprecated="3.2" />
+      <token name="PIXEL_MAP_G_TO_G" value="0x0C77" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_A" value="0x0C75" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_B" value="0x0C74" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_G" value="0x0C73" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_I" value="0x0C70" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_R" value="0x0C72" deprecated="3.2" />
+      <token name="PIXEL_MAP_R_TO_R" value="0x0C76" deprecated="3.2" />
+      <token name="PIXEL_MAP_S_TO_S" value="0x0C71" deprecated="3.2" />
+    </enum>
+    <enum name="MapBufferUsageMask">
+      <token name="CLIENT_STORAGE_BIT" value="0x0200" />
+      <token name="CLIENT_STORAGE_BIT_EXT" value="0x0200" />
+      <token name="DYNAMIC_STORAGE_BIT" value="0x0100" />
+      <token name="DYNAMIC_STORAGE_BIT_EXT" value="0x0100" />
+      <token name="MAP_COHERENT_BIT" value="0x0080" />
+      <token name="MAP_COHERENT_BIT_EXT" value="0x0080" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT" value="0x0010" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT_EXT" value="0x0010" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT" value="0x0008" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT_EXT" value="0x0008" />
+      <token name="MAP_INVALIDATE_RANGE_BIT" value="0x0004" />
+      <token name="MAP_INVALIDATE_RANGE_BIT_EXT" value="0x0004" />
+      <token name="MAP_PERSISTENT_BIT" value="0x0040" />
+      <token name="MAP_PERSISTENT_BIT_EXT" value="0x0040" />
+      <token name="MAP_READ_BIT" value="0x0001" />
+      <token name="MAP_READ_BIT_EXT" value="0x0001" />
+      <token name="MAP_UNSYNCHRONIZED_BIT" value="0x0020" />
+      <token name="MAP_UNSYNCHRONIZED_BIT_EXT" value="0x0020" />
+      <token name="MAP_WRITE_BIT" value="0x0002" />
+      <token name="MAP_WRITE_BIT_EXT" value="0x0002" />
+      <token name="SPARSE_STORAGE_BIT_ARB" value="0x0400" />
+      <token name="LGPU_SEPARATE_STORAGE_BIT_NVX" value="0x0800" />
+      <token name="PER_GPU_STORAGE_BIT_NV" value="0x0800" />
+    </enum>
+    <enum name="MaterialFace">
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT" value="0x0404" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="PixelTexGenMode">
+      <token name="LUMINANCE" value="0x1909" />
+      <token name="LUMINANCE_ALPHA" value="0x190A" />
+      <token name="NONE" value="0" />
+      <token name="PIXEL_TEX_GEN_ALPHA_LS_SGIX" value="0x8189" />
+      <token name="PIXEL_TEX_GEN_ALPHA_MS_SGIX" value="0x818A" />
+      <token name="PIXEL_TEX_GEN_ALPHA_NO_REPLACE_SGIX" value="0x8188" />
+      <token name="PIXEL_TEX_GEN_ALPHA_REPLACE_SGIX" value="0x8187" />
+      <token name="RGB" value="0x1907" />
+      <token name="RGBA" value="0x1908" />
+    </enum>
+    <enum name="PointParameterNameSGIS">
+      <token name="DISTANCE_ATTENUATION_EXT" value="0x8129" />
+      <token name="DISTANCE_ATTENUATION_SGIS" value="0x8129" />
+      <token name="POINT_DISTANCE_ATTENUATION" value="0x8129" deprecated="3.2" />
+      <token name="POINT_DISTANCE_ATTENUATION_ARB" value="0x8129" />
+      <token name="POINT_FADE_THRESHOLD_SIZE" value="0x8128" />
+      <token name="POINT_FADE_THRESHOLD_SIZE_ARB" value="0x8128" />
+      <token name="POINT_FADE_THRESHOLD_SIZE_EXT" value="0x8128" />
+      <token name="POINT_FADE_THRESHOLD_SIZE_SGIS" value="0x8128" />
+      <token name="POINT_SIZE_MAX" value="0x8127" deprecated="3.2" />
+      <token name="POINT_SIZE_MAX_ARB" value="0x8127" />
+      <token name="POINT_SIZE_MAX_EXT" value="0x8127" />
+      <token name="POINT_SIZE_MAX_SGIS" value="0x8127" />
+      <token name="POINT_SIZE_MIN" value="0x8126" deprecated="3.2" />
+      <token name="POINT_SIZE_MIN_ARB" value="0x8126" />
+      <token name="POINT_SIZE_MIN_EXT" value="0x8126" />
+      <token name="POINT_SIZE_MIN_SGIS" value="0x8126" />
+    </enum>
+    <enum name="SamplerParameterName">
+      <token name="TEXTURE_WRAP_S" value="0x2802" />
+      <token name="TEXTURE_WRAP_T" value="0x2803" />
+      <token name="TEXTURE_WRAP_R" value="0x8072" />
+      <token name="TEXTURE_MIN_FILTER" value="0x2801" />
+      <token name="TEXTURE_MAG_FILTER" value="0x2800" />
+      <token name="TEXTURE_BORDER_COLOR" value="0x1004" />
+      <token name="TEXTURE_MIN_LOD" value="0x813A" />
+      <token name="TEXTURE_MAX_LOD" value="0x813B" />
+      <token name="TEXTURE_COMPARE_MODE" value="0x884C" />
+      <token name="TEXTURE_COMPARE_FUNC" value="0x884D" />
+    </enum>
+    <enum name="StencilFaceDirection">
+      <token name="FRONT" value="0x0404" />
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="TextureFilterFuncSGIS">
+      <token name="FILTER4_SGIS" value="0x8146" />
+    </enum>
+    <enum name="TypeEnum">
+      <token name="QUERY_WAIT" value="0x8E13" />
+      <token name="QUERY_NO_WAIT" value="0x8E14" />
+      <token name="QUERY_BY_REGION_WAIT" value="0x8E15" />
+      <token name="QUERY_BY_REGION_NO_WAIT" value="0x8E16" />
+    </enum>
+    <enum name="VertexBufferObjectParameter">
+      <token name="BUFFER_ACCESS" value="0x88BB" />
+      <token name="BUFFER_ACCESS_FLAGS" value="0x911F" />
+      <token name="BUFFER_IMMUTABLE_STORAGE" value="0x821F" />
+      <token name="BUFFER_MAPPED" value="0x88BC" />
+      <token name="BUFFER_MAP_LENGTH" value="0x9120" />
+      <token name="BUFFER_MAP_OFFSET" value="0x9121" />
+      <token name="BUFFER_SIZE" value="0x8764" />
+      <token name="BUFFER_STORAGE_FLAGS" value="0x8220" />
+      <token name="BUFFER_USAGE" value="0x8765" />
+    </enum>
+    <enum name="BufferAccessMask">
+      <token name="MAP_COHERENT_BIT" value="0x0080" />
+      <token name="MAP_COHERENT_BIT_EXT" value="0x0080" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT" value="0x0010" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT_EXT" value="0x0010" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT" value="0x0008" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT_EXT" value="0x0008" />
+      <token name="MAP_INVALIDATE_RANGE_BIT" value="0x0004" />
+      <token name="MAP_INVALIDATE_RANGE_BIT_EXT" value="0x0004" />
+      <token name="MAP_PERSISTENT_BIT" value="0x0040" />
+      <token name="MAP_PERSISTENT_BIT_EXT" value="0x0040" />
+      <token name="MAP_READ_BIT" value="0x0001" />
+      <token name="MAP_READ_BIT_EXT" value="0x0001" />
+      <token name="MAP_UNSYNCHRONIZED_BIT" value="0x0020" />
+      <token name="MAP_UNSYNCHRONIZED_BIT_EXT" value="0x0020" />
+      <token name="MAP_WRITE_BIT" value="0x0002" />
+      <token name="MAP_WRITE_BIT_EXT" value="0x0002" />
+    </enum>
+  </add>
+  <add name="gles2">
+    <enum name="CheckFramebufferStatusTarget">
+      <token name="DRAW_FRAMEBUFFER" value="0x8CA9" />
+      <token name="READ_FRAMEBUFFER" value="0x8CA8" />
+      <token name="FRAMEBUFFER" value="0x8D40" />
+    </enum>
+    <enum name="ColorMaterialFace">
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT" value="0x0404" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="ColorTableParameterPNameSGI">
+      <token name="COLOR_TABLE_BIAS" value="0x80D7" />
+      <token name="COLOR_TABLE_BIAS_SGI" value="0x80D7" />
+      <token name="COLOR_TABLE_SCALE" value="0x80D6" />
+      <token name="COLOR_TABLE_SCALE_SGI" value="0x80D6" />
+    </enum>
+    <enum name="ConvolutionParameterEXT">
+      <token name="CONVOLUTION_BORDER_MODE" value="0x8013" />
+      <token name="CONVOLUTION_BORDER_MODE_EXT" value="0x8013" />
+      <token name="CONVOLUTION_FILTER_BIAS" value="0x8015" />
+      <token name="CONVOLUTION_FILTER_BIAS_EXT" value="0x8015" />
+      <token name="CONVOLUTION_FILTER_SCALE" value="0x8014" />
+      <token name="CONVOLUTION_FILTER_SCALE_EXT" value="0x8014" />
+    </enum>
+    <enum name="CullFaceMode">
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT" value="0x0404" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="DataType" />
+    <enum name="FragmentOpATI">
+      <token name="MOV_ATI" value="0x8961" />
+      <token name="ADD_ATI" value="0x8963" />
+      <token name="MUL_ATI" value="0x8964" />
+      <token name="SUB_ATI" value="0x8965" />
+      <token name="DOT3_ATI" value="0x8966" />
+      <token name="DOT4_ATI" value="0x8967" />
+      <token name="MAD_ATI" value="0x8968" />
+      <token name="LERP_ATI" value="0x8969" />
+      <token name="CND_ATI" value="0x896A" />
+      <token name="CND0_ATI" value="0x896B" />
+      <token name="DOT2_ADD_ATI" value="0x896C" />
+    </enum>
+    <enum name="FramebufferFetchNoncoherent">
+      <token name="FRAMEBUFFER_FETCH_NONCOHERENT_QCOM" value="0x96A2" />
+    </enum>
+    <enum name="GetColorTableParameterPNameSGI">
+      <token name="COLOR_TABLE_ALPHA_SIZE_SGI" value="0x80DD" />
+      <token name="COLOR_TABLE_BIAS_SGI" value="0x80D7" />
+      <token name="COLOR_TABLE_BLUE_SIZE_SGI" value="0x80DC" />
+      <token name="COLOR_TABLE_FORMAT_SGI" value="0x80D8" />
+      <token name="COLOR_TABLE_GREEN_SIZE_SGI" value="0x80DB" />
+      <token name="COLOR_TABLE_INTENSITY_SIZE_SGI" value="0x80DF" />
+      <token name="COLOR_TABLE_LUMINANCE_SIZE_SGI" value="0x80DE" />
+      <token name="COLOR_TABLE_RED_SIZE_SGI" value="0x80DA" />
+      <token name="COLOR_TABLE_SCALE_SGI" value="0x80D6" />
+      <token name="COLOR_TABLE_WIDTH_SGI" value="0x80D9" />
+      <token name="COLOR_TABLE_BIAS" value="0x80D7" />
+      <token name="COLOR_TABLE_SCALE" value="0x80D6" />
+      <token name="COLOR_TABLE_FORMAT" value="0x80D8" />
+      <token name="COLOR_TABLE_WIDTH" value="0x80D9" />
+      <token name="COLOR_TABLE_RED_SIZE" value="0x80DA" />
+      <token name="COLOR_TABLE_GREEN_SIZE" value="0x80DB" />
+      <token name="COLOR_TABLE_BLUE_SIZE" value="0x80DC" />
+      <token name="COLOR_TABLE_ALPHA_SIZE" value="0x80DD" />
+      <token name="COLOR_TABLE_LUMINANCE_SIZE" value="0x80DE" />
+      <token name="COLOR_TABLE_INTENSITY_SIZE" value="0x80DF" />
+    </enum>
+    <enum name="GetConvolutionParameter">
+      <token name="CONVOLUTION_BORDER_MODE_EXT" value="0x8013" />
+      <token name="CONVOLUTION_FILTER_BIAS_EXT" value="0x8015" />
+      <token name="CONVOLUTION_FILTER_SCALE_EXT" value="0x8014" />
+      <token name="CONVOLUTION_FORMAT_EXT" value="0x8017" />
+      <token name="CONVOLUTION_HEIGHT_EXT" value="0x8019" />
+      <token name="CONVOLUTION_WIDTH_EXT" value="0x8018" />
+      <token name="MAX_CONVOLUTION_HEIGHT_EXT" value="0x801B" />
+      <token name="MAX_CONVOLUTION_WIDTH_EXT" value="0x801A" />
+      <token name="CONVOLUTION_BORDER_MODE" value="0x8013" />
+      <token name="CONVOLUTION_BORDER_COLOR" value="0x8154" />
+      <token name="CONVOLUTION_FILTER_SCALE" value="0x8014" />
+      <token name="CONVOLUTION_FILTER_BIAS" value="0x8015" />
+      <token name="CONVOLUTION_FORMAT" value="0x8017" />
+      <token name="CONVOLUTION_WIDTH" value="0x8018" />
+      <token name="CONVOLUTION_HEIGHT" value="0x8019" />
+      <token name="MAX_CONVOLUTION_WIDTH" value="0x801A" />
+      <token name="MAX_CONVOLUTION_HEIGHT" value="0x801B" />
+    </enum>
+    <enum name="GetPixelMap">
+      <token name="PIXEL_MAP_A_TO_A" value="0x0C79" deprecated="3.2" />
+      <token name="PIXEL_MAP_B_TO_B" value="0x0C78" deprecated="3.2" />
+      <token name="PIXEL_MAP_G_TO_G" value="0x0C77" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_A" value="0x0C75" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_B" value="0x0C74" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_G" value="0x0C73" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_I" value="0x0C70" deprecated="3.2" />
+      <token name="PIXEL_MAP_I_TO_R" value="0x0C72" deprecated="3.2" />
+      <token name="PIXEL_MAP_R_TO_R" value="0x0C76" deprecated="3.2" />
+      <token name="PIXEL_MAP_S_TO_S" value="0x0C71" deprecated="3.2" />
+    </enum>
+    <enum name="MapBufferUsageMask">
+      <token name="CLIENT_STORAGE_BIT" value="0x0200" />
+      <token name="CLIENT_STORAGE_BIT_EXT" value="0x0200" />
+      <token name="DYNAMIC_STORAGE_BIT" value="0x0100" />
+      <token name="DYNAMIC_STORAGE_BIT_EXT" value="0x0100" />
+      <token name="MAP_COHERENT_BIT" value="0x0080" />
+      <token name="MAP_COHERENT_BIT_EXT" value="0x0080" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT" value="0x0010" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT_EXT" value="0x0010" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT" value="0x0008" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT_EXT" value="0x0008" />
+      <token name="MAP_INVALIDATE_RANGE_BIT" value="0x0004" />
+      <token name="MAP_INVALIDATE_RANGE_BIT_EXT" value="0x0004" />
+      <token name="MAP_PERSISTENT_BIT" value="0x0040" />
+      <token name="MAP_PERSISTENT_BIT_EXT" value="0x0040" />
+      <token name="MAP_READ_BIT" value="0x0001" />
+      <token name="MAP_READ_BIT_EXT" value="0x0001" />
+      <token name="MAP_UNSYNCHRONIZED_BIT" value="0x0020" />
+      <token name="MAP_UNSYNCHRONIZED_BIT_EXT" value="0x0020" />
+      <token name="MAP_WRITE_BIT" value="0x0002" />
+      <token name="MAP_WRITE_BIT_EXT" value="0x0002" />
+      <token name="SPARSE_STORAGE_BIT_ARB" value="0x0400" />
+      <token name="LGPU_SEPARATE_STORAGE_BIT_NVX" value="0x0800" />
+      <token name="PER_GPU_STORAGE_BIT_NV" value="0x0800" />
+    </enum>
+    <enum name="MaterialFace">
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT" value="0x0404" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="PixelTexGenMode">
+      <token name="LUMINANCE" value="0x1909" />
+      <token name="LUMINANCE_ALPHA" value="0x190A" />
+      <token name="NONE" value="0" />
+      <token name="PIXEL_TEX_GEN_ALPHA_LS_SGIX" value="0x8189" />
+      <token name="PIXEL_TEX_GEN_ALPHA_MS_SGIX" value="0x818A" />
+      <token name="PIXEL_TEX_GEN_ALPHA_NO_REPLACE_SGIX" value="0x8188" />
+      <token name="PIXEL_TEX_GEN_ALPHA_REPLACE_SGIX" value="0x8187" />
+      <token name="RGB" value="0x1907" />
+      <token name="RGBA" value="0x1908" />
+    </enum>
+    <enum name="PointParameterNameSGIS">
+      <token name="DISTANCE_ATTENUATION_EXT" value="0x8129" />
+      <token name="DISTANCE_ATTENUATION_SGIS" value="0x8129" />
+      <token name="POINT_DISTANCE_ATTENUATION" value="0x8129" deprecated="3.2" />
+      <token name="POINT_DISTANCE_ATTENUATION_ARB" value="0x8129" />
+      <token name="POINT_FADE_THRESHOLD_SIZE" value="0x8128" />
+      <token name="POINT_FADE_THRESHOLD_SIZE_ARB" value="0x8128" />
+      <token name="POINT_FADE_THRESHOLD_SIZE_EXT" value="0x8128" />
+      <token name="POINT_FADE_THRESHOLD_SIZE_SGIS" value="0x8128" />
+      <token name="POINT_SIZE_MAX" value="0x8127" deprecated="3.2" />
+      <token name="POINT_SIZE_MAX_ARB" value="0x8127" />
+      <token name="POINT_SIZE_MAX_EXT" value="0x8127" />
+      <token name="POINT_SIZE_MAX_SGIS" value="0x8127" />
+      <token name="POINT_SIZE_MIN" value="0x8126" deprecated="3.2" />
+      <token name="POINT_SIZE_MIN_ARB" value="0x8126" />
+      <token name="POINT_SIZE_MIN_EXT" value="0x8126" />
+      <token name="POINT_SIZE_MIN_SGIS" value="0x8126" />
+    </enum>
+    <enum name="SamplerParameterName">
+      <token name="TEXTURE_WRAP_S" value="0x2802" />
+      <token name="TEXTURE_WRAP_T" value="0x2803" />
+      <token name="TEXTURE_WRAP_R" value="0x8072" />
+      <token name="TEXTURE_MIN_FILTER" value="0x2801" />
+      <token name="TEXTURE_MAG_FILTER" value="0x2800" />
+      <token name="TEXTURE_BORDER_COLOR" value="0x1004" />
+      <token name="TEXTURE_MIN_LOD" value="0x813A" />
+      <token name="TEXTURE_MAX_LOD" value="0x813B" />
+      <token name="TEXTURE_COMPARE_MODE" value="0x884C" />
+      <token name="TEXTURE_COMPARE_FUNC" value="0x884D" />
+    </enum>
+    <enum name="StencilFaceDirection">
+      <token name="FRONT" value="0x0404" />
+      <token name="BACK" value="0x0405" />
+      <token name="FRONT_AND_BACK" value="0x0408" />
+    </enum>
+    <enum name="TextureFilterFuncSGIS">
+      <token name="FILTER4_SGIS" value="0x8146" />
+    </enum>
+    <enum name="TypeEnum">
+      <token name="QUERY_WAIT" value="0x8E13" />
+      <token name="QUERY_NO_WAIT" value="0x8E14" />
+      <token name="QUERY_BY_REGION_WAIT" value="0x8E15" />
+      <token name="QUERY_BY_REGION_NO_WAIT" value="0x8E16" />
+    </enum>
+    <enum name="VertexBufferObjectParameter">
+      <token name="BUFFER_ACCESS" value="0x88BB" />
+      <token name="BUFFER_ACCESS_FLAGS" value="0x911F" />
+      <token name="BUFFER_IMMUTABLE_STORAGE" value="0x821F" />
+      <token name="BUFFER_MAPPED" value="0x88BC" />
+      <token name="BUFFER_MAP_LENGTH" value="0x9120" />
+      <token name="BUFFER_MAP_OFFSET" value="0x9121" />
+      <token name="BUFFER_SIZE" value="0x8764" />
+      <token name="BUFFER_STORAGE_FLAGS" value="0x8220" />
+      <token name="BUFFER_USAGE" value="0x8765" />
+    </enum>
+    <enum name="BufferAccessMask">
+      <token name="MAP_COHERENT_BIT" value="0x0080" />
+      <token name="MAP_COHERENT_BIT_EXT" value="0x0080" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT" value="0x0010" />
+      <token name="MAP_FLUSH_EXPLICIT_BIT_EXT" value="0x0010" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT" value="0x0008" />
+      <token name="MAP_INVALIDATE_BUFFER_BIT_EXT" value="0x0008" />
+      <token name="MAP_INVALIDATE_RANGE_BIT" value="0x0004" />
+      <token name="MAP_INVALIDATE_RANGE_BIT_EXT" value="0x0004" />
+      <token name="MAP_PERSISTENT_BIT" value="0x0040" />
+      <token name="MAP_PERSISTENT_BIT_EXT" value="0x0040" />
+      <token name="MAP_READ_BIT" value="0x0001" />
+      <token name="MAP_READ_BIT_EXT" value="0x0001" />
+      <token name="MAP_UNSYNCHRONIZED_BIT" value="0x0020" />
+      <token name="MAP_UNSYNCHRONIZED_BIT_EXT" value="0x0020" />
+      <token name="MAP_WRITE_BIT" value="0x0002" />
+      <token name="MAP_WRITE_BIT_EXT" value="0x0002" />
+    </enum>
+  </add>
+
+  <overload name="gl">
+    <function name="ActiveStencilFaceEXT" extension="EXT" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>StencilFaceDirection</type>
+      </param>
+    </function>
+    <function name="AlphaFragmentOp1ATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="op" index="0">
+        <type>FragmentOpATI</type>
+      </param>
+      <param name="dst" index="1">
+        <type>GLuint</type>
+      </param>
+      <param name="dstMod" index="2">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1" index="3">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1Rep" index="4">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1Mod" index="5">
+        <type>GLuint</type>
+      </param>
+    </function>
+    <function name="AlphaFragmentOp2ATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="op" index="0">
+        <type>FragmentOpATI</type>
+      </param>
+      <param name="dst" index="1">
+        <type>GLuint</type>
+      </param>
+      <param name="dstMod" index="2">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1" index="3">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1Rep" index="4">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1Mod" index="5">
+        <type>GLuint</type>
+      </param>
+      <param name="arg2" index="6">
+        <type>GLuint</type>
+      </param>
+      <param name="arg2Rep" index="7">
+        <type>GLuint</type>
+      </param>
+      <param name="arg2Mod" index="8">
+        <type>GLuint</type>
+      </param>
+    </function>
+    <function name="AlphaFragmentOp3ATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="op" index="0">
+        <type>FragmentOpATI</type>
+      </param>
+      <param name="dst" index="1">
+        <type>GLuint</type>
+      </param>
+      <param name="dstMod" index="2">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1" index="3">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1Rep" index="4">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1Mod" index="5">
+        <type>GLuint</type>
+      </param>
+      <param name="arg2" index="6">
+        <type>GLuint</type>
+      </param>
+      <param name="arg2Rep" index="7">
+        <type>GLuint</type>
+      </param>
+      <param name="arg2Mod" index="8">
+        <type>GLuint</type>
+      </param>
+      <param name="arg3" index="9">
+        <type>GLuint</type>
+      </param>
+      <param name="arg3Rep" index="10">
+        <type>GLuint</type>
+      </param>
+      <param name="arg3Mod" index="11">
+        <type>GLuint</type>
+      </param>
+    </function>
+    <function name="ApplyTextureEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="mode" index="0">
+        <type>ExtLightTexture</type>
+      </param>
+    </function>
+    <function name="ArrayObjectATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="2">
+        <type>AtiVertexArrayObject</type>
+      </param>
+    </function>
+    <function name="BeginConditionalRenderNV" extension="NV" obsolete="Use ConditionalRenderMode overload instead.">
+      <param name="mode" index="1">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="BeginQueryARB" extension="ARB" obsolete="Use QueryTarget overload instead.">
+      <param name="target" index="0">
+        <type>ArbOcclusionQuery</type>
+      </param>
+    </function>
+    <function name="BindMaterialParameterEXT" extension="EXT" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="BindParameterEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="value" index="0">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="BindProgramARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="BindTextureUnitParameterEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="value" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="BinormalPointerEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="0">
+        <type>ExtCoordinateFrame</type>
+      </param>
+    </function>
+    <function name="BufferStorageExternalEXT" extension="EXT" obsolete="Use BufferStorageMask overload instead.">
+      <param name="flags" index="4">
+        <type>MapBufferUsageMask</type>
+      </param>
+    </function>
+    <function name="ClampColorARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>ArbColorBufferFloat</type>
+      </param>
+      <param name="clamp" index="1">
+        <type>ArbColorBufferFloat</type>
+      </param>
+    </function>
+    <function name="ClearNamedBufferData" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+      <param name="data" index="4">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedBufferData" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+      <param name="data" index="4">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedBufferDataEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="ClearNamedBufferSubData" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+      <param name="data" index="6">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedBufferSubData" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+      <param name="data" index="6">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedBufferSubDataEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="ClearNamedFramebufferfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="value" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedFramebufferfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="value" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedFramebufferiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="value" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedFramebufferiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="value" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedFramebufferuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="value" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedFramebufferuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="value" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClientActiveVertexStreamATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="ColorFormatNV" extension="NV" obsolete="Use ColorPointerType overload instead.">
+      <param name="type" index="1">
+        <type>NvVertexBufferUnifiedMemory</type>
+      </param>
+    </function>
+    <function name="ColorFragmentOp1ATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="op" index="0">
+        <type>FragmentOpATI</type>
+      </param>
+      <param name="dst" index="1">
+        <type>GLuint</type>
+      </param>
+      <param name="dstMask" index="2">
+        <type>GLuint</type>
+      </param>
+      <param name="dstMod" index="3">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1" index="4">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1Rep" index="5">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1Mod" index="6">
+        <type>GLuint</type>
+      </param>
+    </function>
+    <function name="ColorFragmentOp2ATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="op" index="0">
+        <type>FragmentOpATI</type>
+      </param>
+      <param name="dst" index="1">
+        <type>GLuint</type>
+      </param>
+      <param name="dstMask" index="2">
+        <type>GLuint</type>
+      </param>
+      <param name="dstMod" index="3">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1" index="4">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1Rep" index="5">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1Mod" index="6">
+        <type>GLuint</type>
+      </param>
+      <param name="arg2" index="7">
+        <type>GLuint</type>
+      </param>
+      <param name="arg2Rep" index="8">
+        <type>GLuint</type>
+      </param>
+      <param name="arg2Mod" index="9">
+        <type>GLuint</type>
+      </param>
+    </function>
+    <function name="ColorFragmentOp3ATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="op" index="0">
+        <type>FragmentOpATI</type>
+      </param>
+      <param name="dst" index="1">
+        <type>GLuint</type>
+      </param>
+      <param name="dstMask" index="2">
+        <type>GLuint</type>
+      </param>
+      <param name="dstMod" index="3">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1" index="4">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1Rep" index="5">
+        <type>GLuint</type>
+      </param>
+      <param name="arg1Mod" index="6">
+        <type>GLuint</type>
+      </param>
+      <param name="arg2" index="7">
+        <type>GLuint</type>
+      </param>
+      <param name="arg2Rep" index="8">
+        <type>GLuint</type>
+      </param>
+      <param name="arg2Mod" index="9">
+        <type>GLuint</type>
+      </param>
+      <param name="arg3" index="10">
+        <type>GLuint</type>
+      </param>
+      <param name="arg3Rep" index="11">
+        <type>GLuint</type>
+      </param>
+      <param name="arg3Mod" index="12">
+        <type>GLuint</type>
+      </param>
+    </function>
+    <function name="ColorTableParameterfv" extension="Core" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>ColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="ColorTableParameterfvSGI" extension="SGI" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>ColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="ColorTableParameteriv" extension="Core" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>ColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="ColorTableParameterivSGI" extension="SGI" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>ColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="CombinerInputNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="stage" index="0">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="portion" index="1">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="variable" index="2">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="input" index="3">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="mapping" index="4">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="componentUsage" index="5">
+        <type>NvRegisterCombiners</type>
+      </param>
+    </function>
+    <function name="CombinerOutputNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="stage" index="0">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="portion" index="1">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="abOutput" index="2">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="cdOutput" index="3">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="sumOutput" index="4">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="scale" index="5">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="bias" index="6">
+        <type>NvRegisterCombiners</type>
+      </param>
+    </function>
+    <function name="CombinerParameterfNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>NvRegisterCombiners</type>
+      </param>
+    </function>
+    <function name="CombinerParameterfvNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>NvRegisterCombiners</type>
+      </param>
+    </function>
+    <function name="CombinerParameteriNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>NvRegisterCombiners</type>
+      </param>
+    </function>
+    <function name="CombinerParameterivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>NvRegisterCombiners</type>
+      </param>
+    </function>
+    <function name="CombinerStageParameterfvNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="stage" index="0">
+        <type>NvRegisterCombiners2</type>
+      </param>
+      <param name="pname" index="1">
+        <type>NvRegisterCombiners2</type>
+      </param>
+    </function>
+    <function name="CompressedMultiTexSubImage1DEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="5">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedMultiTexSubImage2DEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="7">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedMultiTexSubImage3DEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="9">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedTexSubImage1DARB" extension="ARB" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="4">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedTexSubImage2DARB" extension="ARB" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="6">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedTexSubImage3DARB" extension="ARB" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="8">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage1D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="4">
+        <type>PixelFormat</type>
+      </param>
+      <param name="data" index="6">
+        <count></count>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage1D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="4">
+        <type>PixelFormat</type>
+      </param>
+      <param name="data" index="6">
+        <count></count>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage1DEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="5">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage2D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="6">
+        <type>PixelFormat</type>
+      </param>
+      <param name="data" index="8">
+        <count></count>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage2D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="6">
+        <type>PixelFormat</type>
+      </param>
+      <param name="data" index="8">
+        <count></count>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage2DEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="7">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage3D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="8">
+        <type>PixelFormat</type>
+      </param>
+      <param name="data" index="10">
+        <count></count>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage3D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="8">
+        <type>PixelFormat</type>
+      </param>
+      <param name="data" index="10">
+        <count></count>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage3DEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="9">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameterf" extension="Core" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameterfEXT" extension="EXT" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameterfv" extension="Core" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameterfvEXT" extension="EXT" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameteri" extension="Core" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameteriEXT" extension="EXT" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameteriv" extension="Core" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameterivEXT" extension="EXT" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameterxOES" extension="OES" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameterxvOES" extension="OES" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="CoverFillPathInstancedNV" extension="NV" obsolete="Use InstancedPathCoverMode overload instead.">
+      <param name="coverMode" index="4">
+        <type>PathCoverMode</type>
+      </param>
+    </function>
+    <function name="CoverStrokePathInstancedNV" extension="NV" obsolete="Use InstancedPathCoverMode overload instead.">
+      <param name="coverMode" index="4">
+        <type>PathCoverMode</type>
+      </param>
+    </function>
+    <function name="CullParameterdvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>ExtCullVertex</type>
+      </param>
+    </function>
+    <function name="CullParameterfvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>ExtCullVertex</type>
+      </param>
+    </function>
+    <function name="DrawBuffersARB" extension="ARB" obsolete="Use DrawBufferMode * overload instead.">
+      <param name="bufs" index="1">
+        <type>DrawBufferModeATI *</type>
+      </param>
+    </function>
+    <function name="DrawBuffersATI" extension="ATI" obsolete="Use DrawBufferMode * overload instead.">
+      <param name="bufs" index="1">
+        <type>DrawBufferModeATI *</type>
+      </param>
+    </function>
+    <function name="ElementPointerAPPLE" extension="APPLE" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="0">
+        <type>AppleElementArray</type>
+      </param>
+    </function>
+    <function name="ElementPointerATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="0">
+        <type>AtiElementArray</type>
+      </param>
+    </function>
+    <function name="EvalMapsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvEvaluators</type>
+      </param>
+      <param name="mode" index="1">
+        <type>NvEvaluators</type>
+      </param>
+    </function>
+    <function name="FinalCombinerInputNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="variable" index="0">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="input" index="1">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="mapping" index="2">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="componentUsage" index="3">
+        <type>NvRegisterCombiners</type>
+      </param>
+    </function>
+    <function name="FinishObjectAPPLE" extension="APPLE" obsolete="Use strongly typed overload instead.">
+      <param name="object" index="0">
+        <type>AppleFence</type>
+      </param>
+    </function>
+    <function name="FlushPixelDataRangeNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvPixelDataRange</type>
+      </param>
+    </function>
+    <function name="FragmentColorMaterialSGIX" extension="SGIX" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="FragmentLightfSGIX" extension="SGIX" obsolete="Use strongly typed overload instead.">
+      <param name="light" index="0">
+        <type>SgixFragmentLighting</type>
+      </param>
+      <param name="pname" index="1">
+        <type>SgixFragmentLighting</type>
+      </param>
+    </function>
+    <function name="FragmentLightfvSGIX" extension="SGIX" obsolete="Use strongly typed overload instead.">
+      <param name="light" index="0">
+        <type>SgixFragmentLighting</type>
+      </param>
+      <param name="pname" index="1">
+        <type>SgixFragmentLighting</type>
+      </param>
+    </function>
+    <function name="FragmentLightiSGIX" extension="SGIX" obsolete="Use strongly typed overload instead.">
+      <param name="light" index="0">
+        <type>SgixFragmentLighting</type>
+      </param>
+      <param name="pname" index="1">
+        <type>SgixFragmentLighting</type>
+      </param>
+    </function>
+    <function name="FragmentLightivSGIX" extension="SGIX" obsolete="Use strongly typed overload instead.">
+      <param name="light" index="0">
+        <type>SgixFragmentLighting</type>
+      </param>
+      <param name="pname" index="1">
+        <type>SgixFragmentLighting</type>
+      </param>
+    </function>
+    <function name="FragmentMaterialfSGIX" extension="SGIX" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="FragmentMaterialfvSGIX" extension="SGIX" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="FragmentMaterialiSGIX" extension="SGIX" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="FragmentMaterialivSGIX" extension="SGIX" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="GenSymbolsEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="datatype" index="0">
+        <type>ExtVertexShader</type>
+      </param>
+      <param name="storagetype" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+      <param name="range" index="2">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="GetActiveSubroutineName" extension="Core" obsolete="Use  overload instead.">
+      <param name="name" index="5">
+        <count>bufsize</count>
+      </param>
+    </function>
+    <function name="GetActiveSubroutineName" extension="Core" obsolete="Use  overload instead.">
+      <param name="name" index="5">
+        <count>bufsize</count>
+      </param>
+    </function>
+    <function name="GetActiveSubroutineUniformName" extension="Core" obsolete="Use  overload instead.">
+      <param name="name" index="5">
+        <count>bufsize</count>
+      </param>
+    </function>
+    <function name="GetActiveSubroutineUniformName" extension="Core" obsolete="Use  overload instead.">
+      <param name="name" index="5">
+        <count>bufsize</count>
+      </param>
+    </function>
+    <function name="GetActiveUniformARB" extension="ARB" obsolete="Use UniformType * overload instead.">
+      <param name="type" index="5">
+        <type>AttributeType *</type>
+      </param>
+    </function>
+    <function name="GetActiveVaryingNV" extension="NV" obsolete="Use  overload instead.">
+      <param name="name" index="6">
+        <count>COMPSIZE(program,index,bufSize)</count>
+      </param>
+    </function>
+    <function name="GetArrayObjectfvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>AtiVertexArrayObject</type>
+      </param>
+    </function>
+    <function name="GetArrayObjectivATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>AtiVertexArrayObject</type>
+      </param>
+    </function>
+    <function name="GetBufferParameterivARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>ArbVertexBufferObject</type>
+      </param>
+    </function>
+    <function name="GetColorTableParameterfv" extension="Core" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>GetColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="GetColorTableParameterfvEXT" extension="EXT" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>GetColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="GetColorTableParameterfvSGI" extension="SGI" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>GetColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="GetColorTableParameteriv" extension="Core" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>GetColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="GetColorTableParameterivEXT" extension="EXT" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>GetColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="GetColorTableParameterivSGI" extension="SGI" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>GetColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="GetCombinerInputParameterfvNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="stage" index="0">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="portion" index="1">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="variable" index="2">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="pname" index="3">
+        <type>NvRegisterCombiners</type>
+      </param>
+    </function>
+    <function name="GetCombinerInputParameterivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="stage" index="0">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="portion" index="1">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="variable" index="2">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="pname" index="3">
+        <type>NvRegisterCombiners</type>
+      </param>
+    </function>
+    <function name="GetCombinerOutputParameterfvNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="stage" index="0">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="portion" index="1">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="pname" index="2">
+        <type>NvRegisterCombiners</type>
+      </param>
+    </function>
+    <function name="GetCombinerOutputParameterivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="stage" index="0">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="portion" index="1">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="pname" index="2">
+        <type>NvRegisterCombiners</type>
+      </param>
+    </function>
+    <function name="GetCombinerStageParameterfvNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="stage" index="0">
+        <type>NvRegisterCombiners2</type>
+      </param>
+      <param name="pname" index="1">
+        <type>NvRegisterCombiners2</type>
+      </param>
+    </function>
+    <function name="GetCommandHeaderNV" extension="NV" obsolete="Use CommandOpcodesNV overload instead.">
+      <param name="tokenID" index="0">
+        <type>NvCommandList</type>
+      </param>
+    </function>
+    <function name="GetCompressedTextureImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetCompressedTextureImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetCompressedTextureSubImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="9">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetCompressedTextureSubImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="9">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetConvolutionParameterfv" extension="Core" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="GetConvolutionParameterfvEXT" extension="EXT" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="GetConvolutionParameteriv" extension="Core" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="GetConvolutionParameterivEXT" extension="EXT" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="GetDebugMessageLogAMD" extension="AMD" obsolete="Use  overload instead.">
+      <param name="message" index="6">
+        <count>bufsize</count>
+      </param>
+    </function>
+    <function name="GetDoublei_vEXT" extension="EXT" obsolete="Use GetPName overload instead.">
+      <param name="pname" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetDoubleIndexedvEXT" extension="EXT" obsolete="Use GetPName overload instead.">
+      <param name="target" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetFenceivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>NvFence</type>
+      </param>
+    </function>
+    <function name="GetFinalCombinerInputParameterfvNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="variable" index="0">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="pname" index="1">
+        <type>NvRegisterCombiners</type>
+      </param>
+    </function>
+    <function name="GetFinalCombinerInputParameterivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="variable" index="0">
+        <type>NvRegisterCombiners</type>
+      </param>
+      <param name="pname" index="1">
+        <type>NvRegisterCombiners</type>
+      </param>
+    </function>
+    <function name="GetFloati_vEXT" extension="EXT" obsolete="Use GetPName overload instead.">
+      <param name="pname" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetFloatIndexedvEXT" extension="EXT" obsolete="Use GetPName overload instead.">
+      <param name="target" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetFragmentLightfvSGIX" extension="SGIX" obsolete="Use strongly typed overload instead.">
+      <param name="light" index="0">
+        <type>SgixFragmentLighting</type>
+      </param>
+      <param name="pname" index="1">
+        <type>SgixFragmentLighting</type>
+      </param>
+    </function>
+    <function name="GetFragmentLightivSGIX" extension="SGIX" obsolete="Use strongly typed overload instead.">
+      <param name="light" index="0">
+        <type>SgixFragmentLighting</type>
+      </param>
+      <param name="pname" index="1">
+        <type>SgixFragmentLighting</type>
+      </param>
+    </function>
+    <function name="GetFragmentMaterialfvSGIX" extension="SGIX" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="GetFragmentMaterialivSGIX" extension="SGIX" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="GetHandleARB" extension="ARB" obsolete="Use ContainerType overload instead.">
+      <param name="pname" index="0">
+        <type>ArbShaderObjects</type>
+      </param>
+    </function>
+    <function name="GetImageTransformParameterfvHP" extension="HP" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>HpImageTransform</type>
+      </param>
+      <param name="pname" index="1">
+        <type>HpImageTransform</type>
+      </param>
+    </function>
+    <function name="GetImageTransformParameterivHP" extension="HP" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>HpImageTransform</type>
+      </param>
+      <param name="pname" index="1">
+        <type>HpImageTransform</type>
+      </param>
+    </function>
+    <function name="GetIntegerIndexedvEXT" extension="EXT" obsolete="Use GetPName overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetInternalformati64v" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetInternalformati64v" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetInternalformativ" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetInternalformativ" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetInternalformatSampleivNV" extension="NV" obsolete="Use  overload instead.">
+      <param name="params" index="5">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetInvariantBooleanvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="value" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="GetInvariantFloatvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="value" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="GetInvariantIntegervEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="value" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="GetLocalConstantBooleanvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="value" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="GetLocalConstantFloatvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="value" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="GetLocalConstantIntegervEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="value" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="GetMapAttribParameterfvNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvEvaluators</type>
+      </param>
+      <param name="pname" index="2">
+        <type>NvEvaluators</type>
+      </param>
+    </function>
+    <function name="GetMapAttribParameterivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvEvaluators</type>
+      </param>
+      <param name="pname" index="2">
+        <type>NvEvaluators</type>
+      </param>
+    </function>
+    <function name="GetMapControlPointsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvEvaluators</type>
+      </param>
+      <param name="type" index="2">
+        <type>NvEvaluators</type>
+      </param>
+    </function>
+    <function name="GetMapParameterfvNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvEvaluators</type>
+      </param>
+      <param name="pname" index="1">
+        <type>NvEvaluators</type>
+      </param>
+    </function>
+    <function name="GetMapParameterivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvEvaluators</type>
+      </param>
+      <param name="pname" index="1">
+        <type>NvEvaluators</type>
+      </param>
+    </function>
+    <function name="GetMaterialxOES" extension="OES" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="GetMaterialxvOES" extension="OES" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="GetMultisamplefvNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>NvExplicitMultisample</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferParameteri64v" extension="Core" obsolete="Use BufferPNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferParameteri64v" extension="Core" obsolete="Use BufferPNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferParameteriv" extension="Core" obsolete="Use BufferPNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferParameteriv" extension="Core" obsolete="Use BufferPNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferParameterivEXT" extension="EXT" obsolete="Use BufferPNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferParameterui64vNV" extension="NV" obsolete="Use BufferPNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferPointerv" extension="Core" obsolete="Use BufferPointerNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetNamedBufferPointerv" extension="Core" obsolete="Use BufferPointerNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetNamedBufferPointervEXT" extension="EXT" obsolete="Use BufferPointerNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferSubData" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetNamedBufferSubData" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetNamedProgramivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="GetNamedProgramLocalParameterdvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="GetNamedProgramLocalParameterfvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="GetNamedProgramLocalParameterIivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="GetNamedProgramLocalParameterIuivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="GetNamedProgramStringEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+      <param name="pname" index="2">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="GetnMapdvARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="v" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnPixelMapfvARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="values" index="2">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformdvARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformfvARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformfvKHR" extension="KHR" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformi64vARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformivARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformivKHR" extension="KHR" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformui64vARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformuivARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformuivKHR" extension="KHR" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetObjectBufferfvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>AtiVertexArrayObject</type>
+      </param>
+    </function>
+    <function name="GetObjectBufferivATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>AtiVertexArrayObject</type>
+      </param>
+    </function>
+    <function name="GetOcclusionQueryivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>NvOcclusionQuery</type>
+      </param>
+    </function>
+    <function name="GetOcclusionQueryuivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>NvOcclusionQuery</type>
+      </param>
+    </function>
+    <function name="GetPerfMonitorCounterDataAMD" extension="AMD" obsolete="Use  overload instead.">
+      <param name="data" index="3">
+        <count>dataSize</count>
+      </param>
+    </function>
+    <function name="GetPerfQueryDataINTEL" extension="INTEL" obsolete="Use PerfQueryDataFlags overload instead.">
+      <param name="flags" index="1">
+        <type>GLuint</type>
+      </param>
+    </function>
+    <function name="GetPerfQueryInfoINTEL" extension="INTEL" obsolete="Use PerformanceQueryCapsMaskINTEL * overload instead.">
+      <param name="capsMask" index="6">
+        <type>GLuint *</type>
+      </param>
+    </function>
+    <function name="GetPixelTransformParameterfvEXT" extension="EXT" obsolete="Use GLenum overload instead.">
+      <param name="target" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetPixelTransformParameterivEXT" extension="EXT" obsolete="Use GLenum overload instead.">
+      <param name="target" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetPointeri_vEXT" extension="EXT" obsolete="Use GLenum overload instead.">
+      <param name="pname" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetPointerIndexedvEXT" extension="EXT" obsolete="Use GLenum overload instead.">
+      <param name="target" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetPointervKHR" extension="KHR" obsolete="Use  overload instead.">
+      <param name="params" index="1">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetProgramEnvParameterdvARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetProgramEnvParameterfvARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetProgramEnvParameterIivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="GetProgramEnvParameterIuivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="GetProgramivARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetProgramivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>NvVertexProgram</type>
+      </param>
+    </function>
+    <function name="GetProgramLocalParameterdvARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetProgramLocalParameterfvARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetProgramLocalParameterIivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="GetProgramLocalParameterIuivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="GetProgramResourcefvNV" extension="NV" obsolete="Use  overload instead.">
+      <param name="length" index="6">
+        <count></count>
+      </param>
+      <param name="params" index="7">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetProgramResourceiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="7">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetProgramResourceiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="7">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetProgramStringARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetProgramStringNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>NvVertexProgram</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIiv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIiv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIuiv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIuiv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSynciv" extension="Core" obsolete="Use  overload instead.">
+      <param name="values" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetSynciv" extension="Core" obsolete="Use  overload instead.">
+      <param name="values" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetTexBumpParameterfvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>AtiEnvmapBumpmap</type>
+      </param>
+    </function>
+    <function name="GetTexBumpParameterivATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>AtiEnvmapBumpmap</type>
+      </param>
+    </function>
+    <function name="GetTexFilterFuncSGIS" extension="SGIS" obsolete="Use strongly typed overload instead.">
+      <param name="filter" index="1">
+        <type>SgisTextureFilter4</type>
+      </param>
+    </function>
+    <function name="GetTextureImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetTextureImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetTextureSubImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="11">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetTextureSubImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="11">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetTransformFeedbackVaryingEXT" extension="EXT" obsolete="Use AttributeType * overload instead.">
+      <param name="type" index="5">
+        <type>GLenum *</type>
+      </param>
+    </function>
+    <function name="GetVariantArrayObjectfvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>AtiVertexArrayObject</type>
+      </param>
+    </function>
+    <function name="GetVariantArrayObjectivATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>AtiVertexArrayObject</type>
+      </param>
+    </function>
+    <function name="GetVariantBooleanvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="value" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="GetVariantFloatvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="value" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="GetVariantIntegervEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="value" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="GetVariantPointervEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="value" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="GetVertexArrayPointeri_vEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="param" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetVertexAttribArrayObjectfvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>AtiVertexAttribArrayObject</type>
+      </param>
+    </function>
+    <function name="GetVertexAttribArrayObjectivATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>AtiVertexAttribArrayObject</type>
+      </param>
+    </function>
+    <function name="GetVertexAttribdvARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetVertexAttribdvNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>NvVertexProgram</type>
+      </param>
+    </function>
+    <function name="GetVertexAttribfvARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetVertexAttribfvNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>NvVertexProgram</type>
+      </param>
+    </function>
+    <function name="GetVertexAttribivARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetVertexAttribivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>NvVertexProgram</type>
+      </param>
+    </function>
+    <function name="GetVertexAttribPointervARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetVertexAttribPointervNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>NvVertexProgram</type>
+      </param>
+    </function>
+    <function name="HintPGI" extension="PGI" obsolete="Use VertexHintsMaskPGI overload instead.">
+      <param name="target" index="0">
+        <type>PgiMiscHints</type>
+      </param>
+      <param name="mode" index="1">
+        <type>GLint</type>
+      </param>
+    </function>
+    <function name="IglooInterfaceSGIX" extension="SGIX" obsolete="Use GLenum overload instead.">
+      <param name="pname" index="0">
+        <type>SgixIglooInterface</type>
+      </param>
+    </function>
+    <function name="ImageTransformParameterfHP" extension="HP" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>HpImageTransform</type>
+      </param>
+      <param name="pname" index="1">
+        <type>HpImageTransform</type>
+      </param>
+    </function>
+    <function name="ImageTransformParameterfvHP" extension="HP" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>HpImageTransform</type>
+      </param>
+      <param name="pname" index="1">
+        <type>HpImageTransform</type>
+      </param>
+    </function>
+    <function name="ImageTransformParameteriHP" extension="HP" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>HpImageTransform</type>
+      </param>
+      <param name="pname" index="1">
+        <type>HpImageTransform</type>
+      </param>
+    </function>
+    <function name="ImageTransformParameterivHP" extension="HP" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>HpImageTransform</type>
+      </param>
+      <param name="pname" index="1">
+        <type>HpImageTransform</type>
+      </param>
+    </function>
+    <function name="IndexFuncEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="func" index="0">
+        <type>ExtIndexFunc</type>
+      </param>
+    </function>
+    <function name="IndexMaterialEXT" extension="EXT" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+      <param name="mode" index="1">
+        <type>ExtIndexMaterial</type>
+      </param>
+    </function>
+    <function name="InvalidateNamedFramebufferData" extension="Core" obsolete="Use  overload instead.">
+      <param name="attachments" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="InvalidateNamedFramebufferData" extension="Core" obsolete="Use  overload instead.">
+      <param name="attachments" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="InvalidateNamedFramebufferSubData" extension="Core" obsolete="Use  overload instead.">
+      <param name="attachments" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="InvalidateNamedFramebufferSubData" extension="Core" obsolete="Use  overload instead.">
+      <param name="attachments" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="IsVariantEnabledEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="cap" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="LightEnviSGIX" extension="SGIX" obsolete="Use LightEnvModeSGIX overload instead.">
+      <param name="param" index="1">
+        <type>CheckedInt32</type>
+      </param>
+    </function>
+    <function name="ListDrawCommandsStatesClientNV" extension="NV" obsolete="Use  overload instead.">
+      <param name="indirects" index="2">
+        <count></count>
+      </param>
+      <param name="sizes" index="3">
+        <count></count>
+      </param>
+      <param name="states" index="4">
+        <count></count>
+      </param>
+      <param name="fbos" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="MapBufferRange" extension="Core" obsolete="Use MapBufferAccessMask overload instead.">
+      <param name="access" index="3">
+        <type>BufferAccessMask</type>
+      </param>
+    </function>
+    <function name="MapBufferRange" extension="Core" obsolete="Use MapBufferAccessMask overload instead.">
+      <param name="access" index="3">
+        <type>BufferAccessMask</type>
+      </param>
+    </function>
+    <function name="MapControlPointsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvEvaluators</type>
+      </param>
+      <param name="type" index="2">
+        <type>NvEvaluators</type>
+      </param>
+    </function>
+    <function name="MapNamedBufferRange" extension="Core" obsolete="Use MapBufferAccessMask overload instead.">
+      <param name="access" index="3">
+        <type>BufferAccessMask</type>
+      </param>
+    </function>
+    <function name="MapNamedBufferRange" extension="Core" obsolete="Use MapBufferAccessMask overload instead.">
+      <param name="access" index="3">
+        <type>BufferAccessMask</type>
+      </param>
+    </function>
+    <function name="MapNamedBufferRangeEXT" extension="EXT" obsolete="Use MapBufferAccessMask overload instead.">
+      <param name="access" index="3">
+        <type>BufferAccessMask</type>
+      </param>
+    </function>
+    <function name="MapParameterfvNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvEvaluators</type>
+      </param>
+      <param name="pname" index="1">
+        <type>NvEvaluators</type>
+      </param>
+    </function>
+    <function name="MapParameterivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvEvaluators</type>
+      </param>
+      <param name="pname" index="1">
+        <type>NvEvaluators</type>
+      </param>
+    </function>
+    <function name="MaterialxOES" extension="OES" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="MaterialxvOES" extension="OES" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="MatrixIndexPointerARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="1">
+        <type>ArbMatrixPalette</type>
+      </param>
+    </function>
+    <function name="MultiDrawArraysEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="first" index="1">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+      <param name="count" index="2">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+    </function>
+    <function name="MultiDrawArraysIndirectAMD" extension="AMD" obsolete="Use  overload instead.">
+      <param name="indirect" index="1">
+        <count></count>
+      </param>
+    </function>
+    <function name="MultiDrawElementsBaseVertex" extension="Core" obsolete="Use  overload instead.">
+      <param name="count" index="1">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+      <param name="indices" index="3">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+      <param name="basevertex" index="5">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+    </function>
+    <function name="MultiDrawElementsBaseVertex" extension="Core" obsolete="Use  overload instead.">
+      <param name="count" index="1">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+      <param name="indices" index="3">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+      <param name="basevertex" index="5">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+    </function>
+    <function name="MultiDrawElementsEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="count" index="1">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+      <param name="indices" index="3">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+    </function>
+    <function name="MultiDrawElementsIndirectAMD" extension="AMD" obsolete="Use  overload instead.">
+      <param name="indirect" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="MultiModeDrawArraysIBM" extension="IBM" obsolete="Use  overload instead.">
+      <param name="mode" index="0">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+      <param name="first" index="1">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+      <param name="count" index="2">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+    </function>
+    <function name="MultiModeDrawElementsIBM" extension="IBM" obsolete="Use  overload instead.">
+      <param name="mode" index="0">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+      <param name="count" index="1">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+      <param name="indices" index="3">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+    </function>
+    <function name="MultiTexBufferEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="NamedBufferData" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="NamedBufferData" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="NamedBufferStorage" extension="Core" obsolete="Use BufferStorageMask overload instead.">
+      <param name="flags" index="3">
+        <type>MapBufferUsageMask</type>
+      </param>
+    </function>
+    <function name="NamedBufferStorage" extension="Core" obsolete="Use BufferStorageMask overload instead.">
+      <param name="flags" index="3">
+        <type>MapBufferUsageMask</type>
+      </param>
+    </function>
+    <function name="NamedBufferStorageEXT" extension="EXT" obsolete="Use BufferStorageMask overload instead.">
+      <param name="flags" index="3">
+        <type>MapBufferUsageMask</type>
+      </param>
+    </function>
+    <function name="NamedBufferStorageExternalEXT" extension="EXT" obsolete="Use BufferStorageMask overload instead.">
+      <param name="flags" index="4">
+        <type>MapBufferUsageMask</type>
+      </param>
+    </function>
+    <function name="NamedBufferSubData" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="3">
+        <count>COMPSIZE(size)</count>
+      </param>
+    </function>
+    <function name="NamedBufferSubData" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="3">
+        <count>COMPSIZE(size)</count>
+      </param>
+    </function>
+    <function name="NamedFramebufferDrawBuffers" extension="Core" obsolete="Use  overload instead.">
+      <param name="bufs" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="NamedFramebufferDrawBuffers" extension="Core" obsolete="Use  overload instead.">
+      <param name="bufs" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameter4dEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameter4dvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameter4fEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameter4fvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameterI4iEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameterI4ivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameterI4uiEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameterI4uivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameters4fvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParametersI4ivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParametersI4uivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="NamedProgramStringEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+      <param name="format" index="2">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="NewObjectBufferATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="usage" index="2">
+        <type>AtiVertexArrayObject</type>
+      </param>
+    </function>
+    <function name="NormalStream3bATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="NormalStream3bvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="NormalStream3dATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="NormalStream3dvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="NormalStream3fATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="NormalStream3fvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="NormalStream3iATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="NormalStream3ivATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="NormalStream3sATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="NormalStream3svATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="PassTexCoordATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="dst" index="0">
+        <type>GLuint</type>
+      </param>
+      <param name="coord" index="1">
+        <type>GLuint</type>
+      </param>
+      <param name="swizzle" index="2">
+        <type>AtiFragmentShader</type>
+      </param>
+    </function>
+    <function name="PathColorGenNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="colorFormat" index="2">
+        <type>NvPathRendering</type>
+      </param>
+    </function>
+    <function name="PathCommandsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="coordType" index="4">
+        <type>NvPathRendering</type>
+      </param>
+    </function>
+    <function name="PathCoordsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="coordType" index="2">
+        <type>NvPathRendering</type>
+      </param>
+    </function>
+    <function name="PathGlyphIndexRangeNV" extension="NV" obsolete="Use GLuint * overload instead.">
+      <param name="baseAndCount" index="5">
+        <type>GLuint</type>
+        <count></count>
+      </param>
+    </function>
+    <function name="PathSubCommandsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="coordType" index="6">
+        <type>NvPathRendering</type>
+      </param>
+    </function>
+    <function name="PathSubCoordsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="coordType" index="3">
+        <type>NvPathRendering</type>
+      </param>
+    </function>
+    <function name="PixelDataRangeNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvPixelDataRange</type>
+      </param>
+    </function>
+    <function name="PixelTexGenSGIX" extension="SGIX" obsolete="Use strongly typed overload instead.">
+      <param name="mode" index="0">
+        <type>SgixPixelTexture</type>
+      </param>
+    </function>
+    <function name="PixelTransformParameterfEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>ExtPixelTransform</type>
+      </param>
+      <param name="pname" index="1">
+        <type>ExtPixelTransform</type>
+      </param>
+    </function>
+    <function name="PixelTransformParameterfvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>ExtPixelTransform</type>
+      </param>
+      <param name="pname" index="1">
+        <type>ExtPixelTransform</type>
+      </param>
+    </function>
+    <function name="PixelTransformParameteriEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>ExtPixelTransform</type>
+      </param>
+      <param name="pname" index="1">
+        <type>ExtPixelTransform</type>
+      </param>
+    </function>
+    <function name="PixelTransformParameterivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>ExtPixelTransform</type>
+      </param>
+      <param name="pname" index="1">
+        <type>ExtPixelTransform</type>
+      </param>
+    </function>
+    <function name="PNTrianglesfATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>AtiPnTriangles</type>
+      </param>
+    </function>
+    <function name="PNTrianglesiATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>AtiPnTriangles</type>
+      </param>
+    </function>
+    <function name="PointParameterfARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>ArbPointParameters</type>
+      </param>
+    </function>
+    <function name="PointParameterfEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>ExtPointParameters</type>
+      </param>
+    </function>
+    <function name="PointParameterfSGIS" extension="SGIS" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>SgisPointParameters</type>
+      </param>
+    </function>
+    <function name="PointParameterfvARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>ArbPointParameters</type>
+      </param>
+    </function>
+    <function name="PointParameterfvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>ExtPointParameters</type>
+      </param>
+    </function>
+    <function name="PointParameterfvSGIS" extension="SGIS" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>SgisPointParameters</type>
+      </param>
+    </function>
+    <function name="PointParameteriNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>NvPointSprite</type>
+      </param>
+    </function>
+    <function name="PointParameterivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>NvPointSprite</type>
+      </param>
+    </function>
+    <function name="PointParameterxOES" extension="OES" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>OesFixedPoint</type>
+      </param>
+    </function>
+    <function name="PointParameterxvOES" extension="OES" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>OesFixedPoint</type>
+      </param>
+    </function>
+    <function name="ProgramBufferParametersfvNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvParameterBufferObject</type>
+      </param>
+    </function>
+    <function name="ProgramBufferParametersIivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvParameterBufferObject</type>
+      </param>
+    </function>
+    <function name="ProgramBufferParametersIuivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvParameterBufferObject</type>
+      </param>
+    </function>
+    <function name="ProgramEnvParameter4dARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ProgramEnvParameter4dvARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ProgramEnvParameter4fARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ProgramEnvParameter4fvARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ProgramEnvParameterI4iNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="ProgramEnvParameterI4ivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="ProgramEnvParameterI4uiNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="ProgramEnvParameterI4uivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="ProgramEnvParameters4fvEXT" extension="EXT" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>ExtGpuProgramParameters</type>
+      </param>
+    </function>
+    <function name="ProgramEnvParametersI4ivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="ProgramEnvParametersI4uivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="ProgramLocalParameter4dARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ProgramLocalParameter4dvARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ProgramLocalParameter4fARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ProgramLocalParameter4fvARB" extension="ARB" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ProgramLocalParameterI4iNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="ProgramLocalParameterI4ivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="ProgramLocalParameterI4uiNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="ProgramLocalParameterI4uivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="ProgramLocalParameters4fvEXT" extension="EXT" obsolete="Use ProgramTarget overload instead.">
+      <param name="target" index="0">
+        <type>ExtGpuProgramParameters</type>
+      </param>
+    </function>
+    <function name="ProgramLocalParametersI4ivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="ProgramLocalParametersI4uivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGpuProgram4</type>
+      </param>
+    </function>
+    <function name="ProgramStringARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+      <param name="format" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ProgramVertexLimitNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>NvGeometryProgram4</type>
+      </param>
+    </function>
+    <function name="QueryResourceNV" extension="NV" obsolete="Use  overload instead.">
+      <param name="buffer" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="ReadnPixels" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="7">
+        <count></count>
+      </param>
+    </function>
+    <function name="ReadnPixels" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="7">
+        <count></count>
+      </param>
+    </function>
+    <function name="ReplacementCodePointerSUN" extension="SUN" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="0">
+        <type>SunTriangleList</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiColor3fVertex3fSUN" extension="SUN" obsolete="Use TriangleListSUN overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiColor3fVertex3fvSUN" extension="SUN" obsolete="Use TriangleListSUN * overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN *</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiColor4fNormal3fVertex3fSUN" extension="SUN" obsolete="Use TriangleListSUN overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiColor4fNormal3fVertex3fvSUN" extension="SUN" obsolete="Use TriangleListSUN * overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN *</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiColor4ubVertex3fSUN" extension="SUN" obsolete="Use TriangleListSUN overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiColor4ubVertex3fvSUN" extension="SUN" obsolete="Use TriangleListSUN * overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN *</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiNormal3fVertex3fSUN" extension="SUN" obsolete="Use TriangleListSUN overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiNormal3fVertex3fvSUN" extension="SUN" obsolete="Use TriangleListSUN * overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN *</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiSUN" extension="SUN" obsolete="Use TriangleListSUN overload instead.">
+      <param name="code" index="0">
+        <type>GLuint</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fSUN" extension="SUN" obsolete="Use TriangleListSUN overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiTexCoord2fColor4fNormal3fVertex3fvSUN" extension="SUN" obsolete="Use TriangleListSUN * overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN *</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiTexCoord2fNormal3fVertex3fSUN" extension="SUN" obsolete="Use TriangleListSUN overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiTexCoord2fNormal3fVertex3fvSUN" extension="SUN" obsolete="Use TriangleListSUN * overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN *</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiTexCoord2fVertex3fSUN" extension="SUN" obsolete="Use TriangleListSUN overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiTexCoord2fVertex3fvSUN" extension="SUN" obsolete="Use TriangleListSUN * overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN *</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiVertex3fSUN" extension="SUN" obsolete="Use TriangleListSUN overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuiVertex3fvSUN" extension="SUN" obsolete="Use TriangleListSUN * overload instead.">
+      <param name="rc" index="0">
+        <type>ReplacementCodeSUN *</type>
+      </param>
+    </function>
+    <function name="ReplacementCodeuivSUN" extension="SUN" obsolete="Use TriangleListSUN * overload instead.">
+      <param name="code" index="0">
+        <type>GLuint *</type>
+      </param>
+    </function>
+    <function name="SampleMapATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="dst" index="0">
+        <type>GLuint</type>
+      </param>
+      <param name="interp" index="1">
+        <type>GLuint</type>
+      </param>
+      <param name="swizzle" index="2">
+        <type>AtiFragmentShader</type>
+      </param>
+    </function>
+    <function name="SamplePatternEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="pattern" index="0">
+        <type>ExtMultisample</type>
+      </param>
+    </function>
+    <function name="SecondaryColorPointerListIBM" extension="IBM" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="1">
+        <type>IbmVertexArrayLists</type>
+      </param>
+    </function>
+    <function name="SetFenceNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="condition" index="1">
+        <type>NvFence</type>
+      </param>
+    </function>
+    <function name="SetFragmentShaderConstantATI" extension="ATI" obsolete="Use FragmentShaderConATI overload instead.">
+      <param name="dst" index="0">
+        <type>GLuint</type>
+      </param>
+    </function>
+    <function name="SetInvariantEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="SetLocalConstantEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="ShaderBinary" extension="Core" obsolete="Use ShaderBinaryFormat overload instead.">
+      <param name="binaryformat" index="2">
+        <type>BinaryFormat</type>
+      </param>
+    </function>
+    <function name="ShaderBinary" extension="Core" obsolete="Use ShaderBinaryFormat overload instead.">
+      <param name="binaryformat" index="2">
+        <type>BinaryFormat</type>
+      </param>
+    </function>
+    <function name="ShaderOp1EXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="op" index="0">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="ShaderOp2EXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="op" index="0">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="ShaderOp3EXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="op" index="0">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="SpriteParameterfSGIX" extension="SGIX" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>SgixSprite</type>
+      </param>
+    </function>
+    <function name="SpriteParameterfvSGIX" extension="SGIX" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>SgixSprite</type>
+      </param>
+    </function>
+    <function name="SpriteParameteriSGIX" extension="SGIX" obsolete="Use SpriteModeSGIX overload instead.">
+      <param name="pname" index="0">
+        <type>SgixSprite</type>
+      </param>
+      <param name="param" index="1">
+        <type>CheckedInt32</type>
+      </param>
+    </function>
+    <function name="SpriteParameterivSGIX" extension="SGIX" obsolete="Use SpriteModeSGIX * overload instead.">
+      <param name="pname" index="0">
+        <type>SgixSprite</type>
+      </param>
+      <param name="params" index="1">
+        <type>CheckedInt32 *</type>
+      </param>
+    </function>
+    <function name="StencilOpSeparateATI" extension="ATI" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>StencilFaceDirection</type>
+      </param>
+    </function>
+    <function name="StencilOpValueAMD" extension="AMD" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>StencilFaceDirection</type>
+      </param>
+    </function>
+    <function name="StencilThenCoverFillPathInstancedNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pathNameType" index="1">
+        <type>NvPathRendering</type>
+      </param>
+      <param name="paths" index="2">
+        <count></count>
+      </param>
+      <param name="fillMode" index="4">
+        <type>NvPathRendering</type>
+      </param>
+      <param name="coverMode" index="6">
+        <type>NvPathRendering</type>
+      </param>
+      <param name="transformType" index="7">
+        <type>NvPathRendering</type>
+      </param>
+      <param name="transformValues" index="8">
+        <count></count>
+      </param>
+    </function>
+    <function name="StencilThenCoverFillPathNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="fillMode" index="1">
+        <type>NvPathRendering</type>
+      </param>
+      <param name="coverMode" index="3">
+        <type>NvPathRendering</type>
+      </param>
+    </function>
+    <function name="StencilThenCoverStrokePathInstancedNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pathNameType" index="1">
+        <type>NvPathRendering</type>
+      </param>
+      <param name="paths" index="2">
+        <count></count>
+      </param>
+      <param name="coverMode" index="6">
+        <type>NvPathRendering</type>
+      </param>
+      <param name="transformType" index="7">
+        <type>NvPathRendering</type>
+      </param>
+      <param name="transformValues" index="8">
+        <count></count>
+      </param>
+    </function>
+    <function name="StencilThenCoverStrokePathNV" extension="NV" obsolete="Use PathCoverMode overload instead.">
+      <param name="coverMode" index="3">
+        <type>NvPathRendering</type>
+      </param>
+    </function>
+    <function name="SwizzleEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="outX" index="2">
+        <type>ExtVertexShader</type>
+      </param>
+      <param name="outY" index="3">
+        <type>ExtVertexShader</type>
+      </param>
+      <param name="outZ" index="4">
+        <type>ExtVertexShader</type>
+      </param>
+      <param name="outW" index="5">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="TangentPointerEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="0">
+        <type>ExtCoordinateFrame</type>
+      </param>
+    </function>
+    <function name="TestObjectAPPLE" extension="APPLE" obsolete="Use strongly typed overload instead.">
+      <param name="object" index="0">
+        <type>AppleFence</type>
+      </param>
+    </function>
+    <function name="TexBufferARB" extension="ARB" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexBufferEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexBumpParameterfvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>AtiEnvmapBumpmap</type>
+      </param>
+    </function>
+    <function name="TexBumpParameterivATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>AtiEnvmapBumpmap</type>
+      </param>
+    </function>
+    <function name="TexFilterFuncSGIS" extension="SGIS" obsolete="Use strongly typed overload instead.">
+      <param name="filter" index="1">
+        <type>SgisTextureFilter4</type>
+      </param>
+    </function>
+    <function name="TexImage2DMultisampleCoverageNV" extension="NV" obsolete="Use InternalFormat overload instead.">
+      <param name="internalFormat" index="3">
+        <type>GLint</type>
+      </param>
+    </function>
+    <function name="TexImage3DMultisampleCoverageNV" extension="NV" obsolete="Use InternalFormat overload instead.">
+      <param name="internalFormat" index="3">
+        <type>GLint</type>
+      </param>
+    </function>
+    <function name="TexStorageMem1DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>ExtMemoryObject</type>
+      </param>
+    </function>
+    <function name="TexStorageMem2DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>ExtMemoryObject</type>
+      </param>
+    </function>
+    <function name="TexStorageMem2DMultisampleEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>ExtMemoryObject</type>
+      </param>
+    </function>
+    <function name="TexStorageMem3DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>ExtMemoryObject</type>
+      </param>
+    </function>
+    <function name="TexStorageMem3DMultisampleEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>ExtMemoryObject</type>
+      </param>
+    </function>
+    <function name="TexStorageSparseAMD" extension="AMD" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureBuffer" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureBuffer" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureBufferEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureBufferRange" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureBufferRange" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureBufferRangeEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureImage2DMultisampleCoverageNV" extension="NV" obsolete="Use InternalFormat overload instead.">
+      <param name="internalFormat" index="4">
+        <type>GLint</type>
+      </param>
+    </function>
+    <function name="TextureImage2DMultisampleNV" extension="NV" obsolete="Use InternalFormat overload instead.">
+      <param name="internalFormat" index="3">
+        <type>GLint</type>
+      </param>
+    </function>
+    <function name="TextureImage3DMultisampleCoverageNV" extension="NV" obsolete="Use InternalFormat overload instead.">
+      <param name="internalFormat" index="4">
+        <type>GLint</type>
+      </param>
+    </function>
+    <function name="TextureImage3DMultisampleNV" extension="NV" obsolete="Use InternalFormat overload instead.">
+      <param name="internalFormat" index="3">
+        <type>GLint</type>
+      </param>
+    </function>
+    <function name="TextureLightEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>ExtLightTexture</type>
+      </param>
+    </function>
+    <function name="TextureMaterialEXT" extension="EXT" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="TextureNormalEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="mode" index="0">
+        <type>ExtTexturePerturbNormal</type>
+      </param>
+    </function>
+    <function name="TextureParameterfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="param" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameterfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="param" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameterIiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameterIiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameterIuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameterIuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameteriv" extension="Core" obsolete="Use  overload instead.">
+      <param name="param" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameteriv" extension="Core" obsolete="Use  overload instead.">
+      <param name="param" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureStorage1D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage1D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage1DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2DMultisample" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2DMultisample" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2DMultisampleEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3DMultisample" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3DMultisample" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3DMultisampleEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorageMem1DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>ExtMemoryObject</type>
+      </param>
+    </function>
+    <function name="TextureStorageMem2DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>ExtMemoryObject</type>
+      </param>
+    </function>
+    <function name="TextureStorageMem2DMultisampleEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>ExtMemoryObject</type>
+      </param>
+    </function>
+    <function name="TextureStorageMem3DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>ExtMemoryObject</type>
+      </param>
+    </function>
+    <function name="TextureStorageMem3DMultisampleEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>ExtMemoryObject</type>
+      </param>
+    </function>
+    <function name="TextureStorageSparseAMD" extension="AMD" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TrackMatrixNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="matrix" index="2">
+        <type>NvVertexProgram</type>
+      </param>
+      <param name="transform" index="3">
+        <type>NvVertexProgram</type>
+      </param>
+    </function>
+    <function name="TransformFeedbackVaryingsEXT" extension="EXT" obsolete="Use TransformFeedbackBufferMode overload instead.">
+      <param name="bufferMode" index="3">
+        <type>ExtTransformFeedback</type>
+      </param>
+    </function>
+    <function name="TransformFeedbackVaryingsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="locations" index="2">
+        <type>GLint *</type>
+      </param>
+      <param name="bufferMode" index="3">
+        <type>NvTransformFeedback</type>
+      </param>
+    </function>
+    <function name="UpdateObjectBufferATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="preserve" index="4">
+        <type>AtiVertexArrayObject</type>
+      </param>
+    </function>
+    <function name="VariantArrayObjectATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="1">
+        <type>AtiVertexArrayObject</type>
+      </param>
+    </function>
+    <function name="VariantPointerEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="1">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="VDPAUGetSurfaceivNV" extension="NV" obsolete="Use  overload instead.">
+      <param name="values" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="VertexArrayAttribIFormat" extension="Core" obsolete="Use VertexAttribIType overload instead.">
+      <param name="type" index="3">
+        <type>VertexAttribIntegerType</type>
+      </param>
+    </function>
+    <function name="VertexArrayAttribIFormat" extension="Core" obsolete="Use VertexAttribIType overload instead.">
+      <param name="type" index="3">
+        <type>VertexAttribIntegerType</type>
+      </param>
+    </function>
+    <function name="VertexArrayAttribLFormat" extension="Core" obsolete="Use VertexAttribLType overload instead.">
+      <param name="type" index="3">
+        <type>VertexAttribDoubleType</type>
+      </param>
+    </function>
+    <function name="VertexArrayAttribLFormat" extension="Core" obsolete="Use VertexAttribLType overload instead.">
+      <param name="type" index="3">
+        <type>VertexAttribDoubleType</type>
+      </param>
+    </function>
+    <function name="VertexArrayParameteriAPPLE" extension="APPLE" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>AppleVertexArrayRange</type>
+      </param>
+    </function>
+    <function name="VertexArrayVertexAttribFormatEXT" extension="EXT" obsolete="Use VertexAttribType overload instead.">
+      <param name="type" index="3">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="VertexArrayVertexAttribIFormatEXT" extension="EXT" obsolete="Use VertexAttribIType overload instead.">
+      <param name="type" index="3">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="VertexArrayVertexAttribIOffsetEXT" extension="EXT" obsolete="Use VertexAttribType overload instead.">
+      <param name="type" index="4">
+        <type>VertexAttribEnum</type>
+      </param>
+    </function>
+    <function name="VertexArrayVertexAttribLFormatEXT" extension="EXT" obsolete="Use VertexAttribLType overload instead.">
+      <param name="type" index="3">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="VertexArrayVertexAttribLOffsetEXT" extension="EXT" obsolete="Use VertexAttribLType overload instead.">
+      <param name="type" index="4">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="VertexArrayVertexBuffers" extension="Core" obsolete="Use  overload instead.">
+      <param name="buffers" index="3">
+        <count></count>
+      </param>
+      <param name="offsets" index="4">
+        <count></count>
+      </param>
+      <param name="strides" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="VertexArrayVertexBuffers" extension="Core" obsolete="Use  overload instead.">
+      <param name="buffers" index="3">
+        <count></count>
+      </param>
+      <param name="offsets" index="4">
+        <count></count>
+      </param>
+      <param name="strides" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="VertexAttribFormatNV" extension="NV" obsolete="Use VertexAttribType overload instead.">
+      <param name="type" index="2">
+        <type>NvVertexBufferUnifiedMemory</type>
+      </param>
+    </function>
+    <function name="VertexAttribIFormatNV" extension="NV" obsolete="Use VertexAttribIType overload instead.">
+      <param name="type" index="2">
+        <type>NvVertexBufferUnifiedMemory</type>
+      </param>
+    </function>
+    <function name="VertexAttribIPointerEXT" extension="EXT" obsolete="Use VertexAttribIType overload instead.">
+      <param name="type" index="2">
+        <type>VertexAttribPointerType</type>
+      </param>
+      <param name="pointer" index="4">
+        <count>COMPSIZE(size,type,stride)</count>
+      </param>
+    </function>
+    <function name="VertexAttribLFormatNV" extension="NV" obsolete="Use VertexAttribLType overload instead.">
+      <param name="type" index="2">
+        <type>VertexAttribType</type>
+      </param>
+    </function>
+    <function name="VertexAttribLPointer" extension="Core" obsolete="Use  overload instead.">
+      <param name="pointer" index="4">
+        <count>size</count>
+      </param>
+    </function>
+    <function name="VertexAttribLPointer" extension="Core" obsolete="Use  overload instead.">
+      <param name="pointer" index="4">
+        <count>size</count>
+      </param>
+    </function>
+    <function name="VertexAttribLPointerEXT" extension="EXT" obsolete="Use VertexAttribLType overload instead.">
+      <param name="type" index="2">
+        <type>VertexAttribPointerType</type>
+      </param>
+      <param name="pointer" index="4">
+        <count>size</count>
+      </param>
+    </function>
+    <function name="VertexAttribPointerARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="pointer" index="5">
+        <count>COMPSIZE(size,type,stride)</count>
+      </param>
+    </function>
+    <function name="VertexBlendEnvfATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexBlendEnviATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream1dATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream1dvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream1fATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream1fvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream1iATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream1ivATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream1sATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream1svATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream2dATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream2dvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream2fATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream2fvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream2iATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream2ivATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream2sATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream2svATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream3dATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream3dvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream3fATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream3fvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream3iATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream3ivATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream3sATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream3svATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream4dATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream4dvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream4fATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream4fvATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream4iATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream4ivATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream4sATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexStream4svATI" extension="ATI" obsolete="Use strongly typed overload instead.">
+      <param name="stream" index="0">
+        <type>AtiVertexStreams</type>
+      </param>
+    </function>
+    <function name="VertexWeightPointerEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="1">
+        <type>ExtVertexWeighting</type>
+      </param>
+    </function>
+    <function name="WeightPointerARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="1">
+        <type>ArbVertexBlend</type>
+      </param>
+    </function>
+    <function name="WriteMaskEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="outX" index="2">
+        <type>ExtVertexShader</type>
+      </param>
+      <param name="outY" index="3">
+        <type>ExtVertexShader</type>
+      </param>
+      <param name="outZ" index="4">
+        <type>ExtVertexShader</type>
+      </param>
+      <param name="outW" index="5">
+        <type>ExtVertexShader</type>
+      </param>
+    </function>
+    <function name="ColorMaterial" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="CullFace" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="mode" index="0">
+        <type>CullFaceMode</type>
+      </param>
+    </function>
+    <function name="GetMaterialfv" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="GetMaterialiv" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="Materialf" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="Materialfv" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="Materiali" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="Materialiv" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="PixelMapfv" extension="Core" obsolete="Use GLsizei overload instead.">
+      <param name="mapsize" index="1">
+        <type>CheckedInt32</type>
+      </param>
+    </function>
+    <function name="PixelMapuiv" extension="Core" obsolete="Use GLsizei overload instead.">
+      <param name="mapsize" index="1">
+        <type>CheckedInt32</type>
+      </param>
+    </function>
+    <function name="PixelMapusv" extension="Core" obsolete="Use GLsizei overload instead.">
+      <param name="mapsize" index="1">
+        <type>CheckedInt32</type>
+      </param>
+    </function>
+    <function name="PolygonMode" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="CompressedTexSubImage1D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="4">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedTexSubImage2D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="6">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedTexSubImage3D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="8">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="MultiDrawArrays" extension="Core" obsolete="Use  overload instead.">
+      <param name="first" index="1">
+        <count>COMPSIZE(count)</count>
+      </param>
+      <param name="count" index="2">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+    </function>
+    <function name="MultiDrawElements" extension="Core" obsolete="Use  overload instead.">
+      <param name="count" index="1">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+      <param name="indices" index="3">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+    </function>
+    <function name="VertexAttribPointer" extension="Core" obsolete="Use  overload instead.">
+      <param name="pointer" index="5">
+        <count>COMPSIZE(size,type,stride)</count>
+      </param>
+    </function>
+    <function name="VertexAttribIPointer" extension="Core" obsolete="Use  overload instead.">
+      <param name="pointer" index="4">
+        <count>COMPSIZE(size,type,stride)</count>
+      </param>
+    </function>
+    <function name="GetnColorTable" extension="Core" obsolete="Use  overload instead.">
+      <param name="table" index="4">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnCompressedTexImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnConvolutionFilter" extension="Core" obsolete="Use  overload instead.">
+      <param name="image" index="4">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnHistogram" extension="Core" obsolete="Use HistogramTarget overload instead.">
+      <param name="target" index="0">
+        <type>HistogramTargetEXT</type>
+      </param>
+      <param name="values" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnMapdv" extension="Core" obsolete="Use  overload instead.">
+      <param name="v" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnMinmax" extension="Core" obsolete="Use MinmaxTarget overload instead.">
+      <param name="target" index="0">
+        <type>MinmaxTargetEXT</type>
+      </param>
+      <param name="values" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnPixelMapfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="values" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnPolygonStipple" extension="Core" obsolete="Use  overload instead.">
+      <param name="pattern" index="1">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnSeparableFilter" extension="Core" obsolete="Use SeparableTarget overload instead.">
+      <param name="target" index="0">
+        <type>SeparableTargetEXT</type>
+      </param>
+      <param name="row" index="4">
+        <count></count>
+      </param>
+      <param name="column" index="6">
+        <count></count>
+      </param>
+      <param name="span" index="7">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnTexImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformdv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="SpecializeShader" extension="Core" obsolete="Use  overload instead.">
+      <param name="pConstantIndex" index="3">
+        <count></count>
+      </param>
+      <param name="pConstantValue" index="4">
+        <count></count>
+      </param>
+    </function>
+  </overload>
+  <overload name="glcore">
+    <function name="BeginConditionalRenderNV" extension="NV" obsolete="Use ConditionalRenderMode overload instead.">
+      <param name="mode" index="1">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="ClearNamedBufferData" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+      <param name="data" index="4">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedBufferData" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+      <param name="data" index="4">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedBufferDataEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="ClearNamedBufferSubData" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+      <param name="data" index="6">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedBufferSubData" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+      <param name="data" index="6">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedBufferSubDataEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ClearNamedFramebufferfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="value" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedFramebufferfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="value" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedFramebufferiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="value" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedFramebufferiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="value" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedFramebufferuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="value" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="ClearNamedFramebufferuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="value" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="ColorFormatNV" extension="NV" obsolete="Use ColorPointerType overload instead.">
+      <param name="type" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ColorTableParameterfv" extension="Core" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>ColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="ColorTableParameteriv" extension="Core" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>ColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="CompressedMultiTexSubImage1DEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="5">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedMultiTexSubImage2DEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="7">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedMultiTexSubImage3DEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="9">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage1D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="4">
+        <type>PixelFormat</type>
+      </param>
+      <param name="data" index="6">
+        <count></count>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage1D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="4">
+        <type>PixelFormat</type>
+      </param>
+      <param name="data" index="6">
+        <count></count>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage1DEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="5">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage2D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="6">
+        <type>PixelFormat</type>
+      </param>
+      <param name="data" index="8">
+        <count></count>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage2D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="6">
+        <type>PixelFormat</type>
+      </param>
+      <param name="data" index="8">
+        <count></count>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage2DEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="7">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage3D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="8">
+        <type>PixelFormat</type>
+      </param>
+      <param name="data" index="10">
+        <count></count>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage3D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="8">
+        <type>PixelFormat</type>
+      </param>
+      <param name="data" index="10">
+        <count></count>
+      </param>
+    </function>
+    <function name="CompressedTextureSubImage3DEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="9">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameterf" extension="Core" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameterfv" extension="Core" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameteri" extension="Core" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameteriv" extension="Core" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="CoverFillPathInstancedNV" extension="NV" obsolete="Use InstancedPathCoverMode overload instead.">
+      <param name="coverMode" index="4">
+        <type>PathCoverMode</type>
+      </param>
+    </function>
+    <function name="CoverStrokePathInstancedNV" extension="NV" obsolete="Use InstancedPathCoverMode overload instead.">
+      <param name="coverMode" index="4">
+        <type>PathCoverMode</type>
+      </param>
+    </function>
+    <function name="GetActiveSubroutineName" extension="Core" obsolete="Use  overload instead.">
+      <param name="name" index="5">
+        <count>bufsize</count>
+      </param>
+    </function>
+    <function name="GetActiveSubroutineName" extension="Core" obsolete="Use  overload instead.">
+      <param name="name" index="5">
+        <count>bufsize</count>
+      </param>
+    </function>
+    <function name="GetActiveSubroutineUniformName" extension="Core" obsolete="Use  overload instead.">
+      <param name="name" index="5">
+        <count>bufsize</count>
+      </param>
+    </function>
+    <function name="GetActiveSubroutineUniformName" extension="Core" obsolete="Use  overload instead.">
+      <param name="name" index="5">
+        <count>bufsize</count>
+      </param>
+    </function>
+    <function name="GetColorTableParameterfv" extension="Core" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>GetColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="GetColorTableParameteriv" extension="Core" obsolete="Use ColorTableParameterPName overload instead.">
+      <param name="pname" index="1">
+        <type>GetColorTableParameterPNameSGI</type>
+      </param>
+    </function>
+    <function name="GetCommandHeaderNV" extension="NV" obsolete="Use CommandOpcodesNV overload instead.">
+      <param name="tokenID" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetCompressedTextureImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetCompressedTextureImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetCompressedTextureSubImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="9">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetCompressedTextureSubImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="9">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetConvolutionParameterfv" extension="Core" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="GetConvolutionParameteriv" extension="Core" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="GetDoublei_vEXT" extension="EXT" obsolete="Use GetPName overload instead.">
+      <param name="pname" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetDoubleIndexedvEXT" extension="EXT" obsolete="Use GetPName overload instead.">
+      <param name="target" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetFloati_vEXT" extension="EXT" obsolete="Use GetPName overload instead.">
+      <param name="pname" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetFloatIndexedvEXT" extension="EXT" obsolete="Use GetPName overload instead.">
+      <param name="target" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetIntegerIndexedvEXT" extension="EXT" obsolete="Use GetPName overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetInternalformati64v" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetInternalformati64v" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetInternalformativ" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetInternalformativ" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetInternalformatSampleivNV" extension="NV" obsolete="Use  overload instead.">
+      <param name="params" index="5">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetNamedBufferParameteri64v" extension="Core" obsolete="Use BufferPNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferParameteri64v" extension="Core" obsolete="Use BufferPNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferParameteriv" extension="Core" obsolete="Use BufferPNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferParameteriv" extension="Core" obsolete="Use BufferPNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferParameterivEXT" extension="EXT" obsolete="Use BufferPNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferParameterui64vNV" extension="NV" obsolete="Use BufferPNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferPointerv" extension="Core" obsolete="Use BufferPointerNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetNamedBufferPointerv" extension="Core" obsolete="Use BufferPointerNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetNamedBufferPointervEXT" extension="EXT" obsolete="Use BufferPointerNameARB overload instead.">
+      <param name="pname" index="1">
+        <type>VertexBufferObjectParameter</type>
+      </param>
+    </function>
+    <function name="GetNamedBufferSubData" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetNamedBufferSubData" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetNamedProgramivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetNamedProgramLocalParameterdvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetNamedProgramLocalParameterfvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetNamedProgramLocalParameterIivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetNamedProgramLocalParameterIuivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetNamedProgramStringEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+      <param name="pname" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetnMapdvARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="v" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnPixelMapfvARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="values" index="2">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformdvARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformfvARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformfvKHR" extension="KHR" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformi64vARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformivARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformivKHR" extension="KHR" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformui64vARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformuivARB" extension="ARB" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformuivKHR" extension="KHR" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetPerfMonitorCounterDataAMD" extension="AMD" obsolete="Use  overload instead.">
+      <param name="data" index="3">
+        <count>dataSize</count>
+      </param>
+    </function>
+    <function name="GetPerfQueryDataINTEL" extension="INTEL" obsolete="Use PerfQueryDataFlags overload instead.">
+      <param name="flags" index="1">
+        <type>GLuint</type>
+      </param>
+    </function>
+    <function name="GetPerfQueryInfoINTEL" extension="INTEL" obsolete="Use PerformanceQueryCapsMaskINTEL * overload instead.">
+      <param name="capsMask" index="6">
+        <type>GLuint *</type>
+      </param>
+    </function>
+    <function name="GetPointeri_vEXT" extension="EXT" obsolete="Use GLenum overload instead.">
+      <param name="pname" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetPointerIndexedvEXT" extension="EXT" obsolete="Use GLenum overload instead.">
+      <param name="target" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetPointervKHR" extension="KHR" obsolete="Use  overload instead.">
+      <param name="params" index="1">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetProgramResourcefvNV" extension="NV" obsolete="Use  overload instead.">
+      <param name="length" index="6">
+        <count></count>
+      </param>
+      <param name="params" index="7">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetProgramResourceiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="7">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetProgramResourceiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="7">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIiv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIiv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIuiv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIuiv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSynciv" extension="Core" obsolete="Use  overload instead.">
+      <param name="values" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetSynciv" extension="Core" obsolete="Use  overload instead.">
+      <param name="values" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetTextureImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetTextureImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetTextureSubImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="11">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetTextureSubImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="11">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetVertexArrayPointeri_vEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="param" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="InvalidateNamedFramebufferData" extension="Core" obsolete="Use  overload instead.">
+      <param name="attachments" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="InvalidateNamedFramebufferData" extension="Core" obsolete="Use  overload instead.">
+      <param name="attachments" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="InvalidateNamedFramebufferSubData" extension="Core" obsolete="Use  overload instead.">
+      <param name="attachments" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="InvalidateNamedFramebufferSubData" extension="Core" obsolete="Use  overload instead.">
+      <param name="attachments" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="ListDrawCommandsStatesClientNV" extension="NV" obsolete="Use  overload instead.">
+      <param name="indirects" index="2">
+        <count></count>
+      </param>
+      <param name="sizes" index="3">
+        <count></count>
+      </param>
+      <param name="states" index="4">
+        <count></count>
+      </param>
+      <param name="fbos" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="MapBufferRange" extension="Core" obsolete="Use MapBufferAccessMask overload instead.">
+      <param name="access" index="3">
+        <type>BufferAccessMask</type>
+      </param>
+    </function>
+    <function name="MapBufferRange" extension="Core" obsolete="Use MapBufferAccessMask overload instead.">
+      <param name="access" index="3">
+        <type>BufferAccessMask</type>
+      </param>
+    </function>
+    <function name="MapNamedBufferRange" extension="Core" obsolete="Use MapBufferAccessMask overload instead.">
+      <param name="access" index="3">
+        <type>BufferAccessMask</type>
+      </param>
+    </function>
+    <function name="MapNamedBufferRange" extension="Core" obsolete="Use MapBufferAccessMask overload instead.">
+      <param name="access" index="3">
+        <type>BufferAccessMask</type>
+      </param>
+    </function>
+    <function name="MapNamedBufferRangeEXT" extension="EXT" obsolete="Use MapBufferAccessMask overload instead.">
+      <param name="access" index="3">
+        <type>BufferAccessMask</type>
+      </param>
+    </function>
+    <function name="MultiDrawElementsBaseVertex" extension="Core" obsolete="Use  overload instead.">
+      <param name="count" index="1">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+      <param name="indices" index="3">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+      <param name="basevertex" index="5">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+    </function>
+    <function name="MultiDrawElementsBaseVertex" extension="Core" obsolete="Use  overload instead.">
+      <param name="count" index="1">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+      <param name="indices" index="3">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+      <param name="basevertex" index="5">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+    </function>
+    <function name="MultiTexBufferEXT" extension="EXT" obsolete="Use InternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="NamedBufferData" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="NamedBufferData" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="NamedBufferStorage" extension="Core" obsolete="Use BufferStorageMask overload instead.">
+      <param name="flags" index="3">
+        <type>MapBufferUsageMask</type>
+      </param>
+    </function>
+    <function name="NamedBufferStorage" extension="Core" obsolete="Use BufferStorageMask overload instead.">
+      <param name="flags" index="3">
+        <type>MapBufferUsageMask</type>
+      </param>
+    </function>
+    <function name="NamedBufferStorageEXT" extension="EXT" obsolete="Use BufferStorageMask overload instead.">
+      <param name="flags" index="3">
+        <type>MapBufferUsageMask</type>
+      </param>
+    </function>
+    <function name="NamedBufferSubData" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="3">
+        <count>COMPSIZE(size)</count>
+      </param>
+    </function>
+    <function name="NamedBufferSubData" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="3">
+        <count>COMPSIZE(size)</count>
+      </param>
+    </function>
+    <function name="NamedFramebufferDrawBuffers" extension="Core" obsolete="Use  overload instead.">
+      <param name="bufs" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="NamedFramebufferDrawBuffers" extension="Core" obsolete="Use  overload instead.">
+      <param name="bufs" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameter4dEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameter4dvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameter4fEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameter4fvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameterI4iEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameterI4ivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameterI4uiEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameterI4uivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParameters4fvEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParametersI4ivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="NamedProgramLocalParametersI4uivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="NamedProgramStringEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>All</type>
+      </param>
+      <param name="format" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PathColorGenNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="colorFormat" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PathCommandsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="coordType" index="4">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PathCoordsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="coordType" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PathGlyphIndexRangeNV" extension="NV" obsolete="Use GLuint * overload instead.">
+      <param name="baseAndCount" index="5">
+        <type>GLuint</type>
+        <count></count>
+      </param>
+    </function>
+    <function name="PathSubCommandsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="coordType" index="6">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PathSubCoordsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="coordType" index="3">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ReadnPixels" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="7">
+        <count></count>
+      </param>
+    </function>
+    <function name="ReadnPixels" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="7">
+        <count></count>
+      </param>
+    </function>
+    <function name="ShaderBinary" extension="Core" obsolete="Use ShaderBinaryFormat overload instead.">
+      <param name="binaryformat" index="2">
+        <type>BinaryFormat</type>
+      </param>
+    </function>
+    <function name="ShaderBinary" extension="Core" obsolete="Use ShaderBinaryFormat overload instead.">
+      <param name="binaryformat" index="2">
+        <type>BinaryFormat</type>
+      </param>
+    </function>
+    <function name="StencilThenCoverFillPathInstancedNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pathNameType" index="1">
+        <type>All</type>
+      </param>
+      <param name="paths" index="2">
+        <count></count>
+      </param>
+      <param name="fillMode" index="4">
+        <type>All</type>
+      </param>
+      <param name="coverMode" index="6">
+        <type>All</type>
+      </param>
+      <param name="transformType" index="7">
+        <type>All</type>
+      </param>
+      <param name="transformValues" index="8">
+        <count></count>
+      </param>
+    </function>
+    <function name="StencilThenCoverFillPathNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="fillMode" index="1">
+        <type>All</type>
+      </param>
+      <param name="coverMode" index="3">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="StencilThenCoverStrokePathInstancedNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pathNameType" index="1">
+        <type>All</type>
+      </param>
+      <param name="paths" index="2">
+        <count></count>
+      </param>
+      <param name="coverMode" index="6">
+        <type>All</type>
+      </param>
+      <param name="transformType" index="7">
+        <type>All</type>
+      </param>
+      <param name="transformValues" index="8">
+        <count></count>
+      </param>
+    </function>
+    <function name="StencilThenCoverStrokePathNV" extension="NV" obsolete="Use PathCoverMode overload instead.">
+      <param name="coverMode" index="3">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TexBufferARB" extension="ARB" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureBuffer" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureBuffer" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureBufferEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureBufferRange" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureBufferRange" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureBufferRangeEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureParameterfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="param" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameterfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="param" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameterIiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameterIiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameterIuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameterIuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameteriv" extension="Core" obsolete="Use  overload instead.">
+      <param name="param" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureParameteriv" extension="Core" obsolete="Use  overload instead.">
+      <param name="param" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="TextureStorage1D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage1D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage1DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2DMultisample" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2DMultisample" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2DMultisampleEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3DMultisample" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3DMultisample" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3DMultisampleEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="VertexArrayAttribIFormat" extension="Core" obsolete="Use VertexAttribIType overload instead.">
+      <param name="type" index="3">
+        <type>VertexAttribIntegerType</type>
+      </param>
+    </function>
+    <function name="VertexArrayAttribIFormat" extension="Core" obsolete="Use VertexAttribIType overload instead.">
+      <param name="type" index="3">
+        <type>VertexAttribIntegerType</type>
+      </param>
+    </function>
+    <function name="VertexArrayAttribLFormat" extension="Core" obsolete="Use VertexAttribLType overload instead.">
+      <param name="type" index="3">
+        <type>VertexAttribDoubleType</type>
+      </param>
+    </function>
+    <function name="VertexArrayAttribLFormat" extension="Core" obsolete="Use VertexAttribLType overload instead.">
+      <param name="type" index="3">
+        <type>VertexAttribDoubleType</type>
+      </param>
+    </function>
+    <function name="VertexArrayVertexAttribFormatEXT" extension="EXT" obsolete="Use VertexAttribType overload instead.">
+      <param name="type" index="3">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="VertexArrayVertexAttribIFormatEXT" extension="EXT" obsolete="Use VertexAttribIType overload instead.">
+      <param name="type" index="3">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="VertexArrayVertexAttribIOffsetEXT" extension="EXT" obsolete="Use VertexAttribType overload instead.">
+      <param name="type" index="4">
+        <type>VertexAttribEnum</type>
+      </param>
+    </function>
+    <function name="VertexArrayVertexAttribLFormatEXT" extension="EXT" obsolete="Use VertexAttribLType overload instead.">
+      <param name="type" index="3">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="VertexArrayVertexAttribLOffsetEXT" extension="EXT" obsolete="Use VertexAttribLType overload instead.">
+      <param name="type" index="4">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="VertexArrayVertexBuffers" extension="Core" obsolete="Use  overload instead.">
+      <param name="buffers" index="3">
+        <count></count>
+      </param>
+      <param name="offsets" index="4">
+        <count></count>
+      </param>
+      <param name="strides" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="VertexArrayVertexBuffers" extension="Core" obsolete="Use  overload instead.">
+      <param name="buffers" index="3">
+        <count></count>
+      </param>
+      <param name="offsets" index="4">
+        <count></count>
+      </param>
+      <param name="strides" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="VertexAttribFormatNV" extension="NV" obsolete="Use VertexAttribType overload instead.">
+      <param name="type" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="VertexAttribIFormatNV" extension="NV" obsolete="Use VertexAttribIType overload instead.">
+      <param name="type" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="VertexAttribLFormatNV" extension="NV" obsolete="Use VertexAttribLType overload instead.">
+      <param name="type" index="2">
+        <type>VertexAttribType</type>
+      </param>
+    </function>
+    <function name="VertexAttribLPointer" extension="Core" obsolete="Use  overload instead.">
+      <param name="pointer" index="4">
+        <count>size</count>
+      </param>
+    </function>
+    <function name="VertexAttribLPointer" extension="Core" obsolete="Use  overload instead.">
+      <param name="pointer" index="4">
+        <count>size</count>
+      </param>
+    </function>
+    <function name="CullFace" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="mode" index="0">
+        <type>CullFaceMode</type>
+      </param>
+    </function>
+    <function name="PolygonMode" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="CompressedTexSubImage1D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="4">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedTexSubImage2D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="6">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CompressedTexSubImage3D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="8">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="MultiDrawArrays" extension="Core" obsolete="Use  overload instead.">
+      <param name="first" index="1">
+        <count>COMPSIZE(count)</count>
+      </param>
+      <param name="count" index="2">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+    </function>
+    <function name="MultiDrawElements" extension="Core" obsolete="Use  overload instead.">
+      <param name="count" index="1">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+      <param name="indices" index="3">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+    </function>
+    <function name="VertexAttribPointer" extension="Core" obsolete="Use  overload instead.">
+      <param name="pointer" index="5">
+        <count>COMPSIZE(size,type,stride)</count>
+      </param>
+    </function>
+    <function name="VertexAttribIPointer" extension="Core" obsolete="Use  overload instead.">
+      <param name="pointer" index="4">
+        <count>COMPSIZE(size,type,stride)</count>
+      </param>
+    </function>
+    <function name="GetnColorTable" extension="Core" obsolete="Use  overload instead.">
+      <param name="table" index="4">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnCompressedTexImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnConvolutionFilter" extension="Core" obsolete="Use  overload instead.">
+      <param name="image" index="4">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnHistogram" extension="Core" obsolete="Use HistogramTarget overload instead.">
+      <param name="target" index="0">
+        <type>HistogramTargetEXT</type>
+      </param>
+      <param name="values" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnMapdv" extension="Core" obsolete="Use  overload instead.">
+      <param name="v" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnMinmax" extension="Core" obsolete="Use MinmaxTarget overload instead.">
+      <param name="target" index="0">
+        <type>MinmaxTargetEXT</type>
+      </param>
+      <param name="values" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnPixelMapfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="values" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnPolygonStipple" extension="Core" obsolete="Use  overload instead.">
+      <param name="pattern" index="1">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnSeparableFilter" extension="Core" obsolete="Use SeparableTarget overload instead.">
+      <param name="target" index="0">
+        <type>SeparableTargetEXT</type>
+      </param>
+      <param name="row" index="4">
+        <count></count>
+      </param>
+      <param name="column" index="6">
+        <count></count>
+      </param>
+      <param name="span" index="7">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnTexImage" extension="Core" obsolete="Use  overload instead.">
+      <param name="pixels" index="5">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformdv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="SpecializeShader" extension="Core" obsolete="Use  overload instead.">
+      <param name="pConstantIndex" index="3">
+        <count></count>
+      </param>
+      <param name="pConstantValue" index="4">
+        <count></count>
+      </param>
+    </function>
+  </overload>
+  <overload name="gles1">
+    <function name="ConvolutionParameterxOES" extension="OES" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="ConvolutionParameterxvOES" extension="OES" obsolete="Use ConvolutionParameter overload instead.">
+      <param name="pname" index="1">
+        <type>ConvolutionParameterEXT</type>
+      </param>
+    </function>
+    <function name="DiscardFramebufferEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+      <param name="attachments" index="2">
+        <type>GLenum *</type>
+      </param>
+    </function>
+    <function name="DrawTexfvOES" extension="OES" obsolete="Use  overload instead.">
+      <param name="coords" index="0">
+        <count></count>
+      </param>
+    </function>
+    <function name="DrawTexivOES" extension="OES" obsolete="Use  overload instead.">
+      <param name="coords" index="0">
+        <count></count>
+      </param>
+    </function>
+    <function name="DrawTexsvOES" extension="OES" obsolete="Use  overload instead.">
+      <param name="coords" index="0">
+        <count></count>
+      </param>
+    </function>
+    <function name="DrawTexxvOES" extension="OES" obsolete="Use  overload instead.">
+      <param name="coords" index="0">
+        <count></count>
+      </param>
+    </function>
+    <function name="ExtGetBufferPointervQCOM" extension="QCOM" obsolete="Use  overload instead.">
+      <param name="params" index="1">
+        <count></count>
+      </param>
+    </function>
+    <function name="FenceSyncAPPLE" extension="APPLE" obsolete="Use SyncBehaviorFlags overload instead.">
+      <param name="flags" index="1">
+        <type>GLbitfield</type>
+      </param>
+    </function>
+    <function name="GetBufferPointervOES" extension="OES" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetFenceivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetMaterialxOES" extension="OES" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="GetMaterialxvOES" extension="OES" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="GetnUniformfvEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformivEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetObjectLabel" extension="Core" obsolete="Use ObjectIdentifier overload instead.">
+      <param name="identifier" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetPointervKHR" extension="KHR" obsolete="Use  overload instead.">
+      <param name="params" index="1">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetSyncivAPPLE" extension="APPLE" obsolete="Use  overload instead.">
+      <param name="values" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="MapBufferRangeEXT" extension="EXT" obsolete="Use MapBufferAccessMask overload instead.">
+      <param name="access" index="3">
+        <type>BufferAccessMask</type>
+      </param>
+    </function>
+    <function name="MaterialxOES" extension="OES" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="MaterialxvOES" extension="OES" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="MatrixIndexPointerOES" extension="OES" obsolete="Use strongly typed overload instead.">
+      <param name="type" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="MultiDrawArraysEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="first" index="1">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+      <param name="count" index="2">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+    </function>
+    <function name="MultiDrawElementsEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="count" index="1">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+      <param name="indices" index="3">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+    </function>
+    <function name="PointParameterxOES" extension="OES" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PointParameterxvOES" extension="OES" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="SetFenceNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="condition" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TexStorage1DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexStorage2DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexStorage3DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage1DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="WaitSyncAPPLE" extension="APPLE" obsolete="Use SyncBehaviorFlags overload instead.">
+      <param name="flags" index="1">
+        <type>GLbitfield</type>
+      </param>
+    </function>
+    <function name="CompressedTexSubImage2D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="6">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CullFace" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="mode" index="0">
+        <type>CullFaceMode</type>
+      </param>
+    </function>
+    <function name="GetBufferParameteriv" extension="Core" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetMaterialfv" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="GetMaterialxv" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="Materialf" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="Materialfv" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="Materialx" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="Materialxv" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="PointParameterf" extension="Core" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PointParameterfv" extension="Core" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PointParameterx" extension="Core" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PointParameterxv" extension="Core" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>All</type>
+      </param>
+    </function>
+  </overload>
+  <overload name="gles2">
+    <function name="BeginConditionalRenderNV" extension="NV" obsolete="Use ConditionalRenderMode overload instead.">
+      <param name="mode" index="1">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="BufferStorageEXT" extension="EXT" obsolete="Use BufferStorageMask overload instead.">
+      <param name="flags" index="3">
+        <type>MapBufferUsageMask</type>
+      </param>
+    </function>
+    <function name="BufferStorageExternalEXT" extension="EXT" obsolete="Use BufferStorageMask overload instead.">
+      <param name="flags" index="4">
+        <type>MapBufferUsageMask</type>
+      </param>
+    </function>
+    <function name="CompressedTexSubImage3DOES" extension="OES" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="8">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CoverFillPathInstancedNV" extension="NV" obsolete="Use InstancedPathCoverMode overload instead.">
+      <param name="coverMode" index="4">
+        <type>PathCoverMode</type>
+      </param>
+    </function>
+    <function name="CoverStrokePathInstancedNV" extension="NV" obsolete="Use InstancedPathCoverMode overload instead.">
+      <param name="coverMode" index="4">
+        <type>PathCoverMode</type>
+      </param>
+    </function>
+    <function name="DiscardFramebufferEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+      <param name="attachments" index="2">
+        <type>GLenum *</type>
+      </param>
+    </function>
+    <function name="DrawElementsInstancedANGLE" extension="ANGLE" obsolete="Use DrawElementsType overload instead.">
+      <param name="type" index="2">
+        <type>PrimitiveType</type>
+      </param>
+    </function>
+    <function name="DrawElementsInstancedBaseInstanceEXT" extension="EXT" obsolete="Use DrawElementsType overload instead.">
+      <param name="type" index="2">
+        <type>PrimitiveType</type>
+      </param>
+    </function>
+    <function name="DrawElementsInstancedBaseVertexBaseInstanceEXT" extension="EXT" obsolete="Use DrawElementsType overload instead.">
+      <param name="type" index="2">
+        <type>PrimitiveType</type>
+      </param>
+    </function>
+    <function name="DrawElementsInstancedNV" extension="NV" obsolete="Use DrawElementsType overload instead.">
+      <param name="type" index="2">
+        <type>PrimitiveType</type>
+      </param>
+    </function>
+    <function name="ExtGetBufferPointervQCOM" extension="QCOM" obsolete="Use  overload instead.">
+      <param name="params" index="1">
+        <count></count>
+      </param>
+    </function>
+    <function name="FenceSyncAPPLE" extension="APPLE" obsolete="Use SyncBehaviorFlags overload instead.">
+      <param name="flags" index="1">
+        <type>GLbitfield</type>
+      </param>
+    </function>
+    <function name="GetBufferPointervOES" extension="OES" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetFenceivNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetFloati_vNV" extension="NV" obsolete="Use GetPName overload instead.">
+      <param name="target" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetFloati_vOES" extension="OES" obsolete="Use GetPName overload instead.">
+      <param name="target" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetIntegeri_vEXT" extension="EXT" obsolete="Use GetPName overload instead.">
+      <param name="target" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetInternalformatSampleivNV" extension="NV" obsolete="Use  overload instead.">
+      <param name="params" index="5">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformfv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformfvEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformfvKHR" extension="KHR" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformivEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetnUniformivKHR" extension="KHR" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformuiv" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetnUniformuivKHR" extension="KHR" obsolete="Use  overload instead.">
+      <param name="params" index="3">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetObjectLabel" extension="Core" obsolete="Use ObjectIdentifier overload instead.">
+      <param name="identifier" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetObjectLabel" extension="Core" obsolete="Use ObjectIdentifier overload instead.">
+      <param name="identifier" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetPerfMonitorCounterDataAMD" extension="AMD" obsolete="Use  overload instead.">
+      <param name="data" index="3">
+        <count>dataSize</count>
+      </param>
+    </function>
+    <function name="GetPerfQueryDataINTEL" extension="INTEL" obsolete="Use PerfQueryDataFlags overload instead.">
+      <param name="flags" index="1">
+        <type>GLuint</type>
+      </param>
+    </function>
+    <function name="GetPerfQueryInfoINTEL" extension="INTEL" obsolete="Use PerformanceQueryCapsMaskINTEL * overload instead.">
+      <param name="capsMask" index="6">
+        <type>GLuint *</type>
+      </param>
+    </function>
+    <function name="GetPointervKHR" extension="KHR" obsolete="Use  overload instead.">
+      <param name="params" index="1">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetProgramResourcefvNV" extension="NV" obsolete="Use  overload instead.">
+      <param name="length" index="6">
+        <count></count>
+      </param>
+      <param name="params" index="7">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetQueryivEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetQueryObjectivEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetQueryObjectuivEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="params" index="2">
+        <count></count>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIivEXT" extension="EXT" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIivOES" extension="OES" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIuivEXT" extension="EXT" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIuivOES" extension="OES" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSyncivAPPLE" extension="APPLE" obsolete="Use  overload instead.">
+      <param name="values" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="MapBufferRangeEXT" extension="EXT" obsolete="Use MapBufferAccessMask overload instead.">
+      <param name="access" index="3">
+        <type>BufferAccessMask</type>
+      </param>
+    </function>
+    <function name="MultiDrawArraysEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="first" index="1">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+      <param name="count" index="2">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+    </function>
+    <function name="MultiDrawElementsBaseVertexEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="count" index="1">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+      <param name="indices" index="3">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+      <param name="basevertex" index="5">
+        <count>COMPSIZE(drawcount)</count>
+      </param>
+    </function>
+    <function name="MultiDrawElementsEXT" extension="EXT" obsolete="Use  overload instead.">
+      <param name="count" index="1">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+      <param name="indices" index="3">
+        <count>COMPSIZE(primcount)</count>
+      </param>
+    </function>
+    <function name="NamedBufferStorageExternalEXT" extension="EXT" obsolete="Use BufferStorageMask overload instead.">
+      <param name="flags" index="4">
+        <type>MapBufferUsageMask</type>
+      </param>
+    </function>
+    <function name="PathColorGenNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="colorFormat" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PathCommandsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="coordType" index="4">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PathCoordsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="coordType" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PathGlyphIndexRangeNV" extension="NV" obsolete="Use GLuint * overload instead.">
+      <param name="baseAndCount" index="5">
+        <type>GLuint</type>
+        <count></count>
+      </param>
+    </function>
+    <function name="PathSubCommandsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="coordType" index="6">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PathSubCoordsNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="coordType" index="3">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="PolygonModeNV" extension="NV" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>MaterialFace</type>
+      </param>
+    </function>
+    <function name="QueryCounterEXT" extension="EXT" obsolete="Use QueryCounterTarget overload instead.">
+      <param name="target" index="1">
+        <type>QueryTarget</type>
+      </param>
+    </function>
+    <function name="ReadnPixels" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="7">
+        <count></count>
+      </param>
+    </function>
+    <function name="ReadnPixels" extension="Core" obsolete="Use  overload instead.">
+      <param name="data" index="7">
+        <count></count>
+      </param>
+    </function>
+    <function name="SamplerParameterIivEXT" extension="EXT" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="SamplerParameterIivOES" extension="OES" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="SamplerParameterIuivEXT" extension="EXT" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="SamplerParameterIuivOES" extension="OES" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="SetFenceNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="condition" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="StencilThenCoverFillPathInstancedNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pathNameType" index="1">
+        <type>All</type>
+      </param>
+      <param name="paths" index="2">
+        <count></count>
+      </param>
+      <param name="fillMode" index="4">
+        <type>All</type>
+      </param>
+      <param name="coverMode" index="6">
+        <type>All</type>
+      </param>
+      <param name="transformType" index="7">
+        <type>All</type>
+      </param>
+      <param name="transformValues" index="8">
+        <count></count>
+      </param>
+    </function>
+    <function name="StencilThenCoverFillPathNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="fillMode" index="1">
+        <type>All</type>
+      </param>
+      <param name="coverMode" index="3">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="StencilThenCoverStrokePathInstancedNV" extension="NV" obsolete="Use strongly typed overload instead.">
+      <param name="pathNameType" index="1">
+        <type>All</type>
+      </param>
+      <param name="paths" index="2">
+        <count></count>
+      </param>
+      <param name="coverMode" index="6">
+        <type>All</type>
+      </param>
+      <param name="transformType" index="7">
+        <type>All</type>
+      </param>
+      <param name="transformValues" index="8">
+        <count></count>
+      </param>
+    </function>
+    <function name="StencilThenCoverStrokePathNV" extension="NV" obsolete="Use PathCoverMode overload instead.">
+      <param name="coverMode" index="3">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TexBufferEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexBufferOES" extension="OES" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexBufferRangeEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexBufferRangeOES" extension="OES" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexStorage1DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexStorage2DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexStorage3DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexStorage3DMultisampleOES" extension="OES" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexStorageMem1DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TexStorageMem2DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TexStorageMem2DMultisampleEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TexStorageMem3DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TexStorageMem3DMultisampleEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TextureStorage1DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorageMem1DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TextureStorageMem2DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TextureStorageMem2DMultisampleEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TextureStorageMem3DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TextureStorageMem3DMultisampleEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalFormat" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TextureViewEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureViewOES" extension="OES" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="3">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="WaitSyncAPPLE" extension="APPLE" obsolete="Use SyncBehaviorFlags overload instead.">
+      <param name="flags" index="1">
+        <type>GLbitfield</type>
+      </param>
+    </function>
+    <function name="CompressedTexSubImage2D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="6">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="CullFace" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="mode" index="0">
+        <type>CullFaceMode</type>
+      </param>
+    </function>
+    <function name="GetActiveUniform" extension="Core" obsolete="Use UniformType * overload instead.">
+      <param name="type" index="5">
+        <type>AttributeType *</type>
+      </param>
+    </function>
+    <function name="GetBufferParameteriv" extension="Core" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetVertexAttribfv" extension="Core" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetVertexAttribiv" extension="Core" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetVertexAttribPointerv" extension="Core" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ShaderBinary" extension="Core" obsolete="Use ShaderBinaryFormat overload instead.">
+      <param name="binaryformat" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="StencilFuncSeparate" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>StencilFaceDirection</type>
+      </param>
+    </function>
+    <function name="StencilMaskSeparate" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>StencilFaceDirection</type>
+      </param>
+    </function>
+    <function name="StencilOpSeparate" extension="Core" obsolete="Use TriangleFace overload instead.">
+      <param name="face" index="0">
+        <type>StencilFaceDirection</type>
+      </param>
+    </function>
+    <function name="VertexAttribPointer" extension="Core" obsolete="Use  overload instead.">
+      <param name="pointer" index="5">
+        <count>COMPSIZE(size,type,stride)</count>
+      </param>
+    </function>
+    <function name="CompressedTexSubImage3D" extension="Core" obsolete="Use InternalFormat overload instead.">
+      <param name="format" index="8">
+        <type>PixelFormat</type>
+      </param>
+    </function>
+    <function name="DrawBuffers" extension="Core" obsolete="Use DrawBufferMode * overload instead.">
+      <param name="bufs" index="1">
+        <type>DrawBufferModeATI *</type>
+      </param>
+    </function>
+    <function name="FenceSync" extension="Core" obsolete="Use SyncBehaviorFlags overload instead.">
+      <param name="flags" index="1">
+        <type>GLbitfield</type>
+      </param>
+    </function>
+    <function name="GetBufferParameteri64v" extension="Core" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetBufferPointerv" extension="Core" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetInteger64i_v" extension="Core" obsolete="Use GetPName overload instead.">
+      <param name="target" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetIntegeri_v" extension="Core" obsolete="Use GetPName overload instead.">
+      <param name="target" index="0">
+        <type>TypeEnum</type>
+      </param>
+    </function>
+    <function name="GetInternalformativ" extension="Core" obsolete="Use  overload instead.">
+      <param name="params" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetSamplerParameterfv" extension="Core" obsolete="Use SamplerParameterF overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameteriv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSynciv" extension="Core" obsolete="Use  overload instead.">
+      <param name="values" index="4">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="GetTransformFeedbackVarying" extension="Core" obsolete="Use AttributeType * overload instead.">
+      <param name="type" index="5">
+        <type>GLenum *</type>
+      </param>
+    </function>
+    <function name="InvalidateFramebuffer" extension="Core" obsolete="Use InvalidateFramebufferAttachment * overload instead.">
+      <param name="attachments" index="2">
+        <type>GLenum *</type>
+      </param>
+    </function>
+    <function name="InvalidateSubFramebuffer" extension="Core" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>All</type>
+      </param>
+      <param name="attachments" index="2">
+        <type>FramebufferAttachment *</type>
+      </param>
+    </function>
+    <function name="MapBufferRange" extension="Core" obsolete="Use MapBufferAccessMask overload instead.">
+      <param name="access" index="3">
+        <type>BufferAccessMask</type>
+      </param>
+    </function>
+    <function name="SamplerParameterf" extension="Core" obsolete="Use SamplerParameterF overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="SamplerParameterfv" extension="Core" obsolete="Use SamplerParameterF overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="SamplerParameteri" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="SamplerParameteriv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="TexStorage2D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexStorage3D" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TransformFeedbackVaryings" extension="Core" obsolete="Use TransformFeedbackBufferMode overload instead.">
+      <param name="bufferMode" index="3">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="VertexAttribIPointer" extension="Core" obsolete="Use VertexAttribIType overload instead.">
+      <param name="type" index="2">
+        <type>VertexAttribPointerType</type>
+      </param>
+      <param name="pointer" index="4">
+        <count>COMPSIZE(size,type,stride)</count>
+      </param>
+    </function>
+    <function name="WaitSync" extension="Core" obsolete="Use SyncBehaviorFlags overload instead.">
+      <param name="flags" index="1">
+        <type>GLbitfield</type>
+      </param>
+    </function>
+    <function name="GetMultisamplefv" extension="Core" obsolete="Use strongly typed overload instead.">
+      <param name="pname" index="0">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="GetProgramResourceiv" extension="Core" obsolete="Use ProgramResourceProperty * overload instead.">
+      <param name="props" index="4">
+        <type>GLenum *</type>
+      </param>
+      <param name="params" index="7">
+        <count>bufSize</count>
+      </param>
+    </function>
+    <function name="TexStorage2DMultisample" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="VertexAttribFormat" extension="Core" obsolete="Use VertexAttribType overload instead.">
+      <param name="type" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="VertexAttribIFormat" extension="Core" obsolete="Use VertexAttribIType overload instead.">
+      <param name="type" index="2">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="CopyImageSubData" extension="Core" obsolete="Use CopyImageSubDataTarget overload instead.">
+      <param name="srcTarget" index="1">
+        <type>CopyBufferSubDataTarget</type>
+      </param>
+      <param name="dstTarget" index="7">
+        <type>CopyBufferSubDataTarget</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIiv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameterIuiv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="SamplerParameterIiv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="SamplerParameterIuiv" extension="Core" obsolete="Use SamplerParameterI overload instead.">
+      <param name="pname" index="1">
+        <type>SamplerParameterName</type>
+      </param>
+    </function>
+    <function name="TexBuffer" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexBufferRange" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="1">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+    <function name="TexStorage3DMultisample" extension="Core" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="internalformat" index="2">
+        <type>InternalFormat</type>
+      </param>
+    </function>
+  </overload>
+
+  <!-- A few manually added overloads that where to complicated to auto-generate -->
+  <overload name="gl">
+    <function name="GetNamedProgramivEXT" extension="EXT" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+      <param name="pname" index="2">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="GetProgramStringARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>AssemblyProgramTargetArb</type>
+      </param>
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="ProgramStringARB" extension="ARB" obsolete="Use strongly typed overload instead.">
+      <param name="target" index="0">
+        <type>AssemblyProgramTargetArb</type>
+      </param>
+      <param name="pname" index="1">
+        <type>All</type>
+      </param>
+    </function>
+    <function name="TextureStorage1DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+      <param name="internalformat" index="3">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="TextureStorage2DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+      <param name="internalformat" index="3">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="TextureStorage3DEXT" extension="EXT" obsolete="Use SizedInternalFormat overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+      <param name="internalformat" index="3">
+        <type>ExtDirectStateAccess</type>
+      </param>
+    </function>
+    <function name="TextureStorage1DEXT" extension="EXT" obsolete="Use All overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+      <param name="internalformat" index="3">
+        <type>SizedInternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage2DEXT" extension="EXT" obsolete="Use All overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+      <param name="internalformat" index="3">
+        <type>SizedInternalFormat</type>
+      </param>
+    </function>
+    <function name="TextureStorage3DEXT" extension="EXT" obsolete="Use All overload instead.">
+      <param name="target" index="1">
+        <type>ExtDirectStateAccess</type>
+      </param>
+      <param name="internalformat" index="3">
+        <type>SizedInternalFormat</type>
+      </param>
+    </function>
+    <function name="LightEnviSGIX" extension="SGIX" obsolete="Use LightEnvModeSGIX overload instead.">
+      <param name="pname" index="0">
+        <type>SgixFragmentLighting</type>
+      </param>
+      <param name="param" index="1">
+        <type>CheckedInt32</type>
+      </param>
+    </function>
+  </overload>
+</signatures>

--- a/src/Generator.Bind/Specifications/GL2/gl.tm
+++ b/src/Generator.Bind/Specifications/GL2/gl.tm
@@ -331,6 +331,19 @@ PathStringFormat,*,*,		    GLenum,*,*
 PathTransformType,*,*,		    GLenum,*,*
 PathHandleMissingGlyphs,*,*,	    GLenum,*,*
 
+CheckFramebufferStatusTarget,*,*,   GLenum,*,*
+ColorMaterialFace,*,*,   GLenum,*,*
+DataType,*,*,   GLenum,*,*
+FramebufferFetchNoncoherent,*,*,   GLenum,*,*
+GetConvolutionParameter,*,*,   GLenum,*,*
+GetPixelMap,*,*,   GLenum,*,*
+MapBufferUsageMask,*,*,   GLenum,*,*
+PixelTexGenMode,*,*,   GLenum,*,*
+PointParameterNameSGIS,*,*,   GLenum,*,*
+SamplerParameter,*,*,   GLenum,*,*
+SamplerParameterName,*,*,   GLenum,*,*
+TextureFilterFuncSGIS,*,*,   GLenum,*,*
+
 # No longer used in gl.spec
 # ClampedColorF,*,*,		      GLclampf,*,*
 # ControlPointNV,*,*,		      GLvoid,*,*

--- a/src/Generator.Bind/Specifications/GL2/overrides.xml
+++ b/src/Generator.Bind/Specifications/GL2/overrides.xml
@@ -5007,6 +5007,12 @@
   </overload>
 
   <replace name="gles1">
+    <function name="GetString" extension="Core">
+      <returns>String</returns>
+    </function>
+  </replace>
+
+  <replace name="gles1">
     <!-- AMD_performance_monitors is not const-correct -->
     <function name="DeletePerfMonitors" extension="AMD">
       <param name="monitors"><flow>in</flow></param>

--- a/src/Generator.Bind/Specifications/GL2/overrides.xml
+++ b/src/Generator.Bind/Specifications/GL2/overrides.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <signatures version="2">
 
-	<!-- gl and glcore -->
+  <!-- gl and glcore -->
   <replace name="gl|glcore">
 
     <!-- Core and EXT_direct_state_access variants -->
@@ -583,6 +583,17 @@
     </function>
 
     <!-- Version 3.3 -->
+
+    <function name="SamplerParameter" extension="Core">
+      <param name="pname"><type>SamplerParameterName</type></param>
+    </function>
+    <function name="SamplerParameterI" extension="Core">
+      <param name="pname"><type>SamplerParameterName</type></param>
+    </function>
+
+    <function name="GetSamplerParameter" extension="Core">
+      <param name="pname"><type>SamplerParameterName</type></param>
+    </function>
 
     <function name="QueryCounter" extension="Core">
       <param name="target">
@@ -1523,9 +1534,9 @@
     </function>
 
     <function name="VertexArrayFogCoordOffset" extension="Ext">
-       <param name="type">
-         <type>FogPointerType</type>
-       </param>
+      <param name="type">
+        <type>FogPointerType</type>
+      </param>
     </function>
 
     <!-- Apple -->
@@ -2327,9 +2338,29 @@
         <type>BeginMode</type>
       </param>
     </function>
+    <function name="GetSamplerParameter" extension="Core" obsolete="Use SamplerParameterName overload instead">
+      <param name="pname" index="1">
+        <type>SamplerParameter</type>
+      </param>
+    </function>
+    <function name="GetSamplerParameterI" extension="Core" obsolete="Use All overload instead">
+      <param name="pname" index="1">
+        <type>ArbSamplerObjects</type>
+      </param>
+    </function>
     <function name="ProgramParameter" extension="Core" obsolete="Use ProgramParameterName overload instead">
       <param name="pname" index="1">
         <type>AssemblyProgramParameterArb</type>
+      </param>
+    </function>
+    <function name="SamplerParameter" extension="Core" obsolete="Use SamplerParameterName overload instead">
+      <param name="pname" index="1">
+        <type>SamplerParameter</type>
+      </param>
+    </function>
+    <function name="SamplerParameterI" extension="Core" obsolete="Use SamplerParameterName overload instead">
+      <param name="pname" index="1">
+        <type>ArbSamplerObjects</type>
       </param>
     </function>
     <function name="StencilFuncSeparate" extension="Core" obsolete="Use StencilFace overload instead">
@@ -4435,6 +4466,23 @@
       <use enum="VERSION_4_5" token="INNOCENT_CONTEXT_RESET" />
       <use enum="VERSION_4_5" token="UNKNOWN_CONTEXT_RESET" />
     </enum>
+    <enum name="SamplerParameter">
+      <token name="TextureWrapS" value = "0x2802" />
+      <token name="TextureWrapT" value = "0x2803" />
+      <token name="TextureWrapR" value = "0x8072" />
+      <token name="TextureMinFilter" value = "0x2801" />
+      <token name="TextureMagFilter" value = "0x2800" />
+      <token name="TextureBorderColor" value = "0x1004" />
+      <token name="TextureMinLod" value = "0x813A" />
+      <token name="TextureMaxLod" value = "0x813B" />
+      <token name="TextureLodBias" value = "0x8501" />
+      <token name="TextureCompareMode" value = "0x884C" />
+      <token name="TextureCompareFunc" value = "0x884D" />
+      <token name="TextureMaxAnisotropyExt" value = "0x84FE" />
+    </enum>
+    <enum name="SamplerParameterName">
+      <reuse enum="SamplerParameter" />
+    </enum>
     <enum name="SeparableTarget">
       <token name="SEPARABLE_2D" value="0x8012" />
     </enum>
@@ -5096,7 +5144,7 @@
       <token name="TEXTURE8" value="0x84C8" />
       <token name="TEXTURE9" value="0x84C9" />
     </enum>
-</add>
+  </add>
 
   <!-- gles2 replacements for 2.0 and 3.0 -->
   <replace name="gles2" version="2.0|3.0">
@@ -5278,6 +5326,16 @@
       <param name="target"><type>TextureTarget</type></param>
     </function>
 
+    <!-- Sampler Objects [3.8.2] -->
+    <function name="SamplerParameter">
+      <param name="pname"><type>SamplerParameterName</type></param>
+    </function>
+
+    <!-- Sampler Queries [6.1.5] -->
+    <function name="GetSamplerParameter">
+      <param name="pname"><type>SamplerParameterName</type></param>
+    </function>
+
     <!-- Texture Image Specification [3.8.3-4] -->
     <function name="TexImage2D">
       <param name="target"><type>TextureTarget2d</type></param>
@@ -5344,26 +5402,26 @@
       <param name="pname"><type>TextureParameterName</type></param>
     </function>
 
-     <!-- Manual Mipmap Generation [3.8.9] -->
-     <function name="GenerateMipmap">
-       <param name="target"><type>TextureTarget</type></param>
-     </function>
+    <!-- Manual Mipmap Generation [3.8.9] -->
+    <function name="GenerateMipmap">
+      <param name="target"><type>TextureTarget</type></param>
+    </function>
 
-      <!-- Enumerated Queries [6.1.3] -->
-     <function name="GetTexParameter">
-       <param name="target"><type>TextureTarget</type></param>
-      <param name="pname"><type>GetTextureParameterName</type></param>
-     </function>
+    <!-- Enumerated Queries [6.1.3] -->
+    <function name="GetTexParameter">
+      <param name="target"><type>TextureTarget</type></param>
+    <param name="pname"><type>GetTextureParameterName</type></param>
+    </function>
 
-     <!-- Stencil Test [4.1.4] -->
-     <function name="StencilFunc">
-       <param name="func"><type>StencilFunction</type></param>
-     </function>
-     <function name="StencilFuncSeparate">
-       <param name="face"><type>StencilFace</type></param>
-       <param name="func"><type>StencilFunction</type></param>
-     </function>
-     <function name="StencilOp">
+    <!-- Stencil Test [4.1.4] -->
+    <function name="StencilFunc">
+      <param name="func"><type>StencilFunction</type></param>
+    </function>
+    <function name="StencilFuncSeparate">
+      <param name="face"><type>StencilFace</type></param>
+      <param name="func"><type>StencilFunction</type></param>
+    </function>
+    <function name="StencilOp">
       <param name="sfail"><type>StencilOp</type></param>
       <param name="dpfail"><type>StencilOp</type></param>
       <param name="dppass"><type>StencilOp</type></param>
@@ -5585,7 +5643,7 @@
     <function name="ObjectLabel">
       <param name="identifier"><type>ObjectLabelIdentifier</type></param>
     </function>
-   </replace>
+  </replace>
 
   <!--  gles2 replacements for backwards compatibility -->
   <replace name="gles2">
@@ -6535,7 +6593,7 @@
 
     <!-- OES_compressed_ETC1_RGB8_texture -->
     <enum name="CompressedInternalFormat">
-       <use token="ETC1_RGB8_OES" />
+      <use token="ETC1_RGB8_OES" />
     </enum>
 
     <!-- For compatibility with OpenTK 1.0 -->
@@ -7120,10 +7178,10 @@
       <use token="RGB_INTEGER" />
       <use token="RG_INTEGER" />
       <use token="RED_INTEGER" />
-	  <use token="DEPTH_COMPONENT" />
-	  <use token="DEPTH_STENCIL" />
-	  <use token="LUMINANCE_ALPHA" />
-	  <use token="LUMINANCE" />
+    <use token="DEPTH_COMPONENT" />
+    <use token="DEPTH_STENCIL" />
+    <use token="LUMINANCE_ALPHA" />
+    <use token="LUMINANCE" />
     </enum>
     <enum name="PixelStoreParameter">
       <use token="PACK_ROW_LENGTH" />
@@ -7219,6 +7277,17 @@
       <use token="RENDERBUFFER_STENCIL_SIZE" />
       <use token="RENDERBUFFER_SAMPLES" />
       <use token="RENDERBUFFER_INTERNAL_FORMAT" />
+    </enum>
+    <enum name="SamplerParameterName">
+      <use token="TEXTURE_WRAP_S" />
+      <use token="TEXTURE_WRAP_T" />
+      <use token="TEXTURE_WRAP_R" />
+      <use token="TEXTURE_MIN_FILTER" />
+      <use token="TEXTURE_MAG_FILTER" />
+      <use token="TEXTURE_MIN_LOD" />
+      <use token="TEXTURE_MAX_LOD" />
+      <use token="TEXTURE_COMPARE_MODE" />
+      <use token="TEXTURE_COMPARE_FUNC" />
     </enum>
     <enum name="ShaderParameter">
       <use token="SHADER_TYPE" />
@@ -7496,7 +7565,7 @@
       <use token="FIXED" />
       <use token="FLOAT" />
       <use token="HALF_FLOAT" />
-	  <use token="INT_2_10_10_10_REV" />
+    <use token="INT_2_10_10_10_REV" />
       <use token="UNSIGNED_INT_2_10_10_10_REV" />
     </enum>
     <enum name="WaitSyncFlags">

--- a/src/Generator.Bind/Specifications/GL2/overrides.xml
+++ b/src/Generator.Bind/Specifications/GL2/overrides.xml
@@ -22,6 +22,7 @@
       <param name="name">
         <type>StringName</type>
       </param>
+      <returns>String</returns>
     </function>
 
     <function name="TexImage1D" extension="Core">
@@ -461,6 +462,7 @@
       <param name="name">
         <type>StringNameIndexed</type>
       </param>
+      <returns>String</returns>
     </function>
 
     <!-- Version 3.1 -->
@@ -581,17 +583,6 @@
     </function>
 
     <!-- Version 3.3 -->
-
-    <function name="SamplerParameter" extension="Core">
-      <param name="pname"><type>SamplerParameterName</type></param>
-    </function>
-    <function name="SamplerParameterI" extension="Core">
-      <param name="pname"><type>SamplerParameterName</type></param>
-    </function>
-
-    <function name="GetSamplerParameter" extension="Core">
-      <param name="pname"><type>SamplerParameterName</type></param>
-    </function>
 
     <function name="QueryCounter" extension="Core">
       <param name="target">
@@ -1926,6 +1917,7 @@
       <param name="name" index="0">
         <type>StringName</type>
       </param>
+      <returns>String</returns>
     </function>
     <function name="GetSync" extension="Core" obsolete="Use SyncParameterName overload instead">
       <param name="pname" index="1">
@@ -2294,7 +2286,7 @@
       </param>
     </function>
     <!-- generated from apitest against svn r3127 -->
-        <function name="BlendEquation" extension="Arb" obsolete="Use BlendEquationMode overload instead">
+    <function name="BlendEquation" extension="Arb" obsolete="Use BlendEquationMode overload instead">
       <param name="mode" index="1">
         <type>ArbDrawBuffersBlend</type>
       </param>
@@ -2335,29 +2327,9 @@
         <type>BeginMode</type>
       </param>
     </function>
-    <function name="GetSamplerParameter" extension="Core" obsolete="Use SamplerParameterName overload instead">
-      <param name="pname" index="1">
-        <type>SamplerParameter</type>
-      </param>
-    </function>
-    <function name="GetSamplerParameterI" extension="Core" obsolete="Use All overload instead">
-      <param name="pname" index="1">
-        <type>ArbSamplerObjects</type>
-      </param>
-    </function>
     <function name="ProgramParameter" extension="Core" obsolete="Use ProgramParameterName overload instead">
       <param name="pname" index="1">
         <type>AssemblyProgramParameterArb</type>
-      </param>
-    </function>
-    <function name="SamplerParameter" extension="Core" obsolete="Use SamplerParameterName overload instead">
-      <param name="pname" index="1">
-        <type>SamplerParameter</type>
-      </param>
-    </function>
-    <function name="SamplerParameterI" extension="Core" obsolete="Use SamplerParameterName overload instead">
-      <param name="pname" index="1">
-        <type>ArbSamplerObjects</type>
       </param>
     </function>
     <function name="StencilFuncSeparate" extension="Core" obsolete="Use StencilFace overload instead">
@@ -4463,23 +4435,6 @@
       <use enum="VERSION_4_5" token="INNOCENT_CONTEXT_RESET" />
       <use enum="VERSION_4_5" token="UNKNOWN_CONTEXT_RESET" />
     </enum>
-    <enum name="SamplerParameter">
-      <token name="TextureWrapS" value = "0x2802" />
-      <token name="TextureWrapT" value = "0x2803" />
-      <token name="TextureWrapR" value = "0x8072" />
-      <token name="TextureMinFilter" value = "0x2801" />
-      <token name="TextureMagFilter" value = "0x2800" />
-      <token name="TextureBorderColor" value = "0x1004" />
-      <token name="TextureMinLod" value = "0x813A" />
-      <token name="TextureMaxLod" value = "0x813B" />
-      <token name="TextureLodBias" value = "0x8501" />
-      <token name="TextureCompareMode" value = "0x884C" />
-      <token name="TextureCompareFunc" value = "0x884D" />
-      <token name="TextureMaxAnisotropyExt" value = "0x84FE" />
-    </enum>
-    <enum name="SamplerParameterName">
-      <reuse enum="SamplerParameter" />
-    </enum>
     <enum name="SeparableTarget">
       <token name="SEPARABLE_2D" value="0x8012" />
     </enum>
@@ -5289,7 +5244,7 @@
       <param name="bufferMode"><type>TransformFeedbackMode</type></param>
     </function>
 
-	<!-- Shader Queries [6.1.12] -->
+    <!-- Shader Queries [6.1.12] -->
     <function name="GetShader">
       <param name="pname"><type>ShaderParameter</type></param>
     </function>
@@ -5315,16 +5270,6 @@
     </function>
     <function name="BindTexture">
       <param name="target"><type>TextureTarget</type></param>
-    </function>
-
-    <!-- Sampler Objects [3.8.2] -->
-    <function name="SamplerParameter">
-      <param name="pname"><type>SamplerParameterName</type></param>
-    </function>
-
-    <!-- Sampler Queries [6.1.5] -->
-    <function name="GetSamplerParameter">
-      <param name="pname"><type>SamplerParameterName</type></param>
     </function>
 
     <!-- Texture Image Specification [3.8.3-4] -->
@@ -5585,9 +5530,11 @@
     </function>
     <function name="GetString">
       <param name="name"><type>StringName</type></param>
+      <returns>String</returns>
     </function>
     <function name="GetStringi">
       <param name="name"><type>StringNameIndexed</type></param>
+      <returns>String</returns>
     </function>
 
     <!-- AMD_performance_monitors is not const-correct -->
@@ -7266,17 +7213,6 @@
       <use token="RENDERBUFFER_STENCIL_SIZE" />
       <use token="RENDERBUFFER_SAMPLES" />
       <use token="RENDERBUFFER_INTERNAL_FORMAT" />
-    </enum>
-    <enum name="SamplerParameterName">
-      <use token="TEXTURE_WRAP_S" />
-      <use token="TEXTURE_WRAP_T" />
-      <use token="TEXTURE_WRAP_R" />
-      <use token="TEXTURE_MIN_FILTER" />
-      <use token="TEXTURE_MAG_FILTER" />
-      <use token="TEXTURE_MIN_LOD" />
-      <use token="TEXTURE_MAX_LOD" />
-      <use token="TEXTURE_COMPARE_MODE" />
-      <use token="TEXTURE_COMPARE_FUNC" />
     </enum>
     <enum name="ShaderParameter">
       <use token="SHADER_TYPE" />

--- a/src/Generator.Converter/GLXmlParser.cs
+++ b/src/Generator.Converter/GLXmlParser.cs
@@ -476,11 +476,31 @@ namespace OpenTK.Convert
                 var words = ret.Split(" ".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
                 if (words[0] == "struct" || words[0] == "const")
                 {
-                    words[1] = group.Value;
+                    // Only replace groups on types that are 32-bits in size.
+                    // This affects glPathCommandsNV where a parameter has type GLubyte*
+                    // but is tagged with the group PathCoordType.
+                    // - Noggin_bops 2024-03-28
+                    if (words[1] == "GLint" ||
+                        words[1] == "GLuint" ||
+                        words[1] == "GLenum" ||
+                        words[1] == "GLbitfield")
+                    {
+                        words[1] = group.Value;
+                    }
                 }
                 else
                 {
-                    words[0] = group.Value;
+                    // Only replace groups on types that are 32-bits in size.
+                    // This affects glPathCommandsNV where a parameter has type GLubyte*
+                    // but is tagged with the group PathCoordType.
+                    // - Noggin_bops 2024-03-28
+                    if (words[0] == "GLint" ||
+                        words[0] == "GLuint" ||
+                        words[0] == "GLenum" ||
+                        words[0] == "GLbitfield")
+                    {
+                        words[0] = group.Value;
+                    }
                 }
 
                 ret = String.Join(" ", words);

--- a/src/OpenTK.Graphics/OpenGL2/Helper.cs
+++ b/src/OpenTK.Graphics/OpenGL2/Helper.cs
@@ -192,7 +192,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="params">[length: pname]
         /// Specifies the value that parameter Shininess will be set to.
         /// </param>
-        public static void Material(MaterialFace face, MaterialParameter pname, Vector4 @params)
+        public static void Material(TriangleFace face, MaterialParameter pname, Vector4 @params)
         {
             unsafe { Material(face, pname, (float*)&@params.X); }
         }
@@ -210,7 +210,7 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="params">[length: pname]
         /// Specifies the value that parameter Shininess will be set to.
         /// </param>
-        public static void Material(MaterialFace face, MaterialParameter pname, Color4 @params)
+        public static void Material(TriangleFace face, MaterialParameter pname, Color4 @params)
         {
             unsafe { GL.Material(face, pname, (float*)&@params); }
         }

--- a/src/OpenTK.Graphics/OpenGL2/Helper.cs
+++ b/src/OpenTK.Graphics/OpenGL2/Helper.cs
@@ -192,7 +192,8 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="params">[length: pname]
         /// Specifies the value that parameter Shininess will be set to.
         /// </param>
-        public static void Material(TriangleFace face, MaterialParameter pname, Vector4 @params)
+        [Obsolete("Use TriangleFace overload instead.")]
+        public static void Material(MaterialFace face, MaterialParameter pname, Vector4 @params)
         {
             unsafe { Material(face, pname, (float*)&@params.X); }
         }
@@ -210,7 +211,8 @@ namespace OpenTK.Graphics.OpenGL
         /// <param name="params">[length: pname]
         /// Specifies the value that parameter Shininess will be set to.
         /// </param>
-        public static void Material(TriangleFace face, MaterialParameter pname, Color4 @params)
+        [Obsolete("Use TriangleFace overload instead.")]
+        public static void Material(MaterialFace face, MaterialParameter pname, Color4 @params)
         {
             unsafe { GL.Material(face, pname, (float*)&@params); }
         }


### PR DESCRIPTION
### Purpose of this PR

Reruns the converter on the latest version of `gl.xml` and adds a `compatibility 4.8.2.xml` file that adds backwards compatibility overloads.

The only API breakage is that all `GL.NV.PathGlyphIndexRange` overloads that take that take `baseAndCount` as an in-parameter is removed (these overloads should be considered a bug).

### Testing status

Compiles. I have not tested if *all* the deprecations are "correct", but may of them seem to be.