### PR TITLE
[5.0] Add `scalar + vector` and `scalar - vector` in both directions

### DIFF
--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -975,6 +975,34 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector2 operator +(Vector2 left, float right)
+        {
+            left.X += right;
+            left.Y += right;
+            return left;
+        }
+
+        /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector2 operator +(float left, Vector2 right)
+        {
+            right.X += left;
+            right.Y += left;
+            return right;
+        }
+
+        /// <summary>
         /// Adds the specified instances.
         /// </summary>
         /// <param name="left">Left operand.</param>
@@ -986,6 +1014,34 @@ namespace OpenTK.Mathematics
             left.X += right.X;
             left.Y += right.Y;
             return left;
+        }
+
+        /// <summary>
+        /// Subtracts an instance by scalar.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector2 operator -(Vector2 left, float right)
+        {
+            left.X -= right;
+            left.Y -= right;
+            return left;
+        }
+
+        /// <summary>
+        /// Subtracts a scalar by an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector2 operator -(float left, Vector2 right)
+        {
+            right.X = left - right.X;
+            right.Y = left - right.Y;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -1017,7 +1017,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Subtracts an instance by scalar.
+        /// Subtracts an instance by a scalar.
         /// </summary>
         /// <param name="left">The instance.</param>
         /// <param name="right">The scalar.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -948,6 +948,34 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector2d operator +(Vector2d left, double right)
+        {
+            left.X += right;
+            left.Y += right;
+            return left;
+        }
+
+        /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector2d operator +(double left, Vector2d right)
+        {
+            right.X += left;
+            right.Y += left;
+            return right;
+        }
+
+        /// <summary>
         /// Adds two instances.
         /// </summary>
         /// <param name="left">The left instance.</param>
@@ -959,6 +987,34 @@ namespace OpenTK.Mathematics
             left.X += right.X;
             left.Y += right.Y;
             return left;
+        }
+
+        /// <summary>
+        /// Subtracts an instance by scalar.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector2d operator -(Vector2d left, double right)
+        {
+            left.X -= right;
+            left.Y -= right;
+            return left;
+        }
+
+        /// <summary>
+        /// Subtracts a scalar by an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector2d operator -(double left, Vector2d right)
+        {
+            right.X = left - right.X;
+            right.Y = left - right.Y;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -990,7 +990,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Subtracts an instance by scalar.
+        /// Subtracts an instance by a scalar.
         /// </summary>
         /// <param name="left">The instance.</param>
         /// <param name="right">The scalar.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -445,6 +445,34 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector2i operator +(Vector2i left, int right)
+        {
+            left.X += right;
+            left.Y += right;
+            return left;
+        }
+
+        /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector2i operator +(int left, Vector2i right)
+        {
+            right.X += left;
+            right.Y += left;
+            return right;
+        }
+
+        /// <summary>
         /// Adds the specified instances.
         /// </summary>
         /// <param name="left">Left operand.</param>
@@ -456,6 +484,34 @@ namespace OpenTK.Mathematics
             left.X += right.X;
             left.Y += right.Y;
             return left;
+        }
+
+        /// <summary>
+        /// Subtracts an instance by scalar.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector2i operator -(Vector2i left, int right)
+        {
+            left.X -= right;
+            left.Y -= right;
+            return left;
+        }
+
+        /// <summary>
+        /// Subtracts a scalar by an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector2i operator -(int left, Vector2i right)
+        {
+            right.X = left - right.X;
+            right.Y = left - right.Y;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -487,7 +487,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Subtracts an instance by scalar.
+        /// Subtracts an instance by a scalar.
         /// </summary>
         /// <param name="left">The instance.</param>
         /// <param name="right">The scalar.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -1511,6 +1511,34 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector3 operator +(Vector3 left, float right)
+        {
+            left.X += right;
+            left.Y += right;
+            return left;
+        }
+
+        /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector3 operator +(float left, Vector3 right)
+        {
+            right.X += left;
+            right.Y += left;
+            return right;
+        }
+
+        /// <summary>
         /// Adds two instances.
         /// </summary>
         /// <param name="left">The first instance.</param>
@@ -1523,6 +1551,34 @@ namespace OpenTK.Mathematics
             left.Y += right.Y;
             left.Z += right.Z;
             return left;
+        }
+
+        /// <summary>
+        /// Subtracts an instance by scalar.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector3 operator -(Vector3 left, float right)
+        {
+            left.X -= right;
+            left.Y -= right;
+            return left;
+        }
+
+        /// <summary>
+        /// Subtracts a scalar by an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector3 operator -(float left, Vector3 right)
+        {
+            right.X = left - right.X;
+            right.Y = left - right.Y;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -1556,7 +1556,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Subtracts an instance by scalar.
+        /// Subtracts an instance by a scalar.
         /// </summary>
         /// <param name="left">The instance.</param>
         /// <param name="right">The scalar.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -1521,6 +1521,7 @@ namespace OpenTK.Mathematics
         {
             left.X += right;
             left.Y += right;
+            left.Z += right;
             return left;
         }
 
@@ -1535,6 +1536,7 @@ namespace OpenTK.Mathematics
         {
             right.X += left;
             right.Y += left;
+            right.Z += left;
             return right;
         }
 
@@ -1564,6 +1566,7 @@ namespace OpenTK.Mathematics
         {
             left.X -= right;
             left.Y -= right;
+            left.Z -= right;
             return left;
         }
 
@@ -1578,6 +1581,7 @@ namespace OpenTK.Mathematics
         {
             right.X = left - right.X;
             right.Y = left - right.Y;
+            right.Z = left - right.Z;
             return right;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -1377,6 +1377,34 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector3d operator +(Vector3d left, double right)
+        {
+            left.X += right;
+            left.Y += right;
+            return left;
+        }
+
+        /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector3d operator +(double left, Vector3d right)
+        {
+            right.X += left;
+            right.Y += left;
+            return right;
+        }
+
+        /// <summary>
         /// Adds two instances.
         /// </summary>
         /// <param name="left">The first instance.</param>
@@ -1389,6 +1417,34 @@ namespace OpenTK.Mathematics
             left.Y += right.Y;
             left.Z += right.Z;
             return left;
+        }
+
+        /// <summary>
+        /// Subtracts an instance by scalar.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector3d operator -(Vector3d left, double right)
+        {
+            left.X -= right;
+            left.Y -= right;
+            return left;
+        }
+
+        /// <summary>
+        /// Subtracts a scalar by an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector3d operator -(double left, Vector3d right)
+        {
+            right.X = left - right.X;
+            right.Y = left - right.Y;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -1422,7 +1422,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Subtracts an instance by scalar.
+        /// Subtracts an instance by a scalar.
         /// </summary>
         /// <param name="left">The instance.</param>
         /// <param name="right">The scalar.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -1387,6 +1387,7 @@ namespace OpenTK.Mathematics
         {
             left.X += right;
             left.Y += right;
+            left.Z += right;
             return left;
         }
 
@@ -1401,6 +1402,7 @@ namespace OpenTK.Mathematics
         {
             right.X += left;
             right.Y += left;
+            right.Z += left;
             return right;
         }
 
@@ -1430,6 +1432,7 @@ namespace OpenTK.Mathematics
         {
             left.X -= right;
             left.Y -= right;
+            left.Z -= right;
             return left;
         }
 
@@ -1444,6 +1447,7 @@ namespace OpenTK.Mathematics
         {
             right.X = left - right.X;
             right.Y = left - right.Y;
+            right.Z = left - right.Z;
             return right;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -643,6 +643,7 @@ namespace OpenTK.Mathematics
         {
             left.X += right;
             left.Y += right;
+            left.Z += right;
             return left;
         }
 
@@ -657,6 +658,7 @@ namespace OpenTK.Mathematics
         {
             right.X += left;
             right.Y += left;
+            right.Z += left;
             return right;
         }
 
@@ -686,6 +688,7 @@ namespace OpenTK.Mathematics
         {
             left.X -= right;
             left.Y -= right;
+            left.Z -= right;
             return left;
         }
 
@@ -700,6 +703,7 @@ namespace OpenTK.Mathematics
         {
             right.X = left - right.X;
             right.Y = left - right.Y;
+            right.Z = left - right.Z;
             return right;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -633,6 +633,34 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector3i operator +(Vector3i left, int right)
+        {
+            left.X += right;
+            left.Y += right;
+            return left;
+        }
+
+        /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector3i operator +(int left, Vector3i right)
+        {
+            right.X += left;
+            right.Y += left;
+            return right;
+        }
+
+        /// <summary>
         /// Adds two instances.
         /// </summary>
         /// <param name="left">The first instance.</param>
@@ -645,6 +673,34 @@ namespace OpenTK.Mathematics
             left.Y += right.Y;
             left.Z += right.Z;
             return left;
+        }
+
+        /// <summary>
+        /// Subtracts an instance by scalar.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector3i operator -(Vector3i left, int right)
+        {
+            left.X -= right;
+            left.Y -= right;
+            return left;
+        }
+
+        /// <summary>
+        /// Subtracts a scalar by an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector3i operator -(int left, Vector3i right)
+        {
+            right.X = left - right.X;
+            right.Y = left - right.Y;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -678,7 +678,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Subtracts an instance by scalar.
+        /// Subtracts an instance by a scalar.
         /// </summary>
         /// <param name="left">The instance.</param>
         /// <param name="right">The scalar.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -2021,7 +2021,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Subtracts an instance by scalar.
+        /// Subtracts an instance by a scalar.
         /// </summary>
         /// <param name="left">The instance.</param>
         /// <param name="right">The scalar.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -1973,6 +1973,34 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector4 operator +(Vector4 left, float right)
+        {
+            left.X += right;
+            left.Y += right;
+            return left;
+        }
+
+        /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector4 operator +(float left, Vector4 right)
+        {
+            right.X += left;
+            right.Y += left;
+            return right;
+        }
+
+        /// <summary>
         /// Adds two instances.
         /// </summary>
         /// <param name="left">The first instance.</param>
@@ -1986,6 +2014,34 @@ namespace OpenTK.Mathematics
             left.Z += right.Z;
             left.W += right.W;
             return left;
+        }
+
+        /// <summary>
+        /// Subtracts an instance by scalar.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector4 operator -(Vector4 left, float right)
+        {
+            left.X -= right;
+            left.Y -= right;
+            return left;
+        }
+
+        /// <summary>
+        /// Subtracts a scalar by an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector4 operator -(float left, Vector4 right)
+        {
+            right.X = left - right.X;
+            right.Y = left - right.Y;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -1983,6 +1983,8 @@ namespace OpenTK.Mathematics
         {
             left.X += right;
             left.Y += right;
+            left.Z += right;
+            left.W += right;
             return left;
         }
 
@@ -1997,6 +1999,8 @@ namespace OpenTK.Mathematics
         {
             right.X += left;
             right.Y += left;
+            right.Z += left;
+            right.W += left;
             return right;
         }
 
@@ -2027,6 +2031,8 @@ namespace OpenTK.Mathematics
         {
             left.X -= right;
             left.Y -= right;
+            left.Z -= right;
+            left.W -= right;
             return left;
         }
 
@@ -2041,6 +2047,8 @@ namespace OpenTK.Mathematics
         {
             right.X = left - right.X;
             right.Y = left - right.Y;
+            right.Z = left - right.Z;
+            right.W = left - right.W;
             return right;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -2016,7 +2016,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Subtracts an instance by scalar.
+        /// Subtracts an instance by a scalar.
         /// </summary>
         /// <param name="left">The instance.</param>
         /// <param name="right">The scalar.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -1978,6 +1978,8 @@ namespace OpenTK.Mathematics
         {
             left.X += right;
             left.Y += right;
+            left.Z += right;
+            left.W += right;
             return left;
         }
 
@@ -1992,6 +1994,8 @@ namespace OpenTK.Mathematics
         {
             right.X += left;
             right.Y += left;
+            right.Z += left;
+            right.W += left;
             return right;
         }
 
@@ -2022,6 +2026,8 @@ namespace OpenTK.Mathematics
         {
             left.X -= right;
             left.Y -= right;
+            left.Z -= right;
+            left.W -= right;
             return left;
         }
 
@@ -2036,6 +2042,8 @@ namespace OpenTK.Mathematics
         {
             right.X = left - right.X;
             right.Y = left - right.Y;
+            right.Z = left - right.Z;
+            right.W = left - right.W;
             return right;
         }
 

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -1968,6 +1968,34 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector4d operator +(Vector4d left, double right)
+        {
+            left.X += right;
+            left.Y += right;
+            return left;
+        }
+
+        /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector4d operator +(double left, Vector4d right)
+        {
+            right.X += left;
+            right.Y += left;
+            return right;
+        }
+
+        /// <summary>
         /// Adds two instances.
         /// </summary>
         /// <param name="left">The first instance.</param>
@@ -1981,6 +2009,34 @@ namespace OpenTK.Mathematics
             left.Z += right.Z;
             left.W += right.W;
             return left;
+        }
+
+        /// <summary>
+        /// Subtracts an instance by scalar.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector4d operator -(Vector4d left, double right)
+        {
+            left.X -= right;
+            left.Y -= right;
+            return left;
+        }
+
+        /// <summary>
+        /// Subtracts a scalar by an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector4d operator -(double left, Vector4d right)
+        {
+            right.X = left - right.X;
+            right.Y = left - right.Y;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -1488,6 +1488,34 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector4i operator +(Vector4i left, int right)
+        {
+            left.X += right;
+            left.Y += right;
+            return left;
+        }
+
+        /// <summary>
+        /// Adds a scalar to an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector4i operator +(int left, Vector4i right)
+        {
+            right.X += left;
+            right.Y += left;
+            return right;
+        }
+
+        /// <summary>
         /// Adds two instances.
         /// </summary>
         /// <param name="left">The first instance.</param>
@@ -1501,6 +1529,34 @@ namespace OpenTK.Mathematics
             left.Z += right.Z;
             left.W += right.W;
             return left;
+        }
+
+        /// <summary>
+        /// Subtracts an instance by scalar.
+        /// </summary>
+        /// <param name="left">The instance.</param>
+        /// <param name="right">The scalar.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector4i operator -(Vector4i left, int right)
+        {
+            left.X -= right;
+            left.Y -= right;
+            return left;
+        }
+
+        /// <summary>
+        /// Subtracts a scalar by an instance.
+        /// </summary>
+        /// <param name="left">The scalar.</param>
+        /// <param name="right">The instance.</param>
+        /// <returns>The result of the operation.</returns>
+        [Pure]
+        public static Vector4i operator -(int left, Vector4i right)
+        {
+            right.X = left - right.X;
+            right.Y = left - right.Y;
+            return right;
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -1536,7 +1536,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Subtracts an instance by scalar.
+        /// Subtracts an instance by a scalar.
         /// </summary>
         /// <param name="left">The instance.</param>
         /// <param name="right">The scalar.</param>

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -1498,6 +1498,8 @@ namespace OpenTK.Mathematics
         {
             left.X += right;
             left.Y += right;
+            left.Z += right;
+            left.W += right;
             return left;
         }
 
@@ -1512,6 +1514,8 @@ namespace OpenTK.Mathematics
         {
             right.X += left;
             right.Y += left;
+            right.Z += left;
+            right.W += left;
             return right;
         }
 
@@ -1542,6 +1546,8 @@ namespace OpenTK.Mathematics
         {
             left.X -= right;
             left.Y -= right;
+            left.Z -= right;
+            left.W -= right;
             return left;
         }
 
@@ -1556,6 +1562,8 @@ namespace OpenTK.Mathematics
         {
             right.X = left - right.X;
             right.Y = left - right.Y;
+            right.Z = left - right.Z;
+            right.W = left - right.W;
             return right;
         }
 


### PR DESCRIPTION
### Purpose of this PR

Add the remaining missing operators between scalar and vectors. Should all behave like GLSL now.
For example we can now write:
```cs
Vector3 uv = ...
Vector3 ndc = uv * 2.0f - 1.0f; 
```
```cs
Vector3 ndc = ...
Vector3 uv = ndc * 0.5f + 0.5f;
```
