### PR TITLE
Update glfw dependency to correctly be using GLFW 3.4

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
@@ -5,7 +5,7 @@ description
 dependencies
     framework: netcoreapp3.1
         OpenTK.Core ~> #VERSION#
-        OpenTK.redist.glfw >= 3.3.8.39
+        OpenTK.redist.glfw >= 3.4.0.44
 files
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.dll ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.xml ==> lib\netcoreapp3.1


### PR DESCRIPTION
### Purpose of this PR

Fixes #1802

### Testing status

The code using GLFW 3.4 has been written and tested locally where the csproj reference is used instead of the paket reference.
So this change should make it so that this code works in the nuget package. 