### PR TITLE
Fix 4.9.1 build problems

### DIFF
--- a/build/build.fs
+++ b/build/build.fs
@@ -167,7 +167,7 @@ Target.create "AssemblyInfo" (fun _ ->
 
 Target.create "Build"( fun _ ->
     let setOptions a =
-        let customParams = sprintf "/p:DontGenBindings=true/p:PackageVersion=%s/p:ProductVersion=%s" release.AssemblyVersion release.NugetVersion
+        let customParams = sprintf "/p:ContinuousIntegrationBuild=true /p:DontGenBindings=true /p:PackageVersion=%s /p:ProductVersion=%s /p:Version=%s" release.AssemblyVersion release.NugetVersion release.AssemblyVersion
         DotNet.Options.withCustomParams (Some customParams) (dotnetSimple a)
 
     for proj in releaseProjects do

--- a/props/nuget-common.props
+++ b/props/nuget-common.props
@@ -10,6 +10,8 @@
     <PackageOutputPath>$(OpenTKSolutionRoot)\nuget</PackageOutputPath>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
+    <!-- The build system will override this version with the actual version. See build.fs. -->
+    <!-- - Noggin_bops 2024-12-10 -->
     <Version>4.0.0</Version>
   </PropertyGroup>
   <Import Project="common.props" Condition="!$(HasCommonProperties)"/>


### PR DESCRIPTION
### Purpose of this PR

Make assemblies actually have a version that matches the OpenTK version.
Make builds deterministic.
Releasing `4.9.2` will remove the zip file reported in #1780 

### Testing status

Project built locally and then verified with ILSpy and NugetPackageExplorer.