### PR TITLE
[pal2] Fix raw mouse input on windows

### DIFF
--- a/src/OpenTK.Platform/Native/Windows/Win32.cs
+++ b/src/OpenTK.Platform/Native/Windows/Win32.cs
@@ -1438,19 +1438,19 @@ namespace OpenTK.Platform.Native.Windows
         {
             [FieldOffset(0)]
             public RawMouseFlags usFlags;
-            [FieldOffset(2)]
-            public uint ulButtons;
-            [FieldOffset(2)]
-            public ushort usButtonFlags;
             [FieldOffset(4)]
-            public ushort usButtonData;
+            public uint ulButtons;
+            [FieldOffset(4)]
+            public ushort usButtonFlags;
             [FieldOffset(6)]
+            public ushort usButtonData;
+            [FieldOffset(8)]
             public uint ulRawButtons;
-            [FieldOffset(10)]
+            [FieldOffset(12)]
             public int lLastX;
-            [FieldOffset(14)]
+            [FieldOffset(16)]
             public int lLastY;
-            [FieldOffset(18)]
+            [FieldOffset(20)]
             public uint ulExtraInformation;
         }
 

--- a/src/OpenTK.Platform/Native/Windows/WindowComponent.cs
+++ b/src/OpenTK.Platform/Native/Windows/WindowComponent.cs
@@ -719,7 +719,7 @@ namespace OpenTK.Platform.Native.Windows
 
                             if (mouse.usFlags == RawMouseFlags.MoveRelative)
                             {
-                                if (mouse.lLastX != 0 && mouse.lLastY != 0)
+                                if (mouse.lLastX != 0 || mouse.lLastY != 0)
                                 {
                                     HWND h = HWndDict[hWnd];
                                     EventQueue.Raise(h, PlatformEventType.RawMouseMove, new RawMouseMoveEventArgs(h, (mouse.lLastX, mouse.lLastY)));

--- a/tests/OpenTK.Backends.Tests/Program.cs
+++ b/tests/OpenTK.Backends.Tests/Program.cs
@@ -85,7 +85,7 @@ namespace OpenTK.Backends.Tests
             // when we use Toolkit.Init to actually create the components...
             // - Noggin_bops 2024-03-02
             PlatformComponents.PreferSDL2 = false;
-            PlatformComponents.PreferANGLE = true;
+            PlatformComponents.PreferANGLE = false;
 
             if (PlatformComponents.PreferANGLE)
             {

--- a/tests/OpenTK.Backends.Tests/TestApps/FpsCamera.cs
+++ b/tests/OpenTK.Backends.Tests/TestApps/FpsCamera.cs
@@ -81,7 +81,7 @@ void main() {
 ";
 
         bool rawMouseMotionEnabled = false;
-        float rawMouseMotionScale = 1.0f / 65536.0f;
+        float rawMouseMotionScale = 1.0f;
 
         int env_program;
         int env_program_mvp_location;
@@ -224,8 +224,8 @@ void main() {
                 //Vector2 delta = prevPos - state.Position;
                 //prevPos = state.Position;
 
-                cameraRotationY += delta.X * cameraRotationSpeed.X * deltaTime;
-                cameraRotationX += delta.Y * cameraRotationSpeed.Y * deltaTime;
+                cameraRotationY -= delta.X * cameraRotationSpeed.X * deltaTime;
+                cameraRotationX -= delta.Y * cameraRotationSpeed.Y * deltaTime;
                 cameraRotationX = Math.Clamp(cameraRotationX, -80 * D2R, 80 * D2R);
 
                 cameraRotation = Quaternion.FromAxisAngle(Vector3.UnitY, cameraRotationY) *
@@ -277,7 +277,7 @@ void main() {
             {
                 if (rawMouseMotionEnabled == false)
                 {
-                    delta += prevPos - mouseMove.ClientPosition;
+                    delta += mouseMove.ClientPosition - prevPos;
 
                     Console.WriteLine($"Mouse move: {mouseMove.ClientPosition}");
                 }


### PR DESCRIPTION
### Purpose of this PR

* Fixes raw mouse input on Windows
* Affects PAL2 on Windows

Change RAWMOUSE struct layout to match c definition.
Fix incorrect use of &&, it should be ||

### Testing status

* Tested using minimal repro posted in the Discord
* Tested using OpenTK.Backends.Tests 
