### PR TITLE
Add GUID Property to JoystickState

### DIFF
--- a/src/OpenTK.Windowing.Desktop/NativeWindow.cs
+++ b/src/OpenTK.Windowing.Desktop/NativeWindow.cs
@@ -1191,8 +1191,9 @@ namespace OpenTK.Windowing.Desktop
                     GLFW.GetJoystickAxesRaw(i, out var axisCount);
                     GLFW.GetJoystickButtonsRaw(i, out var buttonCount);
                     var name = GLFW.GetJoystickName(i);
+                    var guid = GLFW.GetJoystickGUID(i);
 
-                    _joystickStates[i] = new JoystickState(hatCount, axisCount, buttonCount, i, name);
+                    _joystickStates[i] = new JoystickState(hatCount, axisCount, buttonCount, i, name, guid);
                 }
             }
         }
@@ -1449,8 +1450,9 @@ namespace OpenTK.Windowing.Desktop
                     GLFW.GetJoystickAxesRaw(joy, out var axisCount);
                     GLFW.GetJoystickButtonsRaw(joy, out var buttonCount);
                     var name = GLFW.GetJoystickName(joy);
+                    var guid = GLFW.GetJoystickGUID(joy);
 
-                    _joystickStates[joy] = new JoystickState(hatCount, axisCount, buttonCount, joy, name);
+                    _joystickStates[joy] = new JoystickState(hatCount, axisCount, buttonCount, joy, name, guid);
                 }
                 else
                 {

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/Input/JoystickState.cs
@@ -44,6 +44,11 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         public string Name { get; }
 
         /// <summary>
+        /// Gets the GUID of the joysitck this state describes.
+        /// </summary>
+        public string GUID { get; }
+
+        /// <summary>
         /// Gets the number of buttons on the joystick this state describes.
         /// </summary>
         public int ButtonCount { get => _buttons.Length; }
@@ -58,7 +63,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
         /// </summary>
         public int HatCount { get => _hats.Length; }
 
-        internal JoystickState(int hatCount, int axesCount, int buttonCount, int id, string name)
+        internal JoystickState(int hatCount, int axesCount, int buttonCount, int id, string name, string guid)
         {
             _hats = new Hat[hatCount];
             _axes = new float[axesCount];
@@ -70,6 +75,7 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
 
             Id = id;
             Name = name;
+            GUID = guid;
         }
 
         private JoystickState(JoystickState source)
@@ -78,7 +84,8 @@ namespace OpenTK.Windowing.GraphicsLibraryFramework
                    source._axes.Length,
                    source._buttons.Length,
                    source.Id,
-                   source.Name)
+                   source.Name,
+                   source.GUID)
         {
             Array.Copy(source._hats, _hats, source._hats.Length);
             Array.Copy(source._axes, _axes, source._axes.Length);


### PR DESCRIPTION
### Purpose of this PR

Adds Easy access to the GUID of a joystick without having to use <code>GLFW.GetJoystickGUID</code>.

### Testing status

Didn't do extensive testing cause all I did was add a property to <code>JoystickState</code> and passed the result of <code>GLFW.GetJoystickGUID</code> at construction, but I did do a small check in my game to make sure that I get the same GUID from both methods and it does.

### Comments

Honestly this is just a quality of life change because I don't like having a giant list of usings at the top of my files lol.
