### PR TITLE
Fix AuxiliarySendAuto to be EffectSlotBoolean instead of EffectSlotInteger

### DIFF
--- a/src/OpenAL/OpenTK.Audio.OpenAL/Extensions/Creative.EFX/EFX.cs
+++ b/src/OpenAL/OpenTK.Audio.OpenAL/Extensions/Creative.EFX/EFX.cs
@@ -228,6 +228,17 @@ namespace OpenTK.Audio.OpenAL
             /// <param name="slot">The slot.</param>
             /// <param name="param">The named property.</param>
             /// <param name="value">The value to set the property to.</param>
+            public static void AuxiliaryEffectSlot(int slot, EffectSlotBoolean param, bool value) => _AuxiliaryEffectSlotb(slot, param, value ? 1 : 0);
+            [UnmanagedFunctionPointer(AL.ALCallingConvention)]
+            private delegate void AuxiliaryEffectSlotbDelegate(int slot, EffectSlotBoolean param, int value);
+            private static readonly AuxiliaryEffectSlotbDelegate _AuxiliaryEffectSlotb = LoadDelegate<AuxiliaryEffectSlotbDelegate>("alAuxiliaryEffectSloti");
+
+            /// <summary>
+            /// Sets the value of a named property on the given effect slot.
+            /// </summary>
+            /// <param name="slot">The slot.</param>
+            /// <param name="param">The named property.</param>
+            /// <param name="value">The value to set the property to.</param>
             public static void AuxiliaryEffectSlot(int slot, EffectSlotFloat param, float value) => _AuxiliaryEffectSlotf(slot, param, value);
             [UnmanagedFunctionPointer(AL.ALCallingConvention)]
             private delegate void AuxiliaryEffectSlotfDelegate(int slot, EffectSlotFloat param, float value);

--- a/src/OpenAL/OpenTK.Audio.OpenAL/Extensions/Creative.EFX/Enums/EffectSlotBoolean.cs
+++ b/src/OpenAL/OpenTK.Audio.OpenAL/Extensions/Creative.EFX/Enums/EffectSlotBoolean.cs
@@ -1,5 +1,5 @@
 ﻿//
-// EffectSlotInteger.cs
+// EffectSlotBoolean.cs
 //
 // Copyright (C) 2019 OpenTK
 //

--- a/src/OpenAL/OpenTK.Audio.OpenAL/Extensions/Creative.EFX/Enums/EffectSlotBoolean.cs
+++ b/src/OpenAL/OpenTK.Audio.OpenAL/Extensions/Creative.EFX/Enums/EffectSlotBoolean.cs
@@ -7,29 +7,18 @@
 // of the MIT license. See the LICENSE file for details.
 //
 
-using System;
-
 namespace OpenTK.Audio.OpenAL
 {
     /// <summary>
     /// A list of valid <see cref="int"/> <see cref="ALC.EFX.AuxiliaryEffectSlot(int, EffectSlotInteger, int)"/>/<see cref="ALC.EFX.GetAuxiliaryEffectSlot(int, EffectSlotInteger)"/> parameters.
     /// </summary>
-    public enum EffectSlotInteger
+    public enum EffectSlotBoolean
     {
-        /// <summary>
-        /// This property is used to attach an Effect object to the Auxiliary Effect Slot object. After the attachment,
-        /// the Auxiliary Effect Slot object will contain the effect type and have the same effect parameters that were
-        /// stored in the Effect object. Any Sources feeding the Auxiliary Effect Slot will immediate feed the new
-        /// effect type and new effect parameters.
-        /// </summary>
-        Effect = 0x0001,
-
         /// <summary>
         /// This property is used to enable or disable automatic send adjustments based on the physical positions of the
         /// sources and the listener. This property should be enabled when an application wishes to use a reverb effect
         /// to simulate the environment surrounding a listener or a collection of Sources.
         /// </summary>
-        [Obsolete("Use EffectSlotBoolean.AuxiliarySendAuto instead.")]
         AuxiliarySendAuto = 0x0003,
     }
 }


### PR DESCRIPTION
### Purpose of this PR

Also deprecates `EffectSlotInteger.AuxiliarySendAuto`.

### Testing status

Tested locally.
