### PR TITLE
[5.0] Add `scalar / vector` operators

### DIFF
--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -1097,13 +1097,27 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Divides the specified instance by a scalar.
+        /// Divides an instance by a scalar.
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of the division.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector2 operator /(Vector2 vec, float scale)
+        {
+            vec.X /= scale;
+            vec.Y /= scale;
+            return vec;
+        }
+
+        /// <summary>
+        /// Divides an instance by a scalar.
+        /// </summary>
+        /// <param name="scale">Left operand.</param>
+        /// <param name="vec">Right operand.</param>
+        /// <returns>Result of division.</returns>
+        [Pure]
+        public static Vector2 operator /(float scale, Vector2 vec)
         {
             vec.X /= scale;
             vec.Y /= scale;
@@ -1115,7 +1129,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of the division.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector2 operator /(Vector2 vec, Vector2 scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -259,7 +259,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
-        /// <returns>Result of subtraction.</returns>
+        /// <returns>Result of the subtraction.</returns>
         [Pure]
         public static Vector2 Subtract(Vector2 a, Vector2 b)
         {
@@ -979,7 +979,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
-        /// <returns>Result of addition.</returns>
+        /// <returns>Result of the addition.</returns>
         [Pure]
         public static Vector2 operator +(Vector2 left, Vector2 right)
         {
@@ -993,7 +993,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
-        /// <returns>Result of subtraction.</returns>
+        /// <returns>Result of the subtraction.</returns>
         [Pure]
         public static Vector2 operator -(Vector2 left, Vector2 right)
         {
@@ -1020,7 +1020,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of multiplication.</returns>
+        /// <returns>Result of the multiplication.</returns>
         [Pure]
         public static Vector2 operator *(Vector2 vec, float scale)
         {
@@ -1034,7 +1034,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="scale">Left operand.</param>
         /// <param name="vec">Right operand.</param>
-        /// <returns>Result of multiplication.</returns>
+        /// <returns>Result of the multiplication.</returns>
         [Pure]
         public static Vector2 operator *(float scale, Vector2 vec)
         {
@@ -1048,7 +1048,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="scale">Left operand.</param>
         /// <param name="vec">Right operand.</param>
-        /// <returns>Result of multiplication.</returns>
+        /// <returns>Result of the multiplication.</returns>
         [Pure]
         public static Vector2 operator *(Vector2 vec, Vector2 scale)
         {
@@ -1101,7 +1101,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector2 operator /(Vector2 vec, float scale)
         {
@@ -1129,7 +1129,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector2 operator /(Vector2 vec, Vector2 scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -1113,15 +1113,15 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Divides a scalar by an instance.
         /// </summary>
-        /// <param name="scale">Left operand.</param>
-        /// <param name="vec">Right operand.</param>
-        /// <returns>Result of division.</returns>
+        /// <param name="left">Left operand.</param>
+        /// <param name="right">Right operand.</param>
+        /// <returns>Result of the division.</returns>
         [Pure]
-        public static Vector2 operator /(float scale, Vector2 vec)
+        public static Vector2 operator /(float left, Vector2 right)
         {
-            vec.X = scale / vec.X;
-            vec.Y = scale / vec.Y;
-            return vec;
+            right.X = left / right.X;
+            right.Y = left / right.Y;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -1111,7 +1111,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Divides an instance by a scalar.
+        /// Divides a scalar by an instance.
         /// </summary>
         /// <param name="scale">Left operand.</param>
         /// <param name="vec">Right operand.</param>
@@ -1119,8 +1119,8 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector2 operator /(float scale, Vector2 vec)
         {
-            vec.X /= scale;
-            vec.Y /= scale;
+            vec.X = scale / vec.X;
+            vec.Y = scale / vec.Y;
             return vec;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -1073,22 +1073,36 @@ namespace OpenTK.Mathematics
         /// Divides an instance by a scalar.
         /// </summary>
         /// <param name="vec">The instance.</param>
-        /// <param name="f">The scalar.</param>
-        /// <returns>The result of the operation.</returns>
+        /// <param name="scale">The scalar.</param>
+        /// <returns>Result of division.</returns>
         [Pure]
-        public static Vector2d operator /(Vector2d vec, double f)
+        public static Vector2d operator /(Vector2d vec, double scale)
         {
-            vec.X /= f;
-            vec.Y /= f;
+            vec.X /= scale;
+            vec.Y /= scale;
             return vec;
         }
 
         /// <summary>
-        /// Component-wise division between the specified instance by a scale vector.
+        /// Divides an instance by a scalar.
+        /// </summary>
+        /// <param name="scale">The scalar.</param>
+        /// <param name="vec">The instance.</param>
+        /// <returns>Result of division.</returns>
+        [Pure]
+        public static Vector2d operator /(double scale, Vector2d vec)
+        {
+            vec.X /= scale;
+            vec.Y /= scale;
+            return vec;
+        }
+
+        /// <summary>
+        /// Divides an instance by a scalar.
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of the division.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector2d operator /(Vector2d vec, Vector2d scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -992,27 +992,27 @@ namespace OpenTK.Mathematics
         /// Multiplies an instance by a scalar.
         /// </summary>
         /// <param name="vec">The instance.</param>
-        /// <param name="f">The scalar.</param>
+        /// <param name="scale">The scalar.</param>
         /// <returns>The result of the operation.</returns>
         [Pure]
-        public static Vector2d operator *(Vector2d vec, double f)
+        public static Vector2d operator *(Vector2d vec, double scale)
         {
-            vec.X *= f;
-            vec.Y *= f;
+            vec.X *= scale;
+            vec.Y *= scale;
             return vec;
         }
 
         /// <summary>
         /// Multiply an instance by a scalar.
         /// </summary>
-        /// <param name="f">The scalar.</param>
+        /// <param name="scale">The scalar.</param>
         /// <param name="vec">The instance.</param>
         /// <returns>The result of the operation.</returns>
         [Pure]
-        public static Vector2d operator *(double f, Vector2d vec)
+        public static Vector2d operator *(double scale, Vector2d vec)
         {
-            vec.X *= f;
-            vec.Y *= f;
+            vec.X *= scale;
+            vec.Y *= scale;
             return vec;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -1084,7 +1084,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Divides an instance by a scalar.
+        /// Divides a scalar by an instance.
         /// </summary>
         /// <param name="scale">The scalar.</param>
         /// <param name="vec">The instance.</param>
@@ -1092,8 +1092,8 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector2d operator /(double scale, Vector2d vec)
         {
-            vec.X /= scale;
-            vec.Y /= scale;
+            vec.X = scale / vec.X;
+            vec.Y = scale / vec.Y;
             return vec;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -1086,15 +1086,15 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Divides a scalar by an instance.
         /// </summary>
-        /// <param name="scale">The scalar.</param>
-        /// <param name="vec">The instance.</param>
-        /// <returns>Result of division.</returns>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>Result of the division.</returns>
         [Pure]
-        public static Vector2d operator /(double scale, Vector2d vec)
+        public static Vector2d operator /(double left, Vector2d right)
         {
-            vec.X = scale / vec.X;
-            vec.Y = scale / vec.Y;
-            return vec;
+            right.X = left / right.X;
+            right.Y = left / right.Y;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -255,7 +255,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
-        /// <returns>Result of subtraction.</returns>
+        /// <returns>Result of the subtraction.</returns>
         [Pure]
         public static Vector2d Subtract(Vector2d a, Vector2d b)
         {
@@ -1021,7 +1021,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="scale">Left operand.</param>
         /// <param name="vec">Right operand.</param>
-        /// <returns>Result of multiplication.</returns>
+        /// <returns>Result of the multiplication.</returns>
         [Pure]
         public static Vector2d operator *(Vector2d vec, Vector2d scale)
         {
@@ -1074,7 +1074,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">The instance.</param>
         /// <param name="scale">The scalar.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector2d operator /(Vector2d vec, double scale)
         {
@@ -1102,7 +1102,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector2d operator /(Vector2d vec, Vector2d scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -187,7 +187,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
-        /// <returns>Result of subtraction.</returns>
+        /// <returns>Result of the subtraction.</returns>
         [Pure]
         public static Vector2i Subtract(Vector2i a, Vector2i b)
         {
@@ -449,7 +449,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
-        /// <returns>Result of addition.</returns>
+        /// <returns>Result of the addition.</returns>
         [Pure]
         public static Vector2i operator +(Vector2i left, Vector2i right)
         {
@@ -463,7 +463,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="left">Left operand.</param>
         /// <param name="right">Right operand.</param>
-        /// <returns>Result of subtraction.</returns>
+        /// <returns>Result of the subtraction.</returns>
         [Pure]
         public static Vector2i operator -(Vector2i left, Vector2i right)
         {
@@ -490,7 +490,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of multiplication.</returns>
+        /// <returns>Result of the multiplication.</returns>
         [Pure]
         public static Vector2i operator *(Vector2i vec, int scale)
         {
@@ -504,7 +504,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="scale">Left operand.</param>
         /// <param name="vec">Right operand.</param>
-        /// <returns>Result of multiplication.</returns>
+        /// <returns>Result of the multiplication.</returns>
         [Pure]
         public static Vector2i operator *(int scale, Vector2i vec)
         {
@@ -518,7 +518,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="scale">Left operand.</param>
         /// <param name="vec">Right operand.</param>
-        /// <returns>Result of multiplication.</returns>
+        /// <returns>Result of the multiplication.</returns>
         [Pure]
         public static Vector2i operator *(Vector2i vec, Vector2i scale)
         {
@@ -532,7 +532,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector2i operator /(Vector2i vec, int scale)
         {
@@ -560,7 +560,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector2i operator /(Vector2i vec, Vector2i scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -542,7 +542,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Divides the instance by a scalar using integer division, floor(a/b).
+        /// Divides a scalar by the instance using integer division, floor(a/b).
         /// </summary>
         /// <param name="scale">Left operand.</param>
         /// <param name="vec">Right operand.</param>
@@ -550,8 +550,8 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector2i operator /(int scale, Vector2i vec)
         {
-            vec.X /= scale;
-            vec.Y /= scale;
+            vec.X = scale / vec.X;
+            vec.Y = scale / vec.Y;
             return vec;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -544,15 +544,15 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Divides a scalar by the instance using integer division, floor(a/b).
         /// </summary>
-        /// <param name="scale">Left operand.</param>
-        /// <param name="vec">Right operand.</param>
-        /// <returns>Result of division.</returns>
+        /// <param name="left">Left operand.</param>
+        /// <param name="right">Right operand.</param>
+        /// <returns>Result of the division.</returns>
         [Pure]
-        public static Vector2i operator /(int scale, Vector2i vec)
+        public static Vector2i operator /(int left, Vector2i right)
         {
-            vec.X = scale / vec.X;
-            vec.Y = scale / vec.Y;
-            return vec;
+            right.X = left / right.X;
+            right.Y = left / right.Y;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -532,9 +532,23 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of the division.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector2i operator /(Vector2i vec, int scale)
+        {
+            vec.X /= scale;
+            vec.Y /= scale;
+            return vec;
+        }
+
+        /// <summary>
+        /// Divides the instance by a scalar using integer division, floor(a/b).
+        /// </summary>
+        /// <param name="scale">Left operand.</param>
+        /// <param name="vec">Right operand.</param>
+        /// <returns>Result of division.</returns>
+        [Pure]
+        public static Vector2i operator /(int scale, Vector2i vec)
         {
             vec.X /= scale;
             vec.Y /= scale;
@@ -546,7 +560,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of the division.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector2i operator /(Vector2i vec, Vector2i scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -1643,9 +1643,24 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">The instance.</param>
         /// <param name="scale">The scalar.</param>
-        /// <returns>The result of the calculation.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector3 operator /(Vector3 vec, float scale)
+        {
+            vec.X /= scale;
+            vec.Y /= scale;
+            vec.Z /= scale;
+            return vec;
+        }
+
+        /// <summary>
+        /// Divides an instance by a scalar.
+        /// </summary>
+        /// <param name="scale">The scalar.</param>
+        /// <param name="vec">The instance.</param>
+        /// <returns>Result of division.</returns>
+        [Pure]
+        public static Vector3 operator /(float scale, Vector3 vec)
         {
             vec.X /= scale;
             vec.Y /= scale;
@@ -1658,7 +1673,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of the division.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector3 operator /(Vector3 vec, Vector3 scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -1654,7 +1654,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Divides an instance by a scalar.
+        /// Divides a scalar by an instance.
         /// </summary>
         /// <param name="scale">The scalar.</param>
         /// <param name="vec">The instance.</param>
@@ -1662,9 +1662,9 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector3 operator /(float scale, Vector3 vec)
         {
-            vec.X /= scale;
-            vec.Y /= scale;
-            vec.Z /= scale;
+            vec.X = scale / vec.X;
+            vec.Y = scale / vec.Y;
+            vec.Z = scale / vec.Z;
             return vec;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -287,7 +287,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
-        /// <returns>Result of subtraction.</returns>
+        /// <returns>Result of the subtraction.</returns>
         [Pure]
         public static Vector3 Subtract(Vector3 a, Vector3 b)
         {
@@ -1589,7 +1589,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="scale">Left operand.</param>
         /// <param name="vec">Right operand.</param>
-        /// <returns>Result of multiplication.</returns>
+        /// <returns>Result of the multiplication.</returns>
         [Pure]
         public static Vector3 operator *(Vector3 vec, Vector3 scale)
         {
@@ -1643,7 +1643,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">The instance.</param>
         /// <param name="scale">The scalar.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector3 operator /(Vector3 vec, float scale)
         {
@@ -1673,7 +1673,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector3 operator /(Vector3 vec, Vector3 scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -1656,16 +1656,16 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Divides a scalar by an instance.
         /// </summary>
-        /// <param name="scale">The scalar.</param>
-        /// <param name="vec">The instance.</param>
-        /// <returns>Result of division.</returns>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>Result of the division.</returns>
         [Pure]
-        public static Vector3 operator /(float scale, Vector3 vec)
+        public static Vector3 operator /(float left, Vector3 right)
         {
-            vec.X = scale / vec.X;
-            vec.Y = scale / vec.Y;
-            vec.Z = scale / vec.Z;
-            return vec;
+            right.X = left / right.X;
+            right.Y = left / right.Y;
+            right.Z = left / right.Z;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -1520,7 +1520,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Divides an instance by a scalar.
+        /// Divides a scalar by an instance.
         /// </summary>
         /// <param name="scale">The scalar.</param>
         /// <param name="vec">The instance.</param>
@@ -1528,9 +1528,9 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector3d operator /(double scale, Vector3d vec)
         {
-            vec.X /= scale;
-            vec.Y /= scale;
-            vec.Z /= scale;
+            vec.X = scale / vec.X;
+            vec.Y = scale / vec.Y;
+            vec.Z = scale / vec.Z;
             return vec;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -1522,16 +1522,16 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Divides a scalar by an instance.
         /// </summary>
-        /// <param name="scale">The scalar.</param>
-        /// <param name="vec">The instance.</param>
-        /// <returns>Result of division.</returns>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>Result of the division.</returns>
         [Pure]
-        public static Vector3d operator /(double scale, Vector3d vec)
+        public static Vector3d operator /(double left, Vector3d right)
         {
-            vec.X = scale / vec.X;
-            vec.Y = scale / vec.Y;
-            vec.Z = scale / vec.Z;
-            return vec;
+            right.X = left / right.X;
+            right.Y = left / right.Y;
+            right.Z = left / right.Z;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -1509,9 +1509,24 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">The instance.</param>
         /// <param name="scale">The scalar.</param>
-        /// <returns>The result of the calculation.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector3d operator /(Vector3d vec, double scale)
+        {
+            vec.X /= scale;
+            vec.Y /= scale;
+            vec.Z /= scale;
+            return vec;
+        }
+
+        /// <summary>
+        /// Divides an instance by a scalar.
+        /// </summary>
+        /// <param name="scale">The scalar.</param>
+        /// <param name="vec">The instance.</param>
+        /// <returns>Result of division.</returns>
+        [Pure]
+        public static Vector3d operator /(double scale, Vector3d vec)
         {
             vec.X /= scale;
             vec.Y /= scale;
@@ -1524,7 +1539,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of the division.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector3d operator /(Vector3d vec, Vector3d scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -285,7 +285,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
-        /// <returns>Result of subtraction.</returns>
+        /// <returns>Result of the subtraction.</returns>
         [Pure]
         public static Vector3d Subtract(Vector3d a, Vector3d b)
         {
@@ -1455,7 +1455,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="scale">Left operand.</param>
         /// <param name="vec">Right operand.</param>
-        /// <returns>Result of multiplication.</returns>
+        /// <returns>Result of the multiplication.</returns>
         [Pure]
         public static Vector3d operator *(Vector3d vec, Vector3d scale)
         {
@@ -1509,7 +1509,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">The instance.</param>
         /// <param name="scale">The scalar.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector3d operator /(Vector3d vec, double scale)
         {
@@ -1539,7 +1539,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector3d operator /(Vector3d vec, Vector3d scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -737,7 +737,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Divides the instance by a scalar using integer division, floor(a/b).
+        /// Divides a scalar by the instance using integer division, floor(a/b).
         /// </summary>
         /// <param name="scale">The scalar.</param>
         /// <param name="vec">The instance.</param>
@@ -745,9 +745,9 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector3i operator /(int scale, Vector3i vec)
         {
-            vec.X /= scale;
-            vec.Y /= scale;
-            vec.Z /= scale;
+            vec.X = scale / vec.X;
+            vec.Y = scale / vec.Y;
+            vec.Z = scale / vec.Z;
             return vec;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -726,9 +726,24 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">The instance.</param>
         /// <param name="scale">The scalar.</param>
-        /// <returns>The result of the calculation.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector3i operator /(Vector3i vec, int scale)
+        {
+            vec.X /= scale;
+            vec.Y /= scale;
+            vec.Z /= scale;
+            return vec;
+        }
+
+        /// <summary>
+        /// Divides the instance by a scalar using integer division, floor(a/b).
+        /// </summary>
+        /// <param name="scale">The scalar.</param>
+        /// <param name="vec">The instance.</param>
+        /// <returns>Result of division.</returns>
+        [Pure]
+        public static Vector3i operator /(int scale, Vector3i vec)
         {
             vec.X /= scale;
             vec.Y /= scale;
@@ -741,7 +756,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of the division.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector3i operator /(Vector3i vec, Vector3i scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -739,16 +739,16 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Divides a scalar by the instance using integer division, floor(a/b).
         /// </summary>
-        /// <param name="scale">The scalar.</param>
-        /// <param name="vec">The instance.</param>
-        /// <returns>Result of division.</returns>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>Result of the division.</returns>
         [Pure]
-        public static Vector3i operator /(int scale, Vector3i vec)
+        public static Vector3i operator /(int left, Vector3i right)
         {
-            vec.X = scale / vec.X;
-            vec.Y = scale / vec.Y;
-            vec.Z = scale / vec.Z;
-            return vec;
+            right.X = left / right.X;
+            right.Y = left / right.Y;
+            right.Z = left / right.Z;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -213,7 +213,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
-        /// <returns>Result of subtraction.</returns>
+        /// <returns>Result of the subtraction.</returns>
         [Pure]
         public static Vector3i Subtract(Vector3i a, Vector3i b)
         {
@@ -711,7 +711,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="scale">Left operand.</param>
         /// <param name="vec">Right operand.</param>
-        /// <returns>Result of multiplication.</returns>
+        /// <returns>Result of the multiplication.</returns>
         [Pure]
         public static Vector3i operator *(Vector3i vec, Vector3i scale)
         {
@@ -726,7 +726,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">The instance.</param>
         /// <param name="scale">The scalar.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector3i operator /(Vector3i vec, int scale)
         {
@@ -756,7 +756,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector3i operator /(Vector3i vec, Vector3i scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -2125,17 +2125,17 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Divides a scalar by an instance.
         /// </summary>
-        /// <param name="scale">The scalar.</param>
-        /// <param name="vec">The instance.</param>
-        /// <returns>Result of division.</returns>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>Result of the division.</returns>
         [Pure]
-        public static Vector4 operator /(float scale, Vector4 vec)
+        public static Vector4 operator /(float left, Vector4 right)
         {
-            vec.X = scale / vec.X;
-            vec.Y = scale / vec.Y;
-            vec.Z = scale / vec.Z;
-            vec.W = scale / vec.W;
-            return vec;
+            right.X = left / right.X;
+            right.Y = left / right.Y;
+            right.Z = left / right.Z;
+            right.W = left / right.W;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -2123,7 +2123,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Divides an instance by a scalar.
+        /// Divides a scalar by an instance.
         /// </summary>
         /// <param name="scale">The scalar.</param>
         /// <param name="vec">The instance.</param>
@@ -2131,10 +2131,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector4 operator /(float scale, Vector4 vec)
         {
-            vec.X /= scale;
-            vec.Y /= scale;
-            vec.Z /= scale;
-            vec.W /= scale;
+            vec.X = scale / vec.X;
+            vec.Y = scale / vec.Y;
+            vec.Z = scale / vec.Z;
+            vec.W = scale / vec.W;
             return vec;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -2111,9 +2111,25 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">The instance.</param>
         /// <param name="scale">The scalar.</param>
-        /// <returns>The result of the calculation.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector4 operator /(Vector4 vec, float scale)
+        {
+            vec.X /= scale;
+            vec.Y /= scale;
+            vec.Z /= scale;
+            vec.W /= scale;
+            return vec;
+        }
+
+        /// <summary>
+        /// Divides an instance by a scalar.
+        /// </summary>
+        /// <param name="scale">The scalar.</param>
+        /// <param name="vec">The instance.</param>
+        /// <returns>Result of division.</returns>
+        [Pure]
+        public static Vector4 operator /(float scale, Vector4 vec)
         {
             vec.X /= scale;
             vec.Y /= scale;
@@ -2127,7 +2143,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of the division.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector4 operator /(Vector4 vec, Vector4 scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -329,7 +329,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
-        /// <returns>Result of subtraction.</returns>
+        /// <returns>Result of the subtraction.</returns>
         [Pure]
         public static Vector4 Subtract(Vector4 a, Vector4 b)
         {
@@ -2056,7 +2056,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="scale">Left operand.</param>
         /// <param name="vec">Right operand.</param>
-        /// <returns>Result of multiplication.</returns>
+        /// <returns>Result of the multiplication.</returns>
         [Pure]
         public static Vector4 operator *(Vector4 vec, Vector4 scale)
         {
@@ -2111,7 +2111,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">The instance.</param>
         /// <param name="scale">The scalar.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector4 operator /(Vector4 vec, float scale)
         {
@@ -2143,7 +2143,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector4 operator /(Vector4 vec, Vector4 scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -2106,9 +2106,25 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">The instance.</param>
         /// <param name="scale">The scalar.</param>
-        /// <returns>The result of the calculation.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector4d operator /(Vector4d vec, double scale)
+        {
+            vec.X /= scale;
+            vec.Y /= scale;
+            vec.Z /= scale;
+            vec.W /= scale;
+            return vec;
+        }
+
+        /// <summary>
+        /// Divides an instance by a scalar.
+        /// </summary>
+        /// <param name="scale">The scalar.</param>
+        /// <param name="vec">The instance.</param>
+        /// <returns>Result of division.</returns>
+        [Pure]
+        public static Vector4d operator /(double scale, Vector4d vec)
         {
             vec.X /= scale;
             vec.Y /= scale;
@@ -2122,7 +2138,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of the division.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector4d operator /(Vector4d vec, Vector4d scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -328,7 +328,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
-        /// <returns>Result of subtraction.</returns>
+        /// <returns>Result of the subtraction.</returns>
         [Pure]
         public static Vector4d Subtract(Vector4d a, Vector4d b)
         {
@@ -2051,7 +2051,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="scale">Left operand.</param>
         /// <param name="vec">Right operand.</param>
-        /// <returns>Result of multiplication.</returns>
+        /// <returns>Result of the multiplication.</returns>
         [Pure]
         public static Vector4d operator *(Vector4d vec, Vector4d scale)
         {
@@ -2106,7 +2106,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">The instance.</param>
         /// <param name="scale">The scalar.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector4d operator /(Vector4d vec, double scale)
         {
@@ -2138,7 +2138,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector4d operator /(Vector4d vec, Vector4d scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -2120,17 +2120,17 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Divides a scalar by an instance.
         /// </summary>
-        /// <param name="scale">The scalar.</param>
-        /// <param name="vec">The instance.</param>
-        /// <returns>Result of division.</returns>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>Result of the division.</returns>
         [Pure]
-        public static Vector4d operator /(double scale, Vector4d vec)
+        public static Vector4d operator /(double left, Vector4d right)
         {
-            vec.X = scale / vec.X;
-            vec.Y = scale / vec.Y;
-            vec.Z = scale / vec.Z;
-            vec.W = scale / vec.W;
-            return vec;
+            right.X = left / right.X;
+            right.Y = left / right.Y;
+            right.Z = left / right.Z;
+            right.W = left / right.W;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -2118,7 +2118,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Divides an instance by a scalar.
+        /// Divides a scalar by an instance.
         /// </summary>
         /// <param name="scale">The scalar.</param>
         /// <param name="vec">The instance.</param>
@@ -2126,10 +2126,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector4d operator /(double scale, Vector4d vec)
         {
-            vec.X /= scale;
-            vec.Y /= scale;
-            vec.Z /= scale;
-            vec.W /= scale;
+            vec.X = scale / vec.X;
+            vec.Y = scale / vec.Y;
+            vec.Z = scale / vec.Z;
+            vec.W = scale / vec.W;
             return vec;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -1599,7 +1599,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Divides the instance by a scalar using integer division, floor(a/b).
+        /// Divides a scalar by the instance using integer division, floor(a/b).
         /// </summary>
         /// <param name="scale">The scalar.</param>
         /// <param name="vec">The instance.</param>
@@ -1607,10 +1607,10 @@ namespace OpenTK.Mathematics
         [Pure]
         public static Vector4i operator /(int scale, Vector4i vec)
         {
-            vec.X /= scale;
-            vec.Y /= scale;
-            vec.Z /= scale;
-            vec.W /= scale;
+            vec.X = scale / vec.X;
+            vec.Y = scale / vec.Y;
+            vec.Z = scale / vec.Z;
+            vec.W = scale / vec.W;
             return vec;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -1587,9 +1587,25 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">The instance.</param>
         /// <param name="scale">The scalar.</param>
-        /// <returns>The result of the calculation.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector4i operator /(Vector4i vec, int scale)
+        {
+            vec.X /= scale;
+            vec.Y /= scale;
+            vec.Z /= scale;
+            vec.W /= scale;
+            return vec;
+        }
+
+        /// <summary>
+        /// Divides the instance by a scalar using integer division, floor(a/b).
+        /// </summary>
+        /// <param name="scale">The scalar.</param>
+        /// <param name="vec">The instance.</param>
+        /// <returns>Result of division.</returns>
+        [Pure]
+        public static Vector4i operator /(int scale, Vector4i vec)
         {
             vec.X /= scale;
             vec.Y /= scale;
@@ -1603,7 +1619,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of the division.</returns>
+        /// <returns>Result of division.</returns>
         [Pure]
         public static Vector4i operator /(Vector4i vec, Vector4i scale)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -1601,17 +1601,17 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Divides a scalar by the instance using integer division, floor(a/b).
         /// </summary>
-        /// <param name="scale">The scalar.</param>
-        /// <param name="vec">The instance.</param>
-        /// <returns>Result of division.</returns>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>Result of the division.</returns>
         [Pure]
-        public static Vector4i operator /(int scale, Vector4i vec)
+        public static Vector4i operator /(int left, Vector4i right)
         {
-            vec.X = scale / vec.X;
-            vec.Y = scale / vec.Y;
-            vec.Z = scale / vec.Z;
-            vec.W = scale / vec.W;
-            return vec;
+            right.X = left / right.X;
+            right.Y = left / right.Y;
+            right.Z = left / right.Z;
+            right.W = left / right.W;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -253,7 +253,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="a">First operand.</param>
         /// <param name="b">Second operand.</param>
-        /// <returns>Result of subtraction.</returns>
+        /// <returns>Result of the subtraction.</returns>
         [Pure]
         public static Vector4i Subtract(Vector4i a, Vector4i b)
         {
@@ -1571,7 +1571,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="scale">Left operand.</param>
         /// <param name="vec">Right operand.</param>
-        /// <returns>Result of multiplication.</returns>
+        /// <returns>Result of the multiplication.</returns>
         [Pure]
         public static Vector4i operator *(Vector4i vec, Vector4i scale)
         {
@@ -1587,7 +1587,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">The instance.</param>
         /// <param name="scale">The scalar.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector4i operator /(Vector4i vec, int scale)
         {
@@ -1619,7 +1619,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="vec">Left operand.</param>
         /// <param name="scale">Right operand.</param>
-        /// <returns>Result of division.</returns>
+        /// <returns>Result of the division.</returns>
         [Pure]
         public static Vector4i operator /(Vector4i vec, Vector4i scale)
         {


### PR DESCRIPTION
### Purpose of this PR

Add `scalar / vector` operators to all Vector types.
We already support `vector / scalar` or `scalar * vector` and GLSL has it too so it makes sense to add.

In the future I want to add the same for + and - in both directions, then this is complete in some sense and we have more parity with GLSL. 