### PR TITLE
Replace many math Equals() functions with simd implementation

### DIFF
--- a/src/OpenTK.Mathematics/Data/Quaternion.cs
+++ b/src/OpenTK.Mathematics/Data/Quaternion.cs
@@ -23,6 +23,7 @@ SOFTWARE.
 using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -812,8 +813,10 @@ namespace OpenTK.Mathematics
         /// <inheritdoc />
         public bool Equals(Quaternion other)
         {
-            return Xyz.Equals(other.Xyz) &&
-                   W == other.W;
+            Vector128<float> thisVec = Vector128.LoadUnsafe(ref Xyz.X);
+            Vector128<float> otherVec = Vector128.LoadUnsafe(ref Xyz.X);
+
+            return thisVec == otherVec;
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Data/Quaterniond.cs
+++ b/src/OpenTK.Mathematics/Data/Quaterniond.cs
@@ -23,6 +23,7 @@ SOFTWARE.
 using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -802,8 +803,10 @@ namespace OpenTK.Mathematics
         /// <inheritdoc />
         public bool Equals(Quaterniond other)
         {
-            return Xyz.Equals(other.Xyz) &&
-                   W == other.W;
+            Vector256<double> thisVec = Vector256.LoadUnsafe(ref Xyz.X);
+            Vector256<double> otherVec = Vector256.LoadUnsafe(ref Xyz.X);
+
+            return thisVec == otherVec;
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Matrix/Matrix2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2.cs
@@ -24,6 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace OpenTK.Mathematics
 {
@@ -775,9 +776,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix2 other)
         {
-            return
-                Row0 == other.Row0 &&
-                Row1 == other.Row1;
+            Vector128<float> a = Vector128.LoadUnsafe(ref Row0.X);
+            Vector128<float> b = Vector128.LoadUnsafe(ref other.Row0.X);
+
+            return a == b;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
@@ -24,6 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace OpenTK.Mathematics
 {
@@ -775,9 +776,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix2d other)
         {
-            return
-                Row0 == other.Row0 &&
-                Row1 == other.Row1;
+            Vector256<double> a = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<double> b = Vector256.LoadUnsafe(ref other.Row0.X);
+
+            return a == b;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
@@ -24,6 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace OpenTK.Mathematics
 {
@@ -824,9 +825,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix2x4 other)
         {
-            return
-                Row0 == other.Row0 &&
-                Row1 == other.Row1;
+            Vector256<float> a = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<float> b = Vector256.LoadUnsafe(ref other.Row0.X);
+
+            return a == b;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
@@ -825,10 +825,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix2x4 other)
         {
-            Vector256<float> a = Vector256.LoadUnsafe(ref Row0.X);
-            Vector256<float> b = Vector256.LoadUnsafe(ref other.Row0.X);
+            Vector256<float> aRow01 = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<float> bRow01 = Vector256.LoadUnsafe(ref other.Row0.X);
 
-            return a == b;
+            return aRow01 == bRow01;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
@@ -24,6 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace OpenTK.Mathematics
 {
@@ -824,9 +825,13 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix2x4d other)
         {
-            return
-                Row0 == other.Row0 &&
-                Row1 == other.Row1;
+            Vector256<double> aRow0 = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<double> bRow0 = Vector256.LoadUnsafe(ref other.Row0.X);
+
+            Vector256<double> aRow1 = Vector256.LoadUnsafe(ref Row1.X);
+            Vector256<double> bRow1 = Vector256.LoadUnsafe(ref other.Row1.X);
+
+            return aRow0 == bRow0 && aRow1 == bRow1;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
@@ -1025,13 +1025,13 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix3x4 other)
         {
-            Vector256<float> aLo = Vector256.LoadUnsafe(ref Row0.X);
-            Vector256<float> bLo = Vector256.LoadUnsafe(ref other.Row0.X);
+            Vector256<float> aRow01 = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<float> bRow01 = Vector256.LoadUnsafe(ref other.Row0.X);
 
-            Vector128<float> aHi = Vector128.LoadUnsafe(ref Row2.X);
-            Vector128<float> bHi = Vector128.LoadUnsafe(ref other.Row2.X);
+            Vector128<float> aRow2 = Vector128.LoadUnsafe(ref Row2.X);
+            Vector128<float> bRow2 = Vector128.LoadUnsafe(ref other.Row2.X);
 
-            return aLo == bLo && aHi == bHi;
+            return aRow01 == bRow01 && aRow2 == bRow2;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
@@ -24,6 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace OpenTK.Mathematics
 {
@@ -1024,10 +1025,13 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix3x4 other)
         {
-            return
-                Row0 == other.Row0 &&
-                Row1 == other.Row1 &&
-                Row2 == other.Row2;
+            Vector256<float> aLo = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<float> bLo = Vector256.LoadUnsafe(ref other.Row0.X);
+
+            Vector128<float> aHi = Vector128.LoadUnsafe(ref Row2.X);
+            Vector128<float> bHi = Vector128.LoadUnsafe(ref other.Row2.X);
+
+            return aLo == bLo && aHi == bHi;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
@@ -24,6 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace OpenTK.Mathematics
 {
@@ -1024,10 +1025,19 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix3x4d other)
         {
+            Vector256<double> aRow0 = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<double> bRow0 = Vector256.LoadUnsafe(ref other.Row0.X);
+
+            Vector256<double> aRow1 = Vector256.LoadUnsafe(ref Row1.X);
+            Vector256<double> bRow1 = Vector256.LoadUnsafe(ref other.Row1.X);
+
+            Vector256<double> aRow2 = Vector256.LoadUnsafe(ref Row2.X);
+            Vector256<double> bRow2 = Vector256.LoadUnsafe(ref other.Row2.X);
+
             return
-                Row0 == other.Row0 &&
-                Row1 == other.Row1 &&
-                Row2 == other.Row2;
+                aRow0 == bRow0 &&
+                aRow1 == bRow1 &&
+                aRow2 == bRow2;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -1961,13 +1961,13 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix4 other)
         {
-            Vector256<float> aLo = Vector256.LoadUnsafe(ref Row0.X);
-            Vector256<float> bLo = Vector256.LoadUnsafe(ref other.Row0.X);
+            Vector256<float> aRow01 = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<float> bRow01 = Vector256.LoadUnsafe(ref other.Row0.X);
 
-            Vector256<float> aHi = Vector256.LoadUnsafe(ref Row2.X);
-            Vector256<float> bHi = Vector256.LoadUnsafe(ref other.Row2.X);
+            Vector256<float> aRow23 = Vector256.LoadUnsafe(ref Row2.X);
+            Vector256<float> bRow23 = Vector256.LoadUnsafe(ref other.Row2.X);
 
-            return aLo == bLo && aHi == bHi;
+            return aRow01 == bRow01 && aRow23 == bRow23;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -20,20 +20,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-// Polyfill for older SDKs
-#if NETCOREAPP3_1
-#define NETCOREAPP3_1_OR_GREATER
-#endif
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if NETCOREAPP3_1_OR_GREATER
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
-#endif
 
 namespace OpenTK.Mathematics
 {
@@ -1510,7 +1503,6 @@ namespace OpenTK.Mathematics
         /// <exception cref="InvalidOperationException">Thrown if the Matrix4 is singular.</exception>
         public static void Invert(in Matrix4 mat, out Matrix4 result)
         {
-#if NETCOREAPP3_1_OR_GREATER
             if (Sse3.IsSupported)
             {
                 InvertSse3(in mat, out result);
@@ -1519,12 +1511,8 @@ namespace OpenTK.Mathematics
             {
                 InvertFallback(in mat, out result);
             }
-#else
-            InvertFallback(in mat, out result);
-#endif
         }
 
-#if NETCOREAPP3_1_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe void InvertSse3(in Matrix4 mat, out Matrix4 result)
         {
@@ -1736,7 +1724,6 @@ namespace OpenTK.Mathematics
 #pragma warning restore SA1512 // Single-line comments should not be followed by blank lines
 #pragma warning restore SA1515 // Single-line comment should be preceded by blank line
         }
-#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe void InvertFallback(in Matrix4 mat, out Matrix4 result)
@@ -1974,11 +1961,13 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix4 other)
         {
-            return
-                Row0 == other.Row0 &&
-                Row1 == other.Row1 &&
-                Row2 == other.Row2 &&
-                Row3 == other.Row3;
+            Vector256<float> aLo = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<float> bLo = Vector256.LoadUnsafe(ref other.Row0.X);
+
+            Vector256<float> aHi = Vector256.LoadUnsafe(ref Row2.X);
+            Vector256<float> bHi = Vector256.LoadUnsafe(ref other.Row2.X);
+
+            return aLo == bLo && aHi == bHi;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
@@ -24,6 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace OpenTK.Mathematics
 {
@@ -1812,11 +1813,23 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix4d other)
         {
+            Vector256<double> aRow0 = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<double> bRow0 = Vector256.LoadUnsafe(ref other.Row0.X);
+
+            Vector256<double> aRow1 = Vector256.LoadUnsafe(ref Row1.X);
+            Vector256<double> bRow1 = Vector256.LoadUnsafe(ref other.Row1.X);
+
+            Vector256<double> aRow2 = Vector256.LoadUnsafe(ref Row2.X);
+            Vector256<double> bRow2 = Vector256.LoadUnsafe(ref other.Row2.X);
+
+            Vector256<double> aRow3 = Vector256.LoadUnsafe(ref Row3.X);
+            Vector256<double> bRow3 = Vector256.LoadUnsafe(ref other.Row3.X);
+
             return
-                Row0 == other.Row0 &&
-                Row1 == other.Row1 &&
-                Row2 == other.Row2 &&
-                Row3 == other.Row3;
+                aRow0 == bRow0 &&
+                aRow1 == bRow1 &&
+                aRow2 == bRow2 &&
+                aRow3 == bRow3;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
@@ -24,6 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace OpenTK.Mathematics
 {
@@ -840,11 +841,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix4x2 other)
         {
-            return
-                Row0 == other.Row0 &&
-                Row1 == other.Row1 &&
-                Row2 == other.Row2 &&
-                Row3 == other.Row3;
+            Vector128<float> aRow0123 = Vector128.LoadUnsafe(ref Row0.X);
+            Vector128<float> bRow0123 = Vector128.LoadUnsafe(ref other.Row0.X);
+
+            return aRow0123 == bRow0123;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
@@ -841,8 +841,8 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix4x2 other)
         {
-            Vector128<float> aRow0123 = Vector128.LoadUnsafe(ref Row0.X);
-            Vector128<float> bRow0123 = Vector128.LoadUnsafe(ref other.Row0.X);
+            Vector256<float> aRow0123 = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<float> bRow0123 = Vector256.LoadUnsafe(ref other.Row0.X);
 
             return aRow0123 == bRow0123;
         }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
@@ -24,6 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace OpenTK.Mathematics
 {
@@ -846,11 +847,13 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix4x2d other)
         {
-            return
-                Row0 == other.Row0 &&
-                Row1 == other.Row1 &&
-                Row2 == other.Row2 &&
-                Row3 == other.Row3;
+            Vector256<double> aRow01 = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<double> bRow01 = Vector256.LoadUnsafe(ref other.Row0.X);
+
+            Vector256<double> aRow23 = Vector256.LoadUnsafe(ref Row2.X);
+            Vector256<double> bRow23 = Vector256.LoadUnsafe(ref other.Row2.X);
+
+            return aRow01 == bRow01 && aRow23 == bRow23;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
@@ -24,6 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace OpenTK.Mathematics
 {
@@ -1056,11 +1057,14 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix4x3 other)
         {
-            return
-                Row0 == other.Row0 &&
-                Row1 == other.Row1 &&
-                Row2 == other.Row2 &&
-                Row3 == other.Row3;
+            Vector256<float> aRow012xy = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<float> bRow012xy = Vector256.LoadUnsafe(ref other.Row0.X);
+
+            // Note that we ref .Z and not .X.
+            Vector128<float> aRow2z3 = Vector128.LoadUnsafe(ref Row2.Z);
+            Vector128<float> bRow2z3 = Vector128.LoadUnsafe(ref other.Row2.Z);
+
+            return aRow012xy == bRow012xy && aRow2z3 == bRow2z3;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
@@ -24,6 +24,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace OpenTK.Mathematics
 {
@@ -1055,11 +1056,18 @@ namespace OpenTK.Mathematics
         [Pure]
         public bool Equals(Matrix4x3d other)
         {
-            return
-                Row0 == other.Row0 &&
-                Row1 == other.Row1 &&
-                Row2 == other.Row2 &&
-                Row3 == other.Row3;
+            Vector256<double> aRow01x = Vector256.LoadUnsafe(ref Row0.X);
+            Vector256<double> bRow01x = Vector256.LoadUnsafe(ref other.Row0.X);
+
+            // Note that we ref .Y and not .X.
+            Vector256<double> aRow1yz2xy = Vector256.LoadUnsafe(ref Row1.Y);
+            Vector256<double> bRow1yz2xy = Vector256.LoadUnsafe(ref other.Row1.Y);
+
+            // Note that we ref .Z and not .X.
+            Vector256<double> aRow2z3 = Vector256.LoadUnsafe(ref Row2.Z);
+            Vector256<double> bRow2z3 = Vector256.LoadUnsafe(ref other.Row2.Z);
+
+            return aRow01x == bRow01x && aRow1yz2xy == bRow1yz2xy && aRow2z3 == bRow2z3;
         }
     }
 }

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -25,6 +25,7 @@ using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -2097,10 +2098,10 @@ namespace OpenTK.Mathematics
         /// <inheritdoc />
         public bool Equals(Vector4 other)
         {
-            return X == other.X &&
-                   Y == other.Y &&
-                   Z == other.Z &&
-                   W == other.W;
+            Vector128<float> thisVec = Vector128.LoadUnsafe(ref X);
+            Vector128<float> otherVec = Vector128.LoadUnsafe(ref other.X);
+
+            return thisVec == otherVec;
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -25,6 +25,7 @@ using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -2092,10 +2093,10 @@ namespace OpenTK.Mathematics
         /// <inheritdoc />
         public bool Equals(Vector4d other)
         {
-            return X == other.X &&
-                   Y == other.Y &&
-                   Z == other.Z &&
-                   W == other.W;
+            Vector256<double> thisVec = Vector256.LoadUnsafe(ref X);
+            Vector256<double> otherVec = Vector256.LoadUnsafe(ref other.X);
+
+            return thisVec == otherVec;
         }
 
         /// <inheritdoc />

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -1679,10 +1680,10 @@ namespace OpenTK.Mathematics
         /// <inheritdoc />
         public bool Equals(Vector4i other)
         {
-            return X == other.X &&
-                   Y == other.Y &&
-                   Z == other.Z &&
-                   W == other.W;
+            Vector128<int> thisVec = Vector128.LoadUnsafe(ref X);
+            Vector128<int> otherVec = Vector128.LoadUnsafe(ref other.X);
+
+            return thisVec == otherVec;
         }
 
         /// <inheritdoc />

--- a/tests/OpenTK.Tests/Matrix4Tests.fs
+++ b/tests/OpenTK.Tests/Matrix4Tests.fs
@@ -101,7 +101,7 @@ module Matrix4 =
             Assert.True(equality)
 
         [<Property>]
-        let ``Two matrices with non-identical values are equal`` (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) =
+        let ``Two matrices with non-identical values are equal`` (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) =
             let A = Matrix4(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, 0.0f)
             let B = Matrix4(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, 1.0f)
             let equality = A = B

--- a/tests/OpenTK.Tests/Matrix4Tests.fs
+++ b/tests/OpenTK.Tests/Matrix4Tests.fs
@@ -101,6 +101,14 @@ module Matrix4 =
             Assert.True(equality)
 
         [<Property>]
+        let ``Two matrices with non-identical values are equal`` (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) =
+            let A = Matrix4(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, 0)
+            let B = Matrix4(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, 1)
+            let equality = A = B
+
+            Assert.False(equality)
+
+        [<Property>]
         let ``A matrix is not equal to an object which is not a matrix`` (a : Matrix4, b : Vector3) =
             Assert.False(a.Equals(b))
 

--- a/tests/OpenTK.Tests/Matrix4Tests.fs
+++ b/tests/OpenTK.Tests/Matrix4Tests.fs
@@ -102,8 +102,8 @@ module Matrix4 =
 
         [<Property>]
         let ``Two matrices with non-identical values are equal`` (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) =
-            let A = Matrix4(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, 0)
-            let B = Matrix4(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, 1)
+            let A = Matrix4(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, 0.0f)
+            let B = Matrix4(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, 1.0f)
             let equality = A = B
 
             Assert.False(equality)


### PR DESCRIPTION
Using SIMD for Matrix comparisons significantly improves performance.
The old implementation was creating a bottleneck for me as I had a lot of instances and comparing matrices to test wether a given instanced needed to be reuploaded to the GPU. This new implementation fixed it.

#### Matrix3x4EqualBenchmark
| Method       | Mean     | Error     | StdDev    |
|------------- |---------:|----------:|----------:|
| Current | 8.297 ns | 0.0856 ns | 0.0759 ns |
| Avx2 | 3.259 ns | 0.0282 ns | 0.0264 ns |

#### Matrix4x4EqualBenchmark
| Method       | Mean      | Error     | StdDev    |
|------------- |----------:|----------:|----------:|
| Current | 13.225 ns | 0.1935 ns | 0.1810 ns |
| Avx2 |  3.490 ns | 0.0290 ns | 0.0272 ns |

If .NET 8 was used we could further accelerate functions like this with AVX512. If this gets merged I wanted to add the same to otk4 (just slightly different because of different .net version).