### PR TITLE
Update fullscreen/monitor API to be more reasonable.

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindowSettings.cs
@@ -116,7 +116,7 @@ namespace OpenTK.Windowing.Desktop
         public Version APIVersion { get; set; } = new Version(3, 3);
 
         /// <summary>
-        /// Gets or sets the monitor to open the new window on.
+        /// Gets or sets the monitor to make the window fullscreen on if <see cref="WindowState"/> = <see cref="WindowState.Fullscreen"/> is set.
         /// </summary>
         public MonitorHandle CurrentMonitor { get; set; }
 
@@ -136,13 +136,13 @@ namespace OpenTK.Windowing.Desktop
         public bool StartVisible { get; set; } = true;
 
         /// <summary>
-        ///     Gets or sets the initial value for <see cref="NativeWindow.WindowState"/> on the new window.
-        ///     This setting is ignored if <c><see cref="StartVisible"/> = false</c>.
+        /// Gets or sets the initial value for <see cref="NativeWindow.WindowState"/> on the new window.
+        /// This setting is ignored if <c><see cref="StartVisible"/> = false</c>.
         /// </summary>
         public WindowState WindowState { get; set; } = WindowState.Normal;
 
         /// <summary>
-        ///     Gets or sets the initial value for <see cref="NativeWindow.WindowBorder"/> on the new window.
+        /// Gets or sets the initial value for <see cref="NativeWindow.WindowBorder"/> on the new window.
         /// </summary>
         public WindowBorder WindowBorder { get; set; } = WindowBorder.Resizable;
 
@@ -155,12 +155,12 @@ namespace OpenTK.Windowing.Desktop
         public Vector2i? Location { get; set; }
 
         /// <summary>
-        ///     Gets or sets the initial size of the contents of the window.
+        /// Gets or sets the initial size of the contents of the window.
         /// </summary>
         public Vector2i ClientSize { get; set; } = new Vector2i(640, 360);
 
         /// <summary>
-        ///     Gets or sets the minimum size of the contents of the window.
+        /// Gets or sets the minimum size of the contents of the window.
         /// </summary>
         /// <remarks>
         /// Set to <c>null</c> to remove the minimum size constraint.
@@ -169,7 +169,7 @@ namespace OpenTK.Windowing.Desktop
         public Vector2i? MinimumClientSize { get; set; } = null;
 
         /// <summary>
-        ///     Gets or sets the maximum size of the contents of the window.
+        /// Gets or sets the maximum size of the contents of the window.
         /// </summary>
         /// <remarks>
         /// Set to <c>null</c> to remove the minimum size constraint.
@@ -178,7 +178,7 @@ namespace OpenTK.Windowing.Desktop
         public Vector2i? MaximumClientSize { get; set; } = null;
 
         /// <summary>
-        ///     Gets or sets the initial size of the contents of the window.
+        /// Gets or sets the initial size of the contents of the window.
         /// </summary>
         [Obsolete("Use the " + nameof(ClientSize) + " property to get or set the initial size of the contents of the window.")]
         public Vector2i Size
@@ -188,7 +188,7 @@ namespace OpenTK.Windowing.Desktop
         }
 
         /// <summary>
-        ///     Gets or sets the minimum size of the contents of the window.
+        /// Gets or sets the minimum size of the contents of the window.
         /// </summary>
         /// <remarks>
         /// Set to <c>null</c> to remove the minimum size constraint.
@@ -202,7 +202,7 @@ namespace OpenTK.Windowing.Desktop
         }
 
         /// <summary>
-        ///     Gets or sets the maximum size of the contents of the window.
+        /// Gets or sets the maximum size of the contents of the window.
         /// </summary>
         /// <remarks>
         /// Set to <c>null</c> to remove the minimum size constraint.


### PR DESCRIPTION
### Purpose of this PR

Adds `MakeFullscreen()` function on `NativeWindow` for making the window fullscreen on a specific monitor.
Change `CurrentMonitor` to actually reflect the current monitor the window is on (and changed the type of the property).
Mark the `CurrentMonitor` setter as `Obsolete`, use `MakeCurrent` instead.
Updated documentation.

Fixes #1663

### Testing status

Tested locally on windows.