### PR TITLE
[5.0] Make GLFW loading process `IlcDisableReflection` compatible, reflection free

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/GLFWNative.cs
@@ -17,7 +17,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         {
             // Register DllImport resolver so that the correct dynamic library is loaded on all platforms.
             // On net472, we rely on Mono's DllMap for this. See the .dll.config file.
-            NativeLibrary.SetDllImportResolver(typeof(GLFWNative).Assembly, (name, assembly, path) =>
+            NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), (name, assembly, path) =>
             {
                 if (name != LibraryName)
                 {


### PR DESCRIPTION
### Purpose of this PR

`Assembly.GetExecutingAssembly()` is explicitly [said to work even in reflection free mode](https://github.com/dotnet/runtime/blob/0bd362370bdd649f0f09eb5c1e58cf11d9538804/src/coreclr/nativeaot/docs/reflection-free-mode.md#reflection-apis-that-work-in-reflection-free-mode).
Current `typeof(GLFWNative).Assembly` causes an error for NativeAOT applications using `IlcDisableReflection`: 
```md
Unhandled exception. 0x7ff715016180: TypeInitialization_Type_NoTypeAvailable
 ---> 0x7ff7150156c0: Reflection_Disabled
   at System.RuntimeType.InitializeRuntimeTypeInfoHandle() + 0x2c
   at System.RuntimeType.get_Assembly() + 0x38
   at OpenTK.Windowing.GraphicsLibraryFramework.GLFWNative..cctor() + 0x21
   at System.Runtime.CompilerServices.ClassConstructorRunner.EnsureClassConstructorRun(StaticClassConstructionContext*) + 0xba
   Exception_EndOfInnerExceptionStack
   at System.Runtime.CompilerServices.ClassConstructorRunner.EnsureClassConstructorRun(StaticClassConstructionContext*) + 0x13d
   at System.Runtime.CompilerServices.ClassConstructorRunner.CheckStaticClassConstructionReturnNonGCStaticBase(StaticClassConstructionContext*, IntPtr) + 0xd
   at OpenTK.Windowing.GraphicsLibraryFramework.GLFWNative.glfwInit() + 0x71
```
This change fixes that.

