### PR TITLE
Explicit casts to and from System.Numerics types.

### DIFF
--- a/src/OpenTK.Mathematics/Data/Quaternion.cs
+++ b/src/OpenTK.Mathematics/Data/Quaternion.cs
@@ -803,6 +803,26 @@ namespace OpenTK.Mathematics
             return !(left == right);
         }
 
+        /// <summary>
+        /// Converts <see cref="System.Numerics.Quaternion"/> to <see cref="Quaternion"/>.
+        /// </summary>
+        /// <param name="quat">The <see cref="System.Numerics.Quaternion"/> to cast.</param>
+        [Pure]
+        public static explicit operator Quaternion(System.Numerics.Quaternion quat)
+        {
+            return new Quaternion(quat.X, quat.Y, quat.Z, quat.W);
+        }
+
+        /// <summary>
+        /// Converts <see cref="Quaternion"/> to <see cref="System.Numerics.Quaternion"/>.
+        /// </summary>
+        /// <param name="quat">The <see cref="Quaternion"/> to cast.</param>
+        [Pure]
+        public static explicit operator System.Numerics.Quaternion(Quaternion quat)
+        {
+            return new System.Numerics.Quaternion(quat.X, quat.Y, quat.Z, quat.W);
+        }
+
         /// <inheritdoc />
         public override readonly bool Equals(object obj)
         {

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
@@ -23,6 +23,7 @@ SOFTWARE.
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
+using System.Numerics;
 using System.Runtime.InteropServices;
 
 namespace OpenTK.Mathematics
@@ -793,6 +794,26 @@ namespace OpenTK.Mathematics
         public static bool operator !=(Matrix3x2 left, Matrix3x2 right)
         {
             return !left.Equals(right);
+        }
+
+        /// <summary>
+        /// Converts <see cref="System.Numerics.Matrix3x2"/> to <see cref="Matrix3x2"/>.
+        /// </summary>
+        /// <param name="mat">The <see cref="System.Numerics.Matrix3x2"/> to cast.</param>
+        [Pure]
+        public static explicit operator Matrix3x2(System.Numerics.Matrix3x2 mat)
+        {
+            return new Matrix3x2(mat.M11, mat.M12, mat.M21, mat.M22, mat.M31, mat.M32);
+        }
+
+        /// <summary>
+        /// Converts <see cref="Matrix3x2"/> to <see cref="System.Numerics.Matrix3x2"/>.
+        /// </summary>
+        /// <param name="mat">The <see cref="Matrix3x2"/> to cast.</param>
+        [Pure]
+        public static explicit operator System.Numerics.Matrix3x2(Matrix3x2 mat)
+        {
+            return new System.Numerics.Matrix3x2(mat.M11, mat.M12, mat.M21, mat.M22, mat.M31, mat.M32);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
@@ -23,7 +23,6 @@ SOFTWARE.
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using System.Numerics;
 using System.Runtime.InteropServices;
 
 namespace OpenTK.Mathematics

--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -2170,6 +2170,46 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Converts <see cref="System.Numerics.Matrix4x4"/> to <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="mat">The <see cref="Matrix4"/> to cast.</param>
+        [Pure]
+        [SuppressMessage(
+            "StyleCop.CSharp.ReadabilityRules",
+            "SA1117:ParametersMustBeOnSameLineOrSeparateLines",
+            Justification = "A single line for all 16 parameters is a bit hard to read and 16 seperate lines takes up too much space, so 1 line for each row in the matrix helps visibility.")]
+        public static explicit operator Matrix4(System.Numerics.Matrix4x4 mat)
+        {
+            return new Matrix4
+                (
+                mat.M11, mat.M12, mat.M13, mat.M14,
+                mat.M21, mat.M22, mat.M23, mat.M24,
+                mat.M31, mat.M32, mat.M33, mat.M34,
+                mat.M41, mat.M42, mat.M43, mat.M44
+                );
+        }
+
+        /// <summary>
+        /// Converts <see cref="Matrix4"/> to <see cref="System.Numerics.Matrix4x4"/>.
+        /// </summary>
+        /// <param name="mat">The <see cref="Matrix4"/> to cast.</param>
+        [Pure]
+        [SuppressMessage(
+            "StyleCop.CSharp.ReadabilityRules",
+            "SA1117:ParametersMustBeOnSameLineOrSeparateLines",
+            Justification = "A single line for all 16 parameters is a bit hard to read and 16 seperate lines takes up too much space, so 1 line for each row in the matrix helps visibility.")]
+        public static explicit operator System.Numerics.Matrix4x4(Matrix4 mat)
+        {
+            return new System.Numerics.Matrix4x4
+                (
+                mat.M11, mat.M12, mat.M13, mat.M14,
+                mat.M21, mat.M22, mat.M23, mat.M24,
+                mat.M31, mat.M32, mat.M33, mat.M34,
+                mat.M41, mat.M42, mat.M43, mat.M44
+                );
+        }
+
+        /// <summary>
         /// Returns a System.String that represents the current Matrix4.
         /// </summary>
         /// <returns>The string representation of the matrix.</returns>

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -1215,6 +1215,26 @@ namespace OpenTK.Mathematics
             return new System.Drawing.SizeF(vec.X, vec.Y);
         }
 
+        /// <summary>
+        /// Converts <see cref="System.Numerics.Vector2"/> to <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="vec">The <see cref="System.Numerics.Vector2"/> to cast.</param>
+        [Pure]
+        public static explicit operator Vector2(System.Numerics.Vector2 vec)
+        {
+            return new Vector2(vec.X, vec.Y);
+        }
+
+        /// <summary>
+        /// Converts <see cref="Vector2"/> to <see cref="System.Numerics.Vector2"/>.
+        /// </summary>
+        /// <param name="vec">The <see cref="Vector2"/> to cast.</param>
+        [Pure]
+        public static explicit operator System.Numerics.Vector2(Vector2 vec)
+        {
+            return new System.Numerics.Vector2(vec.X, vec.Y);
+        }
+
         /// <inheritdoc/>
         public override string ToString()
         {

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -1760,6 +1760,26 @@ namespace OpenTK.Mathematics
             return new Vector3(values.X, values.Y, values.Z);
         }
 
+        /// <summary>
+        /// Converts <see cref="System.Numerics.Vector3"/> to <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="vec">The <see cref="System.Numerics.Vector3"/> to cast.</param>
+        [Pure]
+        public static explicit operator Vector3(System.Numerics.Vector3 vec)
+        {
+            return new Vector3(vec.X, vec.Y, vec.Z);
+        }
+
+        /// <summary>
+        /// Converts <see cref="Vector3"/> to <see cref="System.Numerics.Vector3"/>.
+        /// </summary>
+        /// <param name="vec">The <see cref="Vector3"/> to cast.</param>
+        [Pure]
+        public static explicit operator System.Numerics.Vector3(Vector3 vec)
+        {
+            return new System.Numerics.Vector3(vec.X, vec.Y, vec.Z);
+        }
+
         /// <inheritdoc/>
         public override readonly string ToString()
         {

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -2270,6 +2270,26 @@ namespace OpenTK.Mathematics
             return new Vector4(values.X, values.Y, values.Z, values.W);
         }
 
+        /// <summary>
+        /// Converts <see cref="System.Numerics.Vector4"/> to <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="vec">The <see cref="System.Numerics.Vector4"/> to cast.</param>
+        [Pure]
+        public static explicit operator Vector4(System.Numerics.Vector4 vec)
+        {
+            return new Vector4(vec.X, vec.Y, vec.Z, vec.W);
+        }
+
+        /// <summary>
+        /// Converts <see cref="Vector4"/> to <see cref="System.Numerics.Vector4"/>.
+        /// </summary>
+        /// <param name="vec">The <see cref="Vector4"/> to cast.</param>
+        [Pure]
+        public static explicit operator System.Numerics.Vector4(Vector4 vec)
+        {
+            return new System.Numerics.Vector4(vec.X, vec.Y, vec.Z, vec.W);
+        }
+
         /// <inheritdoc/>
         public override readonly string ToString()
         {


### PR DESCRIPTION
### Purpose of this PR

A lot of libraries rely on the <code>System.Numerics</code> types such as <code>System.Numerics.Vector3</code>.  This PR adds explicit casting to and from all the synonymous types in <code>System.Numerics</code> and <code>OpenTK.Mathematics</code>. This is mainly a quality of life change over an actual functional change.

### Testing status

Tested in multiple personal projects where ImGui.Net is used and changed all occurrences where manual conversions are being done to the casting and had virtually no change in behavior.
