### PR TITLE
[5.0] Fix missing `readonly` in math lib

### DIFF
--- a/src/OpenTK.Mathematics/Colors/Color3.cs
+++ b/src/OpenTK.Mathematics/Colors/Color3.cs
@@ -80,7 +80,7 @@ namespace OpenTK.Mathematics
         /// <param name="n">The nth element to get.</param>
         public float this[int n]
         {
-            get
+            readonly get
             {
                 // the old-style switch compiles to slightly smaller IL than the newer one,
                 // so is used here for performance.
@@ -139,7 +139,7 @@ namespace OpenTK.Mathematics
         /// <param name="y">The y component of this color, defined by the color space.</param>
         /// <param name="z">The z component of this color, defined by the color space.</param>
         [Pure]
-        public void Deconstruct(out float x, out float y, out float z)
+        public readonly void Deconstruct(out float x, out float y, out float z)
         {
             x = X;
             y = Y;
@@ -176,7 +176,7 @@ namespace OpenTK.Mathematics
         /// <param name="other">The Color3 structure to compare to.</param>
         /// <returns>True if both Color3 structures contain the same components; false otherwise.</returns>
         [Pure]
-        public bool Equals(Color3<T> other)
+        public readonly bool Equals(Color3<T> other)
         {
             return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z);
         }
@@ -186,7 +186,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <returns>A <see cref="string"/> that describes this Color4 structure.</returns>
         [Pure]
-        public override string ToString()
+        public override readonly string ToString()
         {
             return $"({X}, {Y}, {Z})";
         }
@@ -197,7 +197,7 @@ namespace OpenTK.Mathematics
         /// <param name="obj">An object to compare to.</param>
         /// <returns>True obj is a Color4 structure with the same components as this Color4; false otherwise.</returns>
         [Pure]
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Color3<T> other && Equals(other);
         }
@@ -207,7 +207,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <returns>A System.Int32 containing the hashcode of this Color4 structure.</returns>
         [Pure]
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             unchecked
             {

--- a/src/OpenTK.Mathematics/Colors/Color4.cs
+++ b/src/OpenTK.Mathematics/Colors/Color4.cs
@@ -95,7 +95,7 @@ namespace OpenTK.Mathematics
         /// <param name="n">The nth element to get.</param>
         public float this[int n]
         {
-            get
+            readonly get
             {
                 // the old-style switch compiles to slightly smaller IL than the newer one,
                 // so is used here for performance.
@@ -160,7 +160,7 @@ namespace OpenTK.Mathematics
         /// <param name="z">The z component of this color, defined by the color space.</param>
         /// <param name="w">The w component of this color, defined by the color space.</param>
         [Pure]
-        public void Deconstruct(out float x, out float y, out float z, out float w)
+        public readonly void Deconstruct(out float x, out float y, out float z, out float w)
         {
             x = X;
             y = Y;
@@ -198,7 +198,7 @@ namespace OpenTK.Mathematics
         /// <param name="other">The Color4 structure to compare to.</param>
         /// <returns>True if both Color4 structures contain the same components; false otherwise.</returns>
         [Pure]
-        public bool Equals(Color4<T> other)
+        public readonly bool Equals(Color4<T> other)
         {
             return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z) && W.Equals(other.W);
         }
@@ -208,7 +208,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <returns>A <see cref="string"/> that describes this Color4 structure.</returns>
         [Pure]
-        public override string ToString()
+        public override readonly string ToString()
         {
             return $"({X}, {Y}, {Z}, {W})";
         }
@@ -219,7 +219,7 @@ namespace OpenTK.Mathematics
         /// <param name="obj">An object to compare to.</param>
         /// <returns>True obj is a Color4 structure with the same components as this Color4; false otherwise.</returns>
         [Pure]
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Color4<T> other && Equals(other);
         }
@@ -229,7 +229,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <returns>A System.Int32 containing the hashcode of this Color4 structure.</returns>
         [Pure]
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             unchecked
             {

--- a/src/OpenTK.Mathematics/Geometry/BezierCurveCubic.cs
+++ b/src/OpenTK.Mathematics/Geometry/BezierCurveCubic.cs
@@ -100,7 +100,7 @@ namespace OpenTK.Mathematics
         /// <param name="t">The t value, between 0.0f and 1.0f.</param>
         /// <returns>Resulting point.</returns>
         [Pure]
-        public Vector2 CalculatePoint(float t)
+        public readonly Vector2 CalculatePoint(float t)
         {
             var c = 1.0f - t;
 
@@ -159,7 +159,7 @@ namespace OpenTK.Mathematics
         /// value gets smaller.
         /// </remarks>
         [Pure]
-        public float CalculateLength(float precision)
+        public readonly float CalculateLength(float precision)
         {
             var length = 0.0f;
             var old = CalculatePoint(0.0f);

--- a/src/OpenTK.Mathematics/Geometry/Box2.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2.cs
@@ -95,7 +95,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector2 CenteredSize
         {
-            get => Max - Min;
+            readonly get => Max - Min;
             set
             {
                 Vector2 center = Center;
@@ -110,7 +110,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector2 HalfSize
         {
-            get => CenteredSize / 2;
+            readonly get => CenteredSize / 2;
             set => CenteredSize = value * 2;
         }
 
@@ -120,7 +120,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector2 Center
         {
-            get => HalfSize + _min;
+            readonly get => HalfSize + _min;
             set => Translate(value - Center);
         }
 
@@ -131,7 +131,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Width
         {
-            get => _max.X - _min.X;
+            readonly get => _max.X - _min.X;
             set => _max.X = _min.X + value;
         }
 
@@ -140,7 +140,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Height
         {
-            get => _max.Y - _min.Y;
+            readonly get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
         }
 
@@ -149,7 +149,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Left
         {
-            get => _min.X;
+            readonly get => _min.X;
             set => _min.X = value;
         }
 
@@ -158,7 +158,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Top
         {
-            get => _min.Y;
+            readonly get => _min.Y;
             set => _min.Y = value;
         }
 
@@ -167,7 +167,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Right
         {
-            get => _max.X;
+            readonly get => _max.X;
             set => _max.X = value;
         }
 
@@ -176,7 +176,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Bottom
         {
-            get => _max.Y;
+            readonly get => _max.Y;
             set => _max.Y = value;
         }
 
@@ -185,7 +185,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float X
         {
-            get => _min.X;
+            readonly get => _min.X;
             set => _min.X = value;
         }
 
@@ -194,7 +194,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Y
         {
-            get => _min.Y;
+            readonly get => _min.Y;
             set => _min.Y = value;
         }
 
@@ -203,7 +203,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float SizeX
         {
-            get => _max.X - _min.X;
+            readonly get => _max.X - _min.X;
             set => _max.X = _min.X + value;
         }
 
@@ -212,7 +212,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float SizeY
         {
-            get => _max.Y - _min.Y;
+            readonly get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
         }
 
@@ -221,7 +221,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector2 Size
         {
-            get => new Vector2(_max.X - _min.X, _max.Y - _min.Y);
+            readonly get => new Vector2(_max.X - _min.X, _max.Y - _min.Y);
             set
             {
                 _max.X = _min.X + value.X;
@@ -232,12 +232,12 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets the location of the box.
         /// </summary>
-        public Vector2 Location => _min;
+        public readonly Vector2 Location => _min;
 
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
+        public readonly bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
 
         /// <summary>
         /// Gets a box with all components zero.
@@ -323,7 +323,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box with which to intersect.</param>
         /// <returns>The intersection of itself and the specified Box.</returns>
-        public Box2 Intersected(Box2 other)
+        public readonly Box2 Intersected(Box2 other)
         {
             return Intersect(other, this);
         }
@@ -333,7 +333,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box to test.</param>
         /// <returns>This method returns true if there is any intersection, otherwise false.</returns>
-        public bool IntersectsWith(Box2 other)
+        public readonly bool IntersectsWith(Box2 other)
         {
             return other._min.X < _max.X
                 && _min.X < other._max.X
@@ -346,7 +346,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box to test.</param>
         /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
-        public bool TouchWith(Box2 other)
+        public readonly bool TouchWith(Box2 other)
         {
             return other._min.X <= _max.X
                 && _min.X <= other._max.X
@@ -462,7 +462,7 @@ namespace OpenTK.Mathematics
         /// </param>
         /// <returns>Whether this box contains the point.</returns>
         [Pure]
-        public bool Contains(Vector2 point, bool boundaryInclusive)
+        public readonly bool Contains(Vector2 point, bool boundaryInclusive)
         {
             if (boundaryInclusive)
             {
@@ -634,13 +634,13 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Box2 && Equals((Box2)obj);
         }
 
         /// <inheritdoc/>
-        public bool Equals(Box2 other)
+        public readonly bool Equals(Box2 other)
         {
             return _min.Equals(other._min) &&
                    _max.Equals(other._max);
@@ -653,25 +653,25 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
 
         /// <inheritdoc/>
-        public string ToString(string format, IFormatProvider formatProvider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
             return $"{Min.ToString(format, formatProvider)} - {Max.ToString(format, formatProvider)}";
         }

--- a/src/OpenTK.Mathematics/Geometry/Box2d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2d.cs
@@ -95,7 +95,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector2d CenteredSize
         {
-            get => Max - Min;
+            readonly get => Max - Min;
             set
             {
                 Vector2d center = Center;
@@ -110,7 +110,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector2d HalfSize
         {
-            get => CenteredSize / 2;
+            readonly get => CenteredSize / 2;
             set => CenteredSize = value * 2;
         }
 
@@ -120,7 +120,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector2d Center
         {
-            get => HalfSize + _min;
+            readonly get => HalfSize + _min;
             set => Translate(value - Center);
         }
 
@@ -131,7 +131,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Width
         {
-            get => _max.X - _min.X;
+            readonly get => _max.X - _min.X;
             set => _max.X = _min.X + value;
         }
 
@@ -140,7 +140,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Height
         {
-            get => _max.Y - _min.Y;
+            readonly get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
         }
 
@@ -149,7 +149,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Left
         {
-            get => _min.X;
+            readonly get => _min.X;
             set => _min.X = value;
         }
 
@@ -158,7 +158,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Top
         {
-            get => _min.Y;
+            readonly get => _min.Y;
             set => _min.Y = value;
         }
 
@@ -167,7 +167,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Right
         {
-            get => _max.X;
+            readonly get => _max.X;
             set => _max.X = value;
         }
 
@@ -176,7 +176,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Bottom
         {
-            get => _max.Y;
+            readonly get => _max.Y;
             set => _max.Y = value;
         }
 
@@ -185,7 +185,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double X
         {
-            get => _min.X;
+            readonly get => _min.X;
             set => _min.X = value;
         }
 
@@ -194,7 +194,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Y
         {
-            get => _min.Y;
+            readonly get => _min.Y;
             set => _min.Y = value;
         }
 
@@ -203,7 +203,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double SizeX
         {
-            get => _max.X - _min.X;
+            readonly get => _max.X - _min.X;
             set => _max.X = _min.X + value;
         }
 
@@ -212,7 +212,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double SizeY
         {
-            get => _max.Y - _min.Y;
+            readonly get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
         }
 
@@ -221,7 +221,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector2d Size
         {
-            get => new Vector2d(_max.X - _min.X, _max.Y - _min.Y);
+            readonly get => new Vector2d(_max.X - _min.X, _max.Y - _min.Y);
             set
             {
                 _max.X = _min.X + value.X;
@@ -232,12 +232,12 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets the location of the box.
         /// </summary>
-        public Vector2d Location => _min;
+        public readonly Vector2d Location => _min;
 
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
+        public readonly bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
 
         /// <summary>
         /// Gets a box with all components zero.
@@ -323,7 +323,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box with which to intersect.</param>
         /// <returns>The intersection of itself and the specified Box.</returns>
-        public Box2d Intersected(Box2d other)
+        public readonly Box2d Intersected(Box2d other)
         {
             return Intersect(other, this);
         }
@@ -333,7 +333,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box to test.</param>
         /// <returns>This method returns true if there is any intersection, otherwise false.</returns>
-        public bool IntersectsWith(Box2d other)
+        public readonly bool IntersectsWith(Box2d other)
         {
             return other._min.X < _max.X
                 && _min.X < other._max.X
@@ -346,7 +346,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box to test.</param>
         /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
-        public bool TouchWith(Box2d other)
+        public readonly bool TouchWith(Box2d other)
         {
             return other._min.X <= _max.X
                 && _min.X <= other._max.X
@@ -462,7 +462,7 @@ namespace OpenTK.Mathematics
         /// </param>
         /// <returns>Whether this box contains the point.</returns>
         [Pure]
-        public bool Contains(Vector2d point, bool boundaryInclusive)
+        public readonly bool Contains(Vector2d point, bool boundaryInclusive)
         {
             if (boundaryInclusive)
             {
@@ -622,13 +622,13 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Box2d && Equals((Box2d)obj);
         }
 
         /// <inheritdoc/>
-        public bool Equals(Box2d other)
+        public readonly bool Equals(Box2d other)
         {
             return _min.Equals(other._min) &&
                    _max.Equals(other._max);
@@ -641,25 +641,25 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
 
         /// <inheritdoc/>
-        public string ToString(string format, IFormatProvider formatProvider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
             return $"{Min.ToString(format, formatProvider)} - {Max.ToString(format, formatProvider)}";
         }

--- a/src/OpenTK.Mathematics/Geometry/Box2i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box2i.cs
@@ -82,7 +82,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a vector describing the size of the Box2i structure.
         /// </summary>
-        public Vector2i CenteredSize
+        public readonly Vector2i CenteredSize
         {
             get => Max - Min;
         }
@@ -93,7 +93,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector2i HalfSize
         {
-            get => CenteredSize / 2;
+            readonly get => CenteredSize / 2;
             set
             {
                 Vector2i center = new Vector2i((int)Center.X, (int)Center.Y);
@@ -119,7 +119,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Width
         {
-            get => _max.X - _min.X;
+            readonly get => _max.X - _min.X;
             set => _max.X = _min.X + value;
         }
 
@@ -128,7 +128,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Height
         {
-            get => _max.Y - _min.Y;
+            readonly get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
         }
 
@@ -137,7 +137,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Left
         {
-            get => _min.X;
+            readonly get => _min.X;
             set => _min.X = value;
         }
 
@@ -146,7 +146,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Top
         {
-            get => _min.Y;
+            readonly get => _min.Y;
             set => _min.Y = value;
         }
 
@@ -155,7 +155,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Right
         {
-            get => _max.X;
+            readonly get => _max.X;
             set => _max.X = value;
         }
 
@@ -164,7 +164,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Bottom
         {
-            get => _max.Y;
+            readonly get => _max.Y;
             set => _max.Y = value;
         }
 
@@ -173,7 +173,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int X
         {
-            get => _min.X;
+            readonly get => _min.X;
             set => _min.X = value;
         }
 
@@ -182,7 +182,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Y
         {
-            get => _min.Y;
+            readonly get => _min.Y;
             set => _min.Y = value;
         }
 
@@ -191,7 +191,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int SizeX
         {
-            get => _max.X - _min.X;
+            readonly get => _max.X - _min.X;
             set => _max.X = _min.X + value;
         }
 
@@ -200,7 +200,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int SizeY
         {
-            get => _max.Y - _min.Y;
+            readonly get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
         }
 
@@ -209,7 +209,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector2i Size
         {
-            get => new Vector2i(_max.X - _min.X, _max.Y - _min.Y);
+            readonly get => new Vector2i(_max.X - _min.X, _max.Y - _min.Y);
             set
             {
                 _max.X = _min.X + value.X;
@@ -220,12 +220,12 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets the location of the box.
         /// </summary>
-        public Vector2i Location => _min;
+        public readonly Vector2i Location => _min;
 
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
+        public readonly bool IsZero => _min.X == 0 && _min.Y == 0 && _max.X == 0 && _max.Y == 0;
 
         /// <summary>
         /// Gets a box with a location 0,0 with the a size of 1.
@@ -286,7 +286,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box with which to intersect.</param>
         /// <returns>The intersection of itself and the specified Box.</returns>
-        public Box2i Intersected(Box2i other)
+        public readonly Box2i Intersected(Box2i other)
         {
             return Intersect(other, this);
         }
@@ -296,7 +296,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box to test.</param>
         /// <returns>This method returns true if there is any intersection, otherwise false.</returns>
-        public bool IntersectsWith(Box2i other)
+        public readonly bool IntersectsWith(Box2i other)
         {
             return other._min.X < _max.X
                 && _min.X < other._max.X
@@ -309,7 +309,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box to test.</param>
         /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
-        public bool TouchWith(Box2i other)
+        public readonly bool TouchWith(Box2i other)
         {
             return other._min.X <= _max.X
                 && _min.X <= other._max.X
@@ -381,7 +381,7 @@ namespace OpenTK.Mathematics
         /// </param>
         /// <returns>Whether this box contains the point.</returns>
         [Pure]
-        public bool Contains(Vector2i point, bool boundaryInclusive)
+        public readonly bool Contains(Vector2i point, bool boundaryInclusive)
         {
             if (boundaryInclusive)
             {
@@ -573,13 +573,13 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Box2i && Equals((Box2i)obj);
         }
 
         /// <inheritdoc/>
-        public bool Equals(Box2i other)
+        public readonly bool Equals(Box2i other)
         {
             return _min.Equals(other._min) &&
                    _max.Equals(other._max);
@@ -592,25 +592,25 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
 
         /// <inheritdoc/>
-        public string ToString(string format, IFormatProvider formatProvider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
             return $"{Min.ToString(format, formatProvider)} - {Max.ToString(format, formatProvider)}";
         }

--- a/src/OpenTK.Mathematics/Geometry/Box3.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3.cs
@@ -105,7 +105,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector3 CenteredSize
         {
-            get => Max - Min;
+            readonly get => Max - Min;
             set
             {
                 Vector3 center = Center;
@@ -120,7 +120,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector3 HalfSize
         {
-            get => CenteredSize / 2;
+            readonly get => CenteredSize / 2;
             set => CenteredSize = value * 2;
         }
 
@@ -130,7 +130,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector3 Center
         {
-            get => HalfSize + _min;
+            readonly get => HalfSize + _min;
             set => Translate(value - Center);
         }
 
@@ -141,7 +141,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Width
         {
-            get => _max.X - _min.X;
+            readonly get => _max.X - _min.X;
             set => _max.X = _min.X + value;
         }
 
@@ -150,7 +150,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Height
         {
-            get => _max.Y - _min.Y;
+            readonly get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
         }
 
@@ -159,7 +159,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Depth
         {
-            get => _max.Z - _min.Z;
+            readonly get => _max.Z - _min.Z;
             set => _max.Z = _min.Z + value;
         }
 
@@ -168,7 +168,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Left
         {
-            get => _min.X;
+            readonly get => _min.X;
             set => _min.X = value;
         }
 
@@ -177,7 +177,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Top
         {
-            get => _min.Y;
+            readonly get => _min.Y;
             set => _min.Y = value;
         }
 
@@ -186,7 +186,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Right
         {
-            get => _max.X;
+            readonly get => _max.X;
             set => _max.X = value;
         }
 
@@ -195,7 +195,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Bottom
         {
-            get => _max.Y;
+            readonly get => _max.Y;
             set => _max.Y = value;
         }
 
@@ -204,7 +204,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Front
         {
-            get => _min.Z;
+            readonly get => _min.Z;
             set => _min.Z = value;
         }
 
@@ -213,7 +213,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Back
         {
-            get => _max.Z;
+            readonly get => _max.Z;
             set => _max.Z = value;
         }
 
@@ -222,7 +222,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float X
         {
-            get => _min.X;
+            readonly get => _min.X;
             set => _min.X = value;
         }
 
@@ -231,7 +231,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Y
         {
-            get => _min.Y;
+            readonly get => _min.Y;
             set => _min.Y = value;
         }
 
@@ -240,7 +240,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float Z
         {
-            get => _min.Z;
+            readonly get => _min.Z;
             set => _min.Z = value;
         }
 
@@ -249,7 +249,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float SizeX
         {
-            get => _max.X - _min.X;
+            readonly get => _max.X - _min.X;
             set => _max.X = _min.X + value;
         }
 
@@ -258,7 +258,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float SizeY
         {
-            get => _max.Y - _min.Y;
+            readonly get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
         }
 
@@ -267,7 +267,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public float SizeZ
         {
-            get => _max.Z - _min.Z;
+            readonly get => _max.Z - _min.Z;
             set => _max.Z = _min.Z + value;
         }
 
@@ -276,7 +276,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector3 Size
         {
-            get => new Vector3(_max.X - _min.X, _max.Y - _min.Y, _max.Z - _min.Z);
+            readonly get => new Vector3(_max.X - _min.X, _max.Y - _min.Y, _max.Z - _min.Z);
             set
             {
                 _max.X = _min.X + value.X;
@@ -288,12 +288,12 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets the location of the box.
         /// </summary>
-        public Vector3 Location => _min;
+        public readonly Vector3 Location => _min;
 
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
+        public readonly bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
                            && _max.X == 0 && _max.Y == 0 && _max.Z == 0;
 
         /// <summary>
@@ -387,7 +387,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box with which to intersect.</param>
         /// <returns>The intersection of itself and the specified Box.</returns>
-        public Box3 Intersected(Box3 other)
+        public readonly Box3 Intersected(Box3 other)
         {
             return Intersect(other, this);
         }
@@ -397,7 +397,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box to test.</param>
         /// <returns>This method returns true if there is any intersection, otherwise false.</returns>
-        public bool IntersectsWith(Box3 other)
+        public readonly bool IntersectsWith(Box3 other)
         {
             return other._min.X < _max.X
                 && _min.X < other._max.X
@@ -412,7 +412,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box to test.</param>
         /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
-        public bool TouchWith(Box3 other)
+        public readonly bool TouchWith(Box3 other)
         {
             return other._min.X <= _max.X
                 && _min.X <= other._max.X
@@ -541,7 +541,7 @@ namespace OpenTK.Mathematics
         /// </param>
         /// <returns>Whether this box contains the point.</returns>
         [Pure]
-        public bool Contains(Vector3 point, bool boundaryInclusive)
+        public readonly bool Contains(Vector3 point, bool boundaryInclusive)
         {
             if (boundaryInclusive)
             {
@@ -705,7 +705,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Box3 && Equals((Box3)obj);
         }
@@ -724,25 +724,25 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
 
         /// <inheritdoc/>
-        public string ToString(string format, IFormatProvider formatProvider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
             return $"{Min.ToString(format, formatProvider)} - {Max.ToString(format, formatProvider)}";
         }

--- a/src/OpenTK.Mathematics/Geometry/Box3d.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3d.cs
@@ -105,7 +105,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector3d CenteredSize
         {
-            get => Max - Min;
+            readonly get => Max - Min;
             set
             {
                 Vector3d center = Center;
@@ -120,7 +120,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector3d HalfSize
         {
-            get => CenteredSize / 2;
+            readonly get => CenteredSize / 2;
             set => CenteredSize = value * 2;
         }
 
@@ -130,7 +130,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector3d Center
         {
-            get => HalfSize + _min;
+            readonly get => HalfSize + _min;
             set => Translate(value - Center);
         }
 
@@ -141,7 +141,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Width
         {
-            get => _max.X - _min.X;
+            readonly get => _max.X - _min.X;
             set => _max.X = _min.X + value;
         }
 
@@ -150,7 +150,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Height
         {
-            get => _max.Y - _min.Y;
+            readonly get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
         }
 
@@ -159,7 +159,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Depth
         {
-            get => _max.Z - _min.Z;
+            readonly get => _max.Z - _min.Z;
             set => _max.Z = _min.Z + value;
         }
 
@@ -168,7 +168,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Left
         {
-            get => _min.X;
+            readonly get => _min.X;
             set => _min.X = value;
         }
 
@@ -177,7 +177,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Top
         {
-            get => _min.Y;
+            readonly get => _min.Y;
             set => _min.Y = value;
         }
 
@@ -186,7 +186,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Right
         {
-            get => _max.X;
+            readonly get => _max.X;
             set => _max.X = value;
         }
 
@@ -195,7 +195,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Bottom
         {
-            get => _max.Y;
+            readonly get => _max.Y;
             set => _max.Y = value;
         }
 
@@ -204,7 +204,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Front
         {
-            get => _min.Z;
+            readonly get => _min.Z;
             set => _min.Z = value;
         }
 
@@ -213,7 +213,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Back
         {
-            get => _max.Z;
+            readonly get => _max.Z;
             set => _max.Z = value;
         }
 
@@ -222,7 +222,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double X
         {
-            get => _min.X;
+            readonly get => _min.X;
             set => _min.X = value;
         }
 
@@ -231,7 +231,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Y
         {
-            get => _min.Y;
+            readonly get => _min.Y;
             set => _min.Y = value;
         }
 
@@ -240,7 +240,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double Z
         {
-            get => _min.Z;
+            readonly get => _min.Z;
             set => _min.Z = value;
         }
 
@@ -249,7 +249,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double SizeX
         {
-            get => _max.X - _min.X;
+            readonly get => _max.X - _min.X;
             set => _max.X = _min.X + value;
         }
 
@@ -258,7 +258,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double SizeY
         {
-            get => _max.Y - _min.Y;
+            readonly get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
         }
 
@@ -267,7 +267,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public double SizeZ
         {
-            get => _max.Z - _min.Z;
+            readonly get => _max.Z - _min.Z;
             set => _max.Z = _min.Z + value;
         }
 
@@ -276,7 +276,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector3d Size
         {
-            get => new Vector3d(_max.X - _min.X, _max.Y - _min.Y, _max.Z - _min.Z);
+            readonly get => new Vector3d(_max.X - _min.X, _max.Y - _min.Y, _max.Z - _min.Z);
             set
             {
                 _max.X = _min.X + value.X;
@@ -288,12 +288,12 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets the location of the box.
         /// </summary>
-        public Vector3d Location => _min;
+        public readonly Vector3d Location => _min;
 
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
+        public readonly bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
                            && _max.X == 0 && _max.Y == 0 && _max.Z == 0;
 
         /// <summary>
@@ -387,7 +387,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box with which to intersect.</param>
         /// <returns>The intersection of itself and the specified Box.</returns>
-        public Box3d Intersected(Box3d other)
+        public readonly Box3d Intersected(Box3d other)
         {
             return Intersect(other, this);
         }
@@ -397,7 +397,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box to test.</param>
         /// <returns>This method returns true if there is any intersection, otherwise false.</returns>
-        public bool IntersectsWith(Box3d other)
+        public readonly bool IntersectsWith(Box3d other)
         {
             return other._min.X < _max.X
                 && _min.X < other._max.X
@@ -412,7 +412,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box to test.</param>
         /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
-        public bool TouchWith(Box3d other)
+        public readonly bool TouchWith(Box3d other)
         {
             return other._min.X <= _max.X
                 && _min.X <= other._max.X
@@ -541,7 +541,7 @@ namespace OpenTK.Mathematics
         /// </param>
         /// <returns>Whether this box contains the point.</returns>
         [Pure]
-        public bool Contains(Vector3d point, bool boundaryInclusive)
+        public readonly bool Contains(Vector3d point, bool boundaryInclusive)
         {
             if (boundaryInclusive)
             {
@@ -703,13 +703,13 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Box3d && Equals((Box3d)obj);
         }
 
         /// <inheritdoc/>
-        public bool Equals(Box3d other)
+        public readonly bool Equals(Box3d other)
         {
             return _min.Equals(other._min) &&
                    _max.Equals(other._max);
@@ -722,25 +722,25 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
 
         /// <inheritdoc/>
-        public string ToString(string format, IFormatProvider formatProvider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
             return $"{Min.ToString(format, formatProvider)} - {Max.ToString(format, formatProvider)}";
         }

--- a/src/OpenTK.Mathematics/Geometry/Box3i.cs
+++ b/src/OpenTK.Mathematics/Geometry/Box3i.cs
@@ -84,7 +84,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets a vector describing the size of the Box3i structure.
         /// </summary>
-        public Vector3i CenteredSize
+        public readonly Vector3i CenteredSize
         {
             get => Max - Min;
         }
@@ -95,7 +95,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector3i HalfSize
         {
-            get => CenteredSize / 2;
+            readonly get => CenteredSize / 2;
             set
             {
                 Vector3i center = new Vector3i((int)Center.X, (int)Center.Y, (int)Center.Z);
@@ -121,7 +121,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Width
         {
-            get => _max.X - _min.X;
+            readonly get => _max.X - _min.X;
             set => _max.X = _min.X + value;
         }
 
@@ -130,7 +130,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Height
         {
-            get => _max.Y - _min.Y;
+            readonly get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
         }
 
@@ -139,7 +139,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Depth
         {
-            get => _max.Z - _min.Z;
+            readonly get => _max.Z - _min.Z;
             set => _max.Z = _min.Z + value;
         }
 
@@ -148,7 +148,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Left
         {
-            get => _min.X;
+            readonly get => _min.X;
             set => _min.X = value;
         }
 
@@ -157,7 +157,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Top
         {
-            get => _min.Y;
+            readonly get => _min.Y;
             set => _min.Y = value;
         }
 
@@ -166,7 +166,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Right
         {
-            get => _max.X;
+            readonly get => _max.X;
             set => _max.X = value;
         }
 
@@ -175,7 +175,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Bottom
         {
-            get => _max.Y;
+            readonly get => _max.Y;
             set => _max.Y = value;
         }
 
@@ -184,7 +184,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Front
         {
-            get => _min.Z;
+            readonly get => _min.Z;
             set => _min.Z = value;
         }
 
@@ -193,7 +193,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Back
         {
-            get => _max.Z;
+            readonly get => _max.Z;
             set => _max.Z = value;
         }
 
@@ -202,7 +202,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int X
         {
-            get => _min.X;
+            readonly get => _min.X;
             set => _min.X = value;
         }
 
@@ -211,7 +211,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Y
         {
-            get => _min.Y;
+            readonly get => _min.Y;
             set => _min.Y = value;
         }
 
@@ -220,7 +220,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int Z
         {
-            get => _min.Z;
+            readonly get => _min.Z;
             set => _min.Z = value;
         }
 
@@ -229,7 +229,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int SizeX
         {
-            get => _max.X - _min.X;
+            readonly get => _max.X - _min.X;
             set => _max.X = _min.X + value;
         }
 
@@ -238,7 +238,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int SizeY
         {
-            get => _max.Y - _min.Y;
+            readonly get => _max.Y - _min.Y;
             set => _max.Y = _min.Y + value;
         }
 
@@ -247,7 +247,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public int SizeZ
         {
-            get => _max.Z - _min.Z;
+            readonly get => _max.Z - _min.Z;
             set => _max.Z = _min.Z + value;
         }
 
@@ -256,7 +256,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         public Vector3i Size
         {
-            get => new Vector3i(_max.X - _min.X, _max.Y - _min.Y, _max.Z - _min.Z);
+            readonly get => new Vector3i(_max.X - _min.X, _max.Y - _min.Y, _max.Z - _min.Z);
             set
             {
                 _max.X = _min.X + value.X;
@@ -268,12 +268,12 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Gets the location of the box.
         /// </summary>
-        public Vector3i Location => _min;
+        public readonly Vector3i Location => _min;
 
         /// <summary>
         /// Gets a value indicating whether all values are zero.
         /// </summary>
-        public bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
+        public readonly bool IsZero => _min.X == 0 && _min.Y == 0 && _min.Z == 0
                            && _max.X == 0 && _max.Y == 0 && _max.Z == 0;
 
         /// <summary>
@@ -362,7 +362,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box with which to intersect.</param>
         /// <returns>The intersection of itself and the specified Box.</returns>
-        public Box3i Intersected(Box3i other)
+        public readonly Box3i Intersected(Box3i other)
         {
             return Intersect(other, this);
         }
@@ -372,7 +372,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box to test.</param>
         /// <returns>This method returns true if there is any intersection, otherwise false.</returns>
-        public bool IntersectsWith(Box3i other)
+        public readonly bool IntersectsWith(Box3i other)
         {
             return other._min.X < _max.X
                 && _min.X < other._max.X
@@ -387,7 +387,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="other">The Box to test.</param>
         /// <returns>This method returns true if there is any intersection or touches, otherwise false.</returns>
-        public bool TouchWith(Box3i other)
+        public readonly bool TouchWith(Box3i other)
         {
             return other._min.X <= _max.X
                 && _min.X <= other._max.X
@@ -466,7 +466,7 @@ namespace OpenTK.Mathematics
         /// </param>
         /// <returns>Whether this box contains the point.</returns>
         [Pure]
-        public bool Contains(Vector3i point, bool boundaryInclusive)
+        public readonly bool Contains(Vector3i point, bool boundaryInclusive)
         {
             if (boundaryInclusive)
             {
@@ -628,13 +628,13 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Box3i && Equals((Box3i)obj);
         }
 
         /// <inheritdoc/>
-        public bool Equals(Box3i other)
+        public readonly bool Equals(Box3i other)
         {
             return _min.Equals(other._min) &&
                    _max.Equals(other._max);
@@ -647,25 +647,25 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
 
         /// <inheritdoc/>
-        public string ToString(string format, IFormatProvider formatProvider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
             return $"{Min.ToString(format, formatProvider)} - {Max.ToString(format, formatProvider)}";
         }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
@@ -806,19 +806,19 @@ namespace OpenTK.Mathematics
         /// Returns a System.String that represents the current Matrix2x3.
         /// </summary>
         /// <returns>The string representation of the matrix.</returns>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
@@ -806,25 +806,25 @@ namespace OpenTK.Mathematics
         /// Returns a System.String that represents the current Matrix2x3d.
         /// </summary>
         /// <returns>The string representation of the matrix.</returns>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
 
         /// <inheritdoc/>
-        public string ToString(string format, IFormatProvider formatProvider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
             string row0 = Row0.ToString(format, formatProvider);
             string row1 = Row1.ToString(format, formatProvider);

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
@@ -244,7 +244,7 @@ namespace OpenTK.Mathematics
         /// <returns>The element at the given row and column index.</returns>
         public double this[int rowIndex, int columnIndex]
         {
-            get
+            readonly get
             {
                 if (rowIndex == 0)
                 {

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -1429,19 +1429,19 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
@@ -1457,7 +1457,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Vector2 && Equals((Vector2)obj);
         }

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -1380,19 +1380,19 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
@@ -1408,7 +1408,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Vector2d && Equals((Vector2d)obj);
         }

--- a/src/OpenTK.Mathematics/Vector/Vector2h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2h.cs
@@ -213,25 +213,25 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
 
         /// <inheritdoc/>
-        public string ToString(string format, IFormatProvider formatProvider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
             return string.Format(
                 "({0}{2} {1})",
@@ -241,13 +241,13 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Vector2h && Equals((Vector2h)obj);
         }
 
         /// <inheritdoc/>
-        public bool Equals(Vector2h other)
+        public readonly bool Equals(Vector2h other)
         {
             return X.Equals(other.X) &&
                    Y.Equals(other.Y);

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -749,19 +749,19 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
@@ -777,7 +777,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Vector2i && Equals((Vector2i)obj);
         }

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -1497,7 +1497,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector2 Xy
         {
-            get => Unsafe.As<Vector3, Vector2>(ref this);
+            readonly get => new Vector2(X, Y);
             set
             {
                 X = value.X;

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -1363,7 +1363,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector2d Xy
         {
-            get => Unsafe.As<Vector3d, Vector2d>(ref this);
+            readonly get => new Vector2d(X, Y);
             set
             {
                 X = value.X;
@@ -1814,19 +1814,19 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
@@ -1843,7 +1843,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Vector3d && Equals((Vector3d)obj);
         }

--- a/src/OpenTK.Mathematics/Vector/Vector3h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3h.cs
@@ -132,7 +132,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector2h Xy
         {
-            get => Unsafe.As<Vector3h, Vector2h>(ref this);
+            readonly get => new Vector2h(X, Y);
             set
             {
                 X = value.X;
@@ -397,25 +397,25 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
 
         /// <inheritdoc />
-        public string ToString(string format, IFormatProvider formatProvider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
             return string.Format(
                 "({0}{3} {1}{3} {2})",
@@ -426,13 +426,13 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Vector3h && Equals((Vector3h)obj);
         }
 
         /// <inheritdoc/>
-        public bool Equals(Vector3h other)
+        public readonly bool Equals(Vector3h other)
         {
             return X.Equals(other.X) &&
                    Y.Equals(other.Y) &&

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -493,7 +493,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector2i Xy
         {
-            get => Unsafe.As<Vector3i, Vector2i>(ref this);
+            readonly get => new Vector2i(X, Y);
             set
             {
                 X = value.X;
@@ -928,19 +928,19 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
@@ -957,7 +957,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Vector3i && Equals((Vector3i)obj);
         }

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -1164,7 +1164,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector2 Xy
         {
-            get => Unsafe.As<Vector4, Vector2>(ref this);
+            readonly get => new Vector2(X, Y);
             set
             {
                 X = value.X;
@@ -1332,7 +1332,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector3 Xyz
         {
-            get => Unsafe.As<Vector4, Vector3>(ref this);
+            readonly get => new Vector3(X, Y, Z);
             set
             {
                 X = value.X;

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -1159,7 +1159,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector2d Xy
         {
-            get => Unsafe.As<Vector4d, Vector2d>(ref this);
+            readonly get => new Vector2d(X, Y);
             set
             {
                 X = value.X;
@@ -1327,7 +1327,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector3d Xyz
         {
-            get => Unsafe.As<Vector4d, Vector3d>(ref this);
+            readonly get => new Vector3d(X, Y, Z);
             set
             {
                 X = value.X;
@@ -2424,19 +2424,19 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
@@ -2454,7 +2454,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Vector4d && Equals((Vector4d)obj);
         }

--- a/src/OpenTK.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4h.cs
@@ -177,7 +177,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector2h Xy
         {
-            get => Unsafe.As<Vector4h, Vector2h>(ref this);
+            readonly get => new Vector2h(X, Y);
             set
             {
                 X = value.X;
@@ -345,7 +345,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector3h Xyz
         {
-            get => Unsafe.As<Vector4h, Vector3h>(ref this);
+            readonly get => new Vector3h(X, Y, Z);
             set
             {
                 X = value.X;
@@ -1239,25 +1239,25 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString(null, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(string format)
+        public readonly string ToString(string format)
         {
             return ToString(format, null);
         }
 
         /// <inheritdoc cref="ToString(string, IFormatProvider)"/>
-        public string ToString(IFormatProvider formatProvider)
+        public readonly string ToString(IFormatProvider formatProvider)
         {
             return ToString(null, formatProvider);
         }
 
         /// <inheritdoc />
-        public string ToString(string format, IFormatProvider formatProvider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
             return string.Format(
                 "({0}{4} {1}{4} {2}{4} {3})",
@@ -1269,13 +1269,13 @@ namespace OpenTK.Mathematics
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Vector4h && Equals((Vector4h)obj);
         }
 
         /// <inheritdoc/>
-        public bool Equals(Vector4h other)
+        public readonly bool Equals(Vector4h other)
         {
             return X.Equals(other.X) &&
                    Y.Equals(other.Y) &&

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -546,7 +546,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector2i Xy
         {
-            get => Unsafe.As<Vector4i, Vector2i>(ref this);
+            readonly get => new Vector2i(X, Y);
             set
             {
                 X = value.X;
@@ -714,7 +714,7 @@ namespace OpenTK.Mathematics
         [XmlIgnore]
         public Vector3i Xyz
         {
-            get => Unsafe.As<Vector4i, Vector3i>(ref this);
+            readonly get => new Vector3i(X, Y, Z);
             set
             {
                 X = value.X;


### PR DESCRIPTION
### Purpose of this PR

Successor of #1790, limited to the math lib.
I've also removed all usages of `Unsafe.As` to cast to a smaller type. We don't need that as the getter is inlined anyway and it prevents us from declaring it as `readonly` easily. After inline there is no diff: https://godbolt.org/z/7Y65xhEd8
