### PR TITLE
Add missing paket entires.

### DIFF
--- a/props/nuget-common.props
+++ b/props/nuget-common.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <Authors>The OpenTK team.</Authors>
     <PackageIconUrl>https://raw.githubusercontent.com/opentk/opentk/master/docs/files/img/logo.png</PackageIconUrl>
+    <PackageIcon>images/opentk-blue-hexagon.png</PackageIcon>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <PackageReleaseNotes>Initial 4.0 release.</PackageReleaseNotes>
     <PackageTags>opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick</PackageTags>

--- a/src/OpenAL/OpenTK.Audio.OpenAL/paket
+++ b/src/OpenAL/OpenTK.Audio.OpenAL/paket
@@ -11,6 +11,13 @@ files
     bin\Release\netcoreapp3.1\OpenTK.Audio.OpenAL.xml ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Audio.OpenAL.pdb ==> lib\netcoreapp3.1
     README.md ==> docs
+    ..\..\..\.github\opentk-blue-hexagon.png ==> images
 
-readme
-    docs\README.md
+readme docs\README.md
+iconUrl https://raw.githubusercontent.com/opentk/opentk/refs/heads/master/.github/opentk-blue-hexagon.png
+projectUrl https://github.com/opentk/opentk
+licenseUrl https://opensource.org/licenses/MIT
+licenseExpression MIT
+tags opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick
+repositoryType git
+repositoryUrl https://github.com/opentk/opentk.git

--- a/src/OpenTK.Compute/paket
+++ b/src/OpenTK.Compute/paket
@@ -9,6 +9,13 @@ files
     bin\Release\netcoreapp3.1\OpenTK.Compute.xml ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Compute.pdb ==> lib\netcoreapp3.1
     README.md ==> docs
+    ..\..\.github\opentk-blue-hexagon.png ==> images
 
-readme
-    docs\README.md
+readme docs\README.md
+iconUrl https://raw.githubusercontent.com/opentk/opentk/refs/heads/master/.github/opentk-blue-hexagon.png
+projectUrl https://github.com/opentk/opentk
+licenseUrl https://opensource.org/licenses/MIT
+licenseExpression MIT
+tags opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick
+repositoryType git
+repositoryUrl https://github.com/opentk/opentk.git

--- a/src/OpenTK.Core/paket
+++ b/src/OpenTK.Core/paket
@@ -7,6 +7,13 @@ files
     bin\Release\netstandard2.1\OpenTK.Core.xml ==> lib\netstandard2.1 
     bin\Release\netstandard2.1\OpenTK.Core.pdb ==> lib\netstandard2.1
     README.md ==> docs
+    ..\..\.github\opentk-blue-hexagon.png ==> images
 
-readme
-    docs\README.md
+readme docs\README.md
+iconUrl https://raw.githubusercontent.com/opentk/opentk/refs/heads/master/.github/opentk-blue-hexagon.png
+projectUrl https://github.com/opentk/opentk
+licenseUrl https://opensource.org/licenses/MIT
+licenseExpression MIT
+tags opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick
+repositoryType git
+repositoryUrl https://github.com/opentk/opentk.git

--- a/src/OpenTK.Graphics/paket
+++ b/src/OpenTK.Graphics/paket
@@ -17,6 +17,13 @@ files
     bin\Release\netcoreapp3.1\OpenTK.Graphics.xml ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Graphics.pdb ==> lib\netcoreapp3.1
     README.md ==> docs
+    ..\..\.github\opentk-blue-hexagon.png ==> images
 
-readme
-    docs\README.md
+readme docs\README.md
+iconUrl https://raw.githubusercontent.com/opentk/opentk/refs/heads/master/.github/opentk-blue-hexagon.png
+projectUrl https://github.com/opentk/opentk
+licenseUrl https://opensource.org/licenses/MIT
+licenseExpression MIT
+tags opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick
+repositoryType git
+repositoryUrl https://github.com/opentk/opentk.git

--- a/src/OpenTK.Input/paket
+++ b/src/OpenTK.Input/paket
@@ -7,6 +7,13 @@ files
     bin\Release\netstandard2.0\OpenTK.Input.xml ==> lib\netstandard2.0
     bin\Release\netstandard2.0\OpenTK.Input.pdb ==> lib\netstandard2.0
     README.md ==> docs
+    ..\..\.github\opentk-blue-hexagon.png ==> images
 
-readme
-    docs\README.md
+readme docs\README.md
+iconUrl https://raw.githubusercontent.com/opentk/opentk/refs/heads/master/.github/opentk-blue-hexagon.png
+projectUrl https://github.com/opentk/opentk
+licenseUrl https://opensource.org/licenses/MIT
+licenseExpression MIT
+tags opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick
+repositoryType git
+repositoryUrl https://github.com/opentk/opentk.git

--- a/src/OpenTK.Mathematics/paket
+++ b/src/OpenTK.Mathematics/paket
@@ -16,6 +16,13 @@ files
     bin\Release\netcoreapp3.1\OpenTK.Mathematics.xml ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Mathematics.pdb ==> lib\netcoreapp3.1
     README.md ==> docs
+    ..\..\.github\opentk-blue-hexagon.png ==> images
 
-readme
-    docs\README.md
+readme docs\README.md
+iconUrl https://raw.githubusercontent.com/opentk/opentk/refs/heads/master/.github/opentk-blue-hexagon.png
+projectUrl https://github.com/opentk/opentk
+licenseUrl https://opensource.org/licenses/MIT
+licenseExpression MIT
+tags opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick
+repositoryType git
+repositoryUrl https://github.com/opentk/opentk.git

--- a/src/OpenTK.Windowing.Common/paket
+++ b/src/OpenTK.Windowing.Common/paket
@@ -17,6 +17,13 @@ files
     bin\Release\netcoreapp3.1\OpenTK.Windowing.Common.xml ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Windowing.Common.pdb ==> lib\netcoreapp3.1
     README.md ==> docs
+    ..\..\.github\opentk-blue-hexagon.png ==> images
 
-readme
-    docs\README.md
+readme docs\README.md
+iconUrl https://raw.githubusercontent.com/opentk/opentk/refs/heads/master/.github/opentk-blue-hexagon.png
+projectUrl https://github.com/opentk/opentk
+licenseUrl https://opensource.org/licenses/MIT
+licenseExpression MIT
+tags opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick
+repositoryType git
+repositoryUrl https://github.com/opentk/opentk.git

--- a/src/OpenTK.Windowing.Desktop/paket
+++ b/src/OpenTK.Windowing.Desktop/paket
@@ -13,6 +13,13 @@ files
     bin\Release\netcoreapp3.1\OpenTK.Windowing.Desktop.xml ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Windowing.Desktop.pdb ==> lib\netcoreapp3.1
     README.md ==> docs
+    ..\..\.github\opentk-blue-hexagon.png ==> images
 
-readme
-    docs\README.md
+readme docs\README.md
+iconUrl https://raw.githubusercontent.com/opentk/opentk/refs/heads/master/.github/opentk-blue-hexagon.png
+projectUrl https://github.com/opentk/opentk
+licenseUrl https://opensource.org/licenses/MIT
+licenseExpression MIT
+tags opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick
+repositoryType git
+repositoryUrl https://github.com/opentk/opentk.git

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
@@ -11,6 +11,13 @@ files
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.xml ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.pdb ==> lib\netcoreapp3.1
     README.md ==> docs
+    ..\..\.github\opentk-blue-hexagon.png ==> images
 
-readme
-    docs\README.md
+readme docs\README.md
+iconUrl https://raw.githubusercontent.com/opentk/opentk/refs/heads/master/.github/opentk-blue-hexagon.png
+projectUrl https://github.com/opentk/opentk
+licenseUrl https://opensource.org/licenses/MIT
+licenseExpression MIT
+tags opentk;opengl;cross-platform;openal;csharp;fsharp;vb;dotnet;mono;graphics;game;scientific;science;3d;2d;math;input;gamepad;joystick
+repositoryType git
+repositoryUrl https://github.com/opentk/opentk.git


### PR DESCRIPTION
### Purpose of this PR

The current nuget packages are missing a lot of metadata that I though where being applied from `props/nuget-common.props` but it seems like they are ignored. So this PR aims to add back a bunch of metadata to the nuget packages.

Also includes package icon in nuget package in preparation for proper nuget icons (see https://github.com/fsprojects/Paket/pull/4280)

### Testing status

Tested locally and the nuget packages does contain all of the added metadata.