### PR TITLE
Add Xrandr overrides to OpenTK.Platform.Native.DllResolver.

### DIFF
--- a/src/OpenTK.Platform.Native/DllResolver.cs
+++ b/src/OpenTK.Platform.Native/DllResolver.cs
@@ -103,6 +103,14 @@ namespace OpenTK.Platform.Native
                 "libxcb-xinput.so.0",
             },
 
+            ["Xrandr"] = new string[]
+            {
+                "libXrandr.so",
+                "libXrandr.so.2",
+                "libXrandr.so.1",
+                "libXrandr.so.0",
+            },
+
             ["XScreenSaver"] = new string[]
             {
                 "libXss.so",


### PR DESCRIPTION
### Purpose of this PR
* Just adding more DLL import overrides for Linux systems.

### Testing status
* OpenTK.v5.0.0-pre.10 will not run without this on Fedora 40 WS.
* Please verify with linux systems by running `ldconfig -p | grep Xrandr`