### PR TITLE
[5.0] [WIP] Math - Implement Generic Math interfaces

### DIFF
--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -22,6 +22,7 @@ SOFTWARE.
 
 using System;
 using System.Diagnostics.Contracts;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Xml.Serialization;
@@ -36,7 +37,16 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector2 : IEquatable<Vector2>, IFormattable
+    public struct Vector2 : IEquatable<Vector2>, IFormattable,
+                            IAdditionOperators<Vector2, Vector2, Vector2>,
+                            ISubtractionOperators<Vector2, Vector2, Vector2>,
+                            IUnaryNegationOperators<Vector2, Vector2>,
+                            IMultiplyOperators<Vector2, float, Vector2>,
+                            IMultiplyOperators<Vector2, Vector2, Vector2>,
+                            IMultiplyOperators<Vector2, Matrix2, Vector2>,
+                            IDivisionOperators<Vector2, float, Vector2>,
+                            IDivisionOperators<Vector2, Vector2, Vector2>,
+                            IEqualityOperators<Vector2, Vector2, bool>
     {
         /// <summary>
         /// The X component of the Vector2.


### PR DESCRIPTION
This is my first PR to this repository, so I would appreciate any feedback, especially on the testing part!

### Purpose of this PR

The purpose of this PR is to add changes proposed in #1761. The issue proposes adding generic math interfaces introduced in .NET 7 to existing OpenTK Math structs.

At the time of writing this description, I have only added interfaces to the [Vector2](https://github.com/vovatrykoz/opentk/blob/implement-generic-math-interfaces/src/OpenTK.Mathematics/Vector/Vector2.cs). struct. I will add the interfaces to other structs, but I wanted to open a pull request to get early feedback.

It is not possible to implement some interfaces due to constraint on TSelf: TSelf needs to implement that same mathematical interface. For example, in [IAdditionOperators](https://learn.microsoft.com/en-us/dotnet/api/system.numerics.iadditionoperators-3?view=net-9.0), TSelf also needs to implement IAdditionOperators<TSelf,TOther,TResult>. Therefore, the following interfaces have not been added, even if there are operators that could in theory work:
- IMultiplyOperators<float, Vector2, Vector2>
- IMultiplyOperators<Matrix2, Vector2, Vector2>
- IMultiplyOperators<Quaternion, Vector2, Vector2>

While it is not possible to do much about the floats, it is possible to make Matrix and Quaternion compatible with these interfaces, but the question is should we?

### Testing status

Originally I wanted to add unit tests that would check if a specific struct satisfies generic math constraints. However, I ran into some issues with regard to that. First of all, the compiler adds warning FS3536 when trying to test that. For example, the following code:
```
    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
    module ``Math Generics`` =
        //
        [<Property>]
        let ``Vector2 implements IAdditionOperators<Vector2, Vector2, Vector2> interface`` (v : Vector2) =
            let vectorType = v.GetType()
            let interfaceType = typeof<IAdditionOperators<Vector2, Vector2, Vector2>>

            let implementsInterface (vectorType: Type) (interfaceType: Type) =
                vectorType.IsAssignableTo(interfaceType)

            Assert.True(implementsInterface vectorType interfaceType)
```

Will produce this warning
![image](https://github.com/user-attachments/assets/ee64f322-de42-46be-b6b6-79bef2d4d64d)

According to the [F# documentation](https://github.com/fsharp/fslang-design/blob/main/FSharp-7.0/FS-1124-interfaces-with-static-abstract-members.md#warning-when-using-iwsams-as-types): "At all other locations the use of an IWSAM constraint results in the warning. Note this includes `typeof<ISomeInterface<...>>` - reflecting over IWSAM constraints is sufficiently rare that this is not given a special dispensation."

Some unit tests result in the FS0001 error, for reasons I do not fully understand. Here is another piece of code as an example
```
    [<Properties(Arbitrary = [| typeof<OpenTKGen> |])>]
    module ``Math Generics`` =
        //
        [<Property>]
        let ``Vector2 implements IMultiplyOperators<Vector2, Vector2, Vector2> interface`` (v : Vector2) =
            let vectorType = v.GetType()
            let interfaceType = typeof<IMultiplyOperators<Vector2, Vector2, Vector2>>

            let implementsInterface (vectorType: Type) (interfaceType: Type) =
                vectorType.IsAssignableTo(interfaceType)

            Assert.True(implementsInterface vectorType interfaceType)

        [<Property>]
        let ``Vector2 implements IMultiplyOperators<Vector2, float, Vector2> interface`` (v : Vector2) =
            let vectorType = v.GetType()
            let interfaceType = typeof<IMultiplyOperators<Vector2, float32, Vector2>>

            let implementsInterface (vectorType: Type) (interfaceType: Type) =
                vectorType.IsAssignableTo(interfaceType)

            Assert.True(implementsInterface vectorType interfaceType)
```

In here, the first unit test will result in the following error
![image](https://github.com/user-attachments/assets/037bb2af-25d1-4e0a-a595-810141cf06c4)

However, the second one will only have a warning
![image](https://github.com/user-attachments/assets/b245ed9a-53b5-4871-8b38-3b670126fa88)

I am not sure why F# has such a hard time understanding that these are valid types. This error pops up when trying to test the following interfaces:
- IMultiplyOperators<Vector2, Vector2, Vector2>
- IMultiplyOperators<Vector2, Matrix2, Vector2>
- IDivisionOperators<Vector2, Vector2, Vector2>

I would appreciate advice on how to properly test this or if this issue even needs unit testing. The only other way I can think of is simply typing out examples like so:

```
using System.Numerics;

Animation<Vector2> animation = new(Vector2.One, Vector2.One);

class Animation<T>(T value, T update) where T : IAdditionOperators<T, T, T>
{
    public T Update()
    {
        value += update;
        return value;
    }
}
```

This example can be found here, in Program.cs: https://github.com/vovatrykoz/OpenTk_test
