### PR TITLE
Add missing GLFW 3.4 features to NativeWindow

### DIFF
--- a/src/OpenTK.Windowing.Common/Enums/CursorState.cs
+++ b/src/OpenTK.Windowing.Common/Enums/CursorState.cs
@@ -23,5 +23,10 @@ namespace OpenTK.Windowing.Common
         /// Hides the cursor and locks it to the specified window.
         /// </summary>
         Grabbed,
+
+        /// <summary>
+        /// Confines the cursor to the window content area.
+        /// </summary>
+        Confined,
     }
 }

--- a/src/OpenTK.Windowing.Desktop/GLFWProvider.cs
+++ b/src/OpenTK.Windowing.Desktop/GLFWProvider.cs
@@ -23,22 +23,12 @@ namespace OpenTK.Windowing.Desktop
     /// </summary>
     public static class GLFWProvider
     {
-        // This will throw "through" native frames, which doesn't work anywhere other than windows.
+        // FIXME: This will throw "through" native frames, which doesn't work anywhere other than windows.
         private static void DefaultErrorCallback(ErrorCode errorCode, string description)
         {
-            // FIXME: Maybe we shouldn't throw exceptions here at all?
-            // - Noggin_bops 2024-11-18
-            if (errorCode == ErrorCode.PlatformError)
-            {
-                Trace.WriteLine($"GLFW {errorCode}: {description} (this message is from the OpenTK default glfw error handler, override it with GLFWProvider.SetErrorCallback)");
-            }
-            else
-            {
-                throw new GLFWException(description, errorCode);
-            }
+            throw new GLFWException($"{description} (this is thrown from OpenTKs default GLFW error handler, if you find this exception inconvenient set your own error callback using GLFWProvider.SetErrorCallback)", errorCode);
         }
 
-        // FIXME: This will throw "through" native frames, which doesn't work anywhere other than windows.
         private static GLFWCallbacks.ErrorCallback ErrorCallback = DefaultErrorCallback;
 
         /// <summary>

--- a/src/OpenTK.Windowing.Desktop/GLFWProvider.cs
+++ b/src/OpenTK.Windowing.Desktop/GLFWProvider.cs
@@ -26,7 +26,16 @@ namespace OpenTK.Windowing.Desktop
         // This will throw "through" native frames, which doesn't work anywhere other than windows.
         private static void DefaultErrorCallback(ErrorCode errorCode, string description)
         {
-            throw new GLFWException(description, errorCode);
+            // FIXME: Maybe we shouldn't throw exceptions here at all?
+            // - Noggin_bops 2024-11-18
+            if (errorCode == ErrorCode.PlatformError)
+            {
+                Trace.WriteLine($"GLFW {errorCode}: {description} (this message is from the OpenTK default glfw error handler, override it with GLFWProvider.SetErrorCallback)");
+            }
+            else
+            {
+                throw new GLFWException(description, errorCode);
+            }
         }
 
         // FIXME: This will throw "through" native frames, which doesn't work anywhere other than windows.

--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -447,6 +447,40 @@ namespace OpenTK.Windowing.Desktop
         }
 
         /// <summary>
+        /// Gets or sets if the window should be transparent to mouse input.
+        /// This only works for windows with window border set to <see cref="WindowBorder.Hidden"/>,
+        /// other borders will behave differently between platforms.
+        /// </summary>
+        public unsafe bool MousePassthrough
+        {
+            get
+            {
+                return GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.MousePassthrough);
+            }
+
+            set
+            {
+                GLFW.SetWindowAttrib(WindowPtr, WindowAttribute.MousePassthrough, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets if this window will be displayed on top of all other windows.
+        /// </summary>
+        public unsafe bool AlwaysOnTop
+        {
+            get
+            {
+                return GLFW.GetWindowAttrib(WindowPtr, WindowAttributeGetBool.Floating);
+            }
+
+            set
+            {
+                GLFW.SetWindowAttrib(WindowPtr, WindowAttribute.Floating, value);
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a <see cref="OpenTK.Mathematics.Box2i" /> structure the contains the external bounds of this window,
         /// in screen coordinates.
         /// External bounds include the title bar, borders and drawing area of the window.
@@ -701,6 +735,8 @@ namespace OpenTK.Windowing.Desktop
                         return CursorState.Hidden;
                     case CursorModeValue.CursorDisabled:
                         return CursorState.Grabbed;
+                    case CursorModeValue.CursorCaptured:
+                        return CursorState.Confined;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
@@ -719,6 +755,9 @@ namespace OpenTK.Windowing.Desktop
                         break;
                     case CursorState.Grabbed:
                         inputMode = CursorModeValue.CursorDisabled;
+                        break;
+                    case CursorState.Confined:
+                        inputMode = CursorModeValue.CursorCaptured;
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Enums/CursorModeValue.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Enums/CursorModeValue.cs
@@ -37,6 +37,6 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// <summary>
         /// Makes the cursor visible and confines it to the content area of the window.
         /// </summary>
-        CursorCaptured = 0x00034003,
+        CursorCaptured = 0x00034004,
     }
 }


### PR DESCRIPTION
### Purpose of this PR

Fixes #1719
Added `NativeWindow.AlwaysOnTop` that corresponds to `GLFW_FLOATING`.
Added `NativeWindow.MousePassthrough` that corresponds to `GLFW_MOUSE_PASSTHROUGH`.

Changes the default GLFW error callback to not throw errors when the error code is a platform error, in hopes that wayland support will be better.

### Testing status

All features except the improved wayland support have been tested.