### PR TITLE
Fix glfw calling convention on 32-bit Windows.

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
@@ -9,6 +9,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
     internal static unsafe class GLFWNative
     {
         private const string LibraryName = "glfw3.dll";
+        private const CallingConvention Cdecl = CallingConvention.Cdecl;
 
         public const int GLFW_TRUE = 1;
         public const int GLFW_FALSE = 0;
@@ -71,511 +72,511 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
 
 #pragma warning disable IDE1006 // Naming Styles
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwInit();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwTerminate();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwInitHint(int hint, int value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwInitAllocator(in GLFWallocator allocator);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwInitVulkanLoader(IntPtr loader);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwGetVersion(int* major, int* minor, int* revision);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern byte* glfwGetVersionString();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern ErrorCode glfwGetError(byte** description);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetErrorCallback(GLFWCallbacks.ErrorCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern Platform glfwGetPlatform();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwPlatformSupported(Platform platform);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern Monitor** glfwGetMonitors(int* count);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern Monitor* glfwGetPrimaryMonitor();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwGetMonitorPos(Monitor* monitor, int* x, int* y);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwGetMonitorWorkarea(Monitor* monitor, int* xpos, int* ypos, int* width, int* height);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwGetMonitorPhysicalSize(Monitor* monitor, int* width, int* height);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwGetMonitorContentScale(Monitor* monitor, float* xscale, float* yscale);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern byte* glfwGetMonitorName(Monitor* monitor);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetMonitorUserPointer(Monitor* monitor, void* pointer);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void* glfwGetMonitorUserPointer(Monitor* monitor);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetMonitorCallback(GLFWCallbacks.MonitorCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern VideoMode* glfwGetVideoModes(Monitor* monitor, int* count);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern VideoMode* glfwGetVideoMode(Monitor* monitor);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetGamma(Monitor* monitor, float gamma);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern GammaRamp* glfwGetGammaRamp(Monitor* monitor);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetGammaRamp(Monitor* monitor, GammaRamp* ramp);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwDefaultWindowHints();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwWindowHint(WindowHintInt hint, int value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwWindowHint(WindowHintBool hint, int value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwWindowHint(WindowHintClientApi hint, ClientApi value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwWindowHint(WindowHintReleaseBehavior hint, ReleaseBehavior value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwWindowHint(WindowHintContextApi hint, ContextApi value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwWindowHint(WindowHintRobustness hint, Robustness value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwWindowHint(WindowHintOpenGlProfile hint, OpenGlProfile value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwWindowHintString(int hint, byte* value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern Window* glfwCreateWindow(int width, int height, byte* title, Monitor* monitor, Window* share);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwDestroyWindow(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwWindowShouldClose(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetWindowShouldClose(Window* window, int value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern byte* glfwGetWindowTitle(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetWindowTitle(Window* window, byte* title);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetWindowIcon(Window* window, int count, Image* images);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwGetWindowPos(Window* window, int* x, int* y);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetWindowPos(Window* window, int x, int y);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwGetWindowSize(Window* window, int* width, int* height);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetWindowSizeLimits(Window* window, int minwidth, int minheight, int maxwidth, int maxheight);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetWindowAspectRatio(Window* window, int numer, int denom);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetWindowSize(Window* window, int width, int height);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwGetFramebufferSize(Window* window, int* width, int* height);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwGetWindowFrameSize(Window* window, int* left, int* top, int* right, int* bottom);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwGetWindowContentScale(Window* window, float* xscale, float* yscale);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern float glfwGetWindowOpacity(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetWindowOpacity(Window* window, float opacity);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwIconifyWindow(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwRestoreWindow(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwMaximizeWindow(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwShowWindow(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwHideWindow(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwFocusWindow(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwRequestWindowAttention(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern Monitor* glfwGetWindowMonitor(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetWindowMonitor(Window* window, Monitor* monitor, int x, int y, int width, int height, int refreshRate);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwGetWindowAttrib(Window* window, WindowAttributeGetBool attribute);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwGetWindowAttrib(Window* window, WindowAttributeGetInt attribute);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern ClientApi glfwGetWindowAttrib(Window* window, WindowAttributeGetClientApi attribute);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern ContextApi glfwGetWindowAttrib(Window* window, WindowAttributeGetContextApi attribute);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern OpenGlProfile glfwGetWindowAttrib(Window* window, WindowAttributeGetOpenGlProfile attribute);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern ReleaseBehavior glfwGetWindowAttrib(Window* window, WindowAttributeGetReleaseBehavior attribute);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern Robustness glfwGetWindowAttrib(Window* window, WindowAttributeGetRobustness attribute);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetWindowAttrib(Window* window, WindowAttribute attrib, int value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetWindowUserPointer(Window* window, void* pointer);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void* glfwGetWindowUserPointer(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetWindowPosCallback(Window* window, GLFWCallbacks.WindowPosCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetWindowSizeCallback(Window* window, GLFWCallbacks.WindowSizeCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetWindowCloseCallback(Window* window, GLFWCallbacks.WindowCloseCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetWindowRefreshCallback(Window* window, GLFWCallbacks.WindowRefreshCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetWindowFocusCallback(Window* window, GLFWCallbacks.WindowFocusCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetWindowIconifyCallback(Window* window, GLFWCallbacks.WindowIconifyCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetWindowMaximizeCallback(Window* window, GLFWCallbacks.WindowMaximizeCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetFramebufferSizeCallback(Window* window, GLFWCallbacks.FramebufferSizeCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetWindowContentScaleCallback(Window* window, GLFWCallbacks.WindowContentScaleCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwPollEvents();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwWaitEvents();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwWaitEventsTimeout(double timeout);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwPostEmptyEvent();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern CursorModeValue glfwGetInputMode(Window* window, CursorStateAttribute mode);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwGetInputMode(Window* window, StickyAttributes mode);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwGetInputMode(Window* window, LockKeyModAttribute mode);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwGetInputMode(Window* window, RawMouseMotionAttribute mode);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetInputMode(Window* window, CursorStateAttribute mode, CursorModeValue value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetInputMode(Window* window, StickyAttributes mode, int value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetInputMode(Window* window, LockKeyModAttribute mode, int value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetInputMode(Window* window, RawMouseMotionAttribute mode, int value);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwRawMouseMotionSupported();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern byte* glfwGetKeyName(Keys key, int scancode);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwGetKeyScancode(Keys key);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern InputAction glfwGetKey(Window* window, Keys key);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern InputAction glfwGetMouseButton(Window* window, MouseButton button);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwGetCursorPos(Window* window, double* xpos, double* ypos);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetCursorPos(Window* window, double xpos, double ypos);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern Cursor* glfwCreateCursor(Image* image, int xhot, int yhot);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern Cursor* glfwCreateStandardCursor(CursorShape shape);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwDestroyCursor(Cursor* cursor);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetCursor(Window* window, Cursor* cursor);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetKeyCallback(Window* window, GLFWCallbacks.KeyCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetCharCallback(Window* window, GLFWCallbacks.CharCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetCharModsCallback(Window* window, GLFWCallbacks.CharModsCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetMouseButtonCallback(Window* window, GLFWCallbacks.MouseButtonCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetCursorPosCallback(Window* window, GLFWCallbacks.CursorPosCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetCursorEnterCallback(Window* window, GLFWCallbacks.CursorEnterCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetScrollCallback(Window* window, GLFWCallbacks.ScrollCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetDropCallback(Window* window, GLFWCallbacks.DropCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwJoystickPresent(int jid);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern float* glfwGetJoystickAxes(int jid, int* count);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern JoystickInputAction* glfwGetJoystickButtons(int jid, int* count);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern JoystickHats* glfwGetJoystickHats(int jid, int* count);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern byte* glfwGetJoystickName(int jid);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern byte* glfwGetJoystickGUID(int jid);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetJoystickUserPointer(int jid, void* ptr);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void* glfwGetJoystickUserPointer(int jid);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwJoystickIsGamepad(int jid);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwSetJoystickCallback(GLFWCallbacks.JoystickCallback callback);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwUpdateGamepadMappings(byte* newMapping);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern byte* glfwGetGamepadName(int jid);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwGetGamepadState(int jid, GamepadState* state);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetClipboardString(Window* window, byte* data);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern byte* glfwGetClipboardString(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern double glfwGetTime();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetTime(double time);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern long glfwGetTimerValue();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern long glfwGetTimerFrequency();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwMakeContextCurrent(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern Window* glfwGetCurrentContext();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSwapBuffers(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSwapInterval(int interval);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwExtensionSupported(byte* extensionName);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetProcAddress(byte* procName);
 
         [DllImport(LibraryName, CharSet = CharSet.Ansi)]
         public static extern IntPtr glfwGetProcAddress(string procName);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwVulkanSupported();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern byte** glfwGetRequiredInstanceExtensions(uint* count);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetInstanceProcAddress(VkHandle instance, byte* procName);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwGetPhysicalDevicePresentationSupport(VkHandle instance, VkHandle device, int queueFamily);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwCreateWindowSurface(VkHandle instance, Window* window, void* allocator, out VkHandle surface);
 
 #pragma warning disable SA1124 // Do not use regions
         #region GLFW Native functions
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern byte* glfwGetWin32Adapter(Monitor* monitor);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern byte* glfwGetWin32Monitor(Monitor* monitor);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetWin32Window(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetWGLContext(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern uint glfwGetCocoaMonitor(Monitor* monitor);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetCocoaWindow(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetCocoaView(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetNSGLContext(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetX11Display();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern UIntPtr glfwGetX11Adapter(Monitor* monitor);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern UIntPtr glfwGetX11Monitor(Monitor* monitor);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern UIntPtr glfwGetX11Window(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern void glfwSetX11SelectionString(byte* @string);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern byte* glfwGetX11SelectionString();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern uint glfwGetGLXContext(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern uint glfwGetGLXWindow(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetWaylandDisplay();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetWaylandMonitor(Monitor* monitor);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetWaylandWindow(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetEGLDisplay();
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetEGLContext(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetEGLSurface(Window* window);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwGetOSMesaColorBuffer(Window* window, int* width, int* height, int* format, void** buffer);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern int glfwGetOSMesaDepthBuffer(Window* window, int* width, int* height, int* bytesPerValue, void** buffer);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, CallingConvention = Cdecl)]
         public static extern IntPtr glfwGetOSMesaContext(Window* window);
 
         #endregion


### PR DESCRIPTION
### Purpose of this PR

Fixes #1582
Fixes #1494

### Testing status

Tested on 32-bit windows in release mode (where the error happened), and 64-bit windows.