### PR TITLE
[5.0] Optimize Vector and Matrix Indexer

### DIFF
--- a/src/OpenTK.Mathematics/MathHelper.cs
+++ b/src/OpenTK.Mathematics/MathHelper.cs
@@ -663,9 +663,15 @@ namespace OpenTK.Mathematics
         }
 
         [DoesNotReturn]
-        internal static void ThrowOutOfRangeException(string message)
+        internal static void ThrowOutOfRangeException<T>(string message, T arg0)
         {
-            throw new IndexOutOfRangeException(message);
+            throw new IndexOutOfRangeException(string.Format(message, arg0));
+        }
+
+        [DoesNotReturn]
+        internal static void ThrowOutOfRangeException<T>(string message, T arg0, T arg1)
+        {
+            throw new IndexOutOfRangeException(string.Format(message, arg0));
         }
     }
 }

--- a/src/OpenTK.Mathematics/MathHelper.cs
+++ b/src/OpenTK.Mathematics/MathHelper.cs
@@ -671,7 +671,7 @@ namespace OpenTK.Mathematics
         [DoesNotReturn]
         internal static void ThrowOutOfRangeException<T>(string message, T arg0, T arg1)
         {
-            throw new IndexOutOfRangeException(string.Format(message, arg0));
+            throw new IndexOutOfRangeException(string.Format(message, arg0, arg1));
         }
     }
 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2.cs
@@ -212,7 +212,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 1)
+                if (((uint)rowIndex) >= 2 || ((uint)columnIndex) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -222,7 +222,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 1)
+                if (((uint)rowIndex) >= 2 || ((uint)columnIndex) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2.cs
@@ -212,32 +212,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 2 && ((uint)columnIndex) < 2)
+                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 1)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 2 && ((uint)columnIndex) < 2)
+                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 1)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector2 GetRowUnsafe(in Matrix2 m, int index)
+        private static ref Vector2 GetRowUnsafe(in Matrix2 m, int index)
         {
             ref Vector2 address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
@@ -212,32 +212,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 2 && ((uint)columnIndex) < 2)
+                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 1)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 2 && ((uint)columnIndex) < 2)
+                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 1)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector2d GetRowUnsafe(in Matrix2d m, int index)
+        private static ref Vector2d GetRowUnsafe(in Matrix2d m, int index)
         {
             ref Vector2d address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2d.cs
@@ -212,7 +212,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 1)
+                if (((uint)rowIndex) >= 2 || ((uint)columnIndex) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -222,7 +222,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 1)
+                if (((uint)rowIndex) >= 2 || ((uint)columnIndex) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
@@ -218,32 +218,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 2 && ((uint)columnIndex) < 3)
+                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 2)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 2 && ((uint)columnIndex) < 3)
+                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 2)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector3 GetRowUnsafe(in Matrix2x3 m, int index)
+        private static ref Vector3 GetRowUnsafe(in Matrix2x3 m, int index)
         {
             ref Vector3 address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3.cs
@@ -218,7 +218,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 2)
+                if (((uint)rowIndex) >= 2 || ((uint)columnIndex) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -228,7 +228,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 2)
+                if (((uint)rowIndex) >= 2 || ((uint)columnIndex) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
@@ -217,32 +217,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 2 && ((uint)columnIndex) < 3)
+                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 2)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 2 && ((uint)columnIndex) < 3)
+                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 2)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector3d GetRowUnsafe(in Matrix2x3d m, int index)
+        private static ref Vector3d GetRowUnsafe(in Matrix2x3d m, int index)
         {
             ref Vector3d address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x3d.cs
@@ -217,7 +217,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 2)
+                if (((uint)rowIndex) >= 2 || ((uint)columnIndex) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -227,7 +227,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 2)
+                if (((uint)rowIndex) >= 2 || ((uint)columnIndex) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
@@ -251,7 +251,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 3)
+                if (((uint)rowIndex) >= 2 || ((uint)columnIndex) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -261,7 +261,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 3)
+                if (((uint)rowIndex) >= 2 || ((uint)columnIndex) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4.cs
@@ -251,32 +251,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 2 && ((uint)columnIndex) < 4)
+                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 3)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 2 && ((uint)columnIndex) < 4)
+                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 3)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector4 GetRowUnsafe(in Matrix2x4 m, int index)
+        private static ref Vector4 GetRowUnsafe(in Matrix2x4 m, int index)
         {
             ref Vector4 address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
@@ -251,32 +251,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 2 && ((uint)columnIndex) < 4)
+                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 3)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 2 && ((uint)columnIndex) < 4)
+                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 3)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector4d GetRowUnsafe(in Matrix2x4d m, int index)
+        private static ref Vector4d GetRowUnsafe(in Matrix2x4d m, int index)
         {
             ref Vector4d address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix2x4d.cs
@@ -251,7 +251,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 3)
+                if (((uint)rowIndex) >= 2 || ((uint)columnIndex) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -261,7 +261,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 1 || ((uint)columnIndex) > 3)
+                if (((uint)rowIndex) >= 2 || ((uint)columnIndex) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3.cs
@@ -305,32 +305,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 3 && ((uint)columnIndex) < 3)
+                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 2)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 3 && ((uint)columnIndex) < 3)
+                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 2)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector3 GetRowUnsafe(in Matrix3 m, int index)
+        private static ref Vector3 GetRowUnsafe(in Matrix3 m, int index)
         {
             ref Vector3 address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3.cs
@@ -305,7 +305,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 2)
+                if (((uint)rowIndex) >= 3 || ((uint)columnIndex) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -315,7 +315,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 2)
+                if (((uint)rowIndex) >= 3 || ((uint)columnIndex) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
@@ -305,32 +305,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 3 && ((uint)columnIndex) < 3)
+                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 2)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 3 && ((uint)columnIndex) < 3)
+                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 2)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector3d GetRowUnsafe(in Matrix3d m, int index)
+        private static ref Vector3d GetRowUnsafe(in Matrix3d m, int index)
         {
             ref Vector3d address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3d.cs
@@ -305,7 +305,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 2)
+                if (((uint)rowIndex) >= 3 || ((uint)columnIndex) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -315,7 +315,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 2)
+                if (((uint)rowIndex) >= 3 || ((uint)columnIndex) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
@@ -216,7 +216,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 1)
+                if (((uint)rowIndex) >= 3 || ((uint)columnIndex) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -226,7 +226,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 1)
+                if (((uint)rowIndex) >= 3 || ((uint)columnIndex) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2.cs
@@ -216,32 +216,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 3 && ((uint)columnIndex) < 2)
+                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 1)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 3 && ((uint)columnIndex) < 2)
+                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 1)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector2 GetRowUnsafe(in Matrix3x2 m, int index)
+        private static ref Vector2 GetRowUnsafe(in Matrix3x2 m, int index)
         {
             ref Vector2 address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2d.cs
@@ -216,32 +216,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 3 && ((uint)columnIndex) < 2)
+                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 1)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 3 && ((uint)columnIndex) < 2)
+                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 1)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector2d GetRowUnsafe(in Matrix3x2d m, int index)
+        private static ref Vector2d GetRowUnsafe(in Matrix3x2d m, int index)
         {
             ref Vector2d address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x2d.cs
@@ -216,7 +216,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 1)
+                if (((uint)rowIndex) >= 3 || ((uint)columnIndex) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -226,7 +226,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 1)
+                if (((uint)rowIndex) >= 3 || ((uint)columnIndex) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
@@ -306,7 +306,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 3)
+                if (((uint)rowIndex) >= 3 || ((uint)columnIndex) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -316,7 +316,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 3)
+                if (((uint)rowIndex) >= 3 || ((uint)columnIndex) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4.cs
@@ -306,32 +306,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 3 && ((uint)columnIndex) < 4)
+                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 3)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 3 && ((uint)columnIndex) < 4)
+                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 3)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector4 GetRowUnsafe(in Matrix3x4 m, int index)
+        private static ref Vector4 GetRowUnsafe(in Matrix3x4 m, int index)
         {
             ref Vector4 address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
@@ -306,7 +306,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 3)
+                if (((uint)rowIndex) >= 3 || ((uint)columnIndex) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -316,7 +316,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 3)
+                if (((uint)rowIndex) >= 3 || ((uint)columnIndex) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix3x4d.cs
@@ -306,32 +306,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 3 && ((uint)columnIndex) < 4)
+                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 3)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 3 && ((uint)columnIndex) < 4)
+                if (((uint)rowIndex) > 2 || ((uint)columnIndex) > 3)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector4d GetRowUnsafe(in Matrix3x4d m, int index)
+        private static ref Vector4d GetRowUnsafe(in Matrix3x4d m, int index)
         {
             ref Vector4d address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -431,7 +431,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 3)
+                if (((uint)rowIndex) >= 4 || ((uint)columnIndex) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -441,7 +441,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 3)
+                if (((uint)rowIndex) >= 4 || ((uint)columnIndex) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4.cs
@@ -431,32 +431,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 4 && ((uint)columnIndex) < 4)
+                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 3)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 4 && ((uint)columnIndex) < 4)
+                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 3)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector4 GetRowUnsafe(in Matrix4 m, int index)
+        private static ref Vector4 GetRowUnsafe(in Matrix4 m, int index)
         {
             ref Vector4 address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
@@ -412,32 +412,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 4 && ((uint)columnIndex) < 4)
+                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 3)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 4 && ((uint)columnIndex) < 4)
+                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 3)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector4d GetRowUnsafe(in Matrix4d m, int index)
+        private static ref Vector4d GetRowUnsafe(in Matrix4d m, int index)
         {
             ref Vector4d address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4d.cs
@@ -412,7 +412,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 3)
+                if (((uint)rowIndex) >= 4 || ((uint)columnIndex) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -422,7 +422,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 3)
+                if (((uint)rowIndex) >= 4 || ((uint)columnIndex) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
@@ -247,32 +247,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 4 && ((uint)columnIndex) < 2)
+                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 1)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 4 && ((uint)columnIndex) < 2)
+                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 1)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector2 GetRowUnsafe(in Matrix4x2 m, int index)
+        private static ref Vector2 GetRowUnsafe(in Matrix4x2 m, int index)
         {
             ref Vector2 address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2.cs
@@ -247,7 +247,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 1)
+                if (((uint)rowIndex) >= 4 || ((uint)columnIndex) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -257,7 +257,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 1)
+                if (((uint)rowIndex) >= 4 || ((uint)columnIndex) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
@@ -247,32 +247,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 4 && ((uint)columnIndex) < 2)
+                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 1)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 4 && ((uint)columnIndex) < 2)
+                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 1)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector2d GetRowUnsafe(in Matrix4x2d m, int index)
+        private static ref Vector2d GetRowUnsafe(in Matrix4x2d m, int index)
         {
             ref Vector2d address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x2d.cs
@@ -247,7 +247,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 1)
+                if (((uint)rowIndex) >= 4 || ((uint)columnIndex) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -257,7 +257,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 1)
+                if (((uint)rowIndex) >= 4 || ((uint)columnIndex) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
@@ -304,7 +304,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 2)
+                if (((uint)rowIndex) >= 4 || ((uint)columnIndex) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -314,7 +314,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 2)
+                if (((uint)rowIndex) >= 4 || ((uint)columnIndex) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3.cs
@@ -304,32 +304,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 4 && ((uint)columnIndex) < 3)
+                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 2)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 4 && ((uint)columnIndex) < 3)
+                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 2)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector3 GetRowUnsafe(in Matrix4x3 m, int index)
+        private static ref Vector3 GetRowUnsafe(in Matrix4x3 m, int index)
         {
             ref Vector3 address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
@@ -309,7 +309,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 2)
+                if (((uint)rowIndex) >= 4 || ((uint)columnIndex) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
@@ -319,7 +319,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 2)
+                if (((uint)rowIndex) >= 4 || ((uint)columnIndex) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }

--- a/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
+++ b/src/OpenTK.Mathematics/Matrix/Matrix4x3d.cs
@@ -309,32 +309,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)rowIndex) < 4 && ((uint)columnIndex) < 3)
+                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 2)
                 {
-                    return GetRowUnsafe(in this, rowIndex)[columnIndex];
+                    MathHelper.ThrowOutOfRangeException("You tried to access this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to access this matrix at: ({rowIndex}, {columnIndex})");
-                    return default;
-                }
+
+                return GetRowUnsafe(in this, rowIndex)[columnIndex];
             }
 
             set
             {
-                if (((uint)rowIndex) < 4 && ((uint)columnIndex) < 3)
+                if (((uint)rowIndex) > 3 || ((uint)columnIndex) > 2)
                 {
-                    GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this matrix at: ({0}, {1})", rowIndex, columnIndex);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException($"You tried to set this matrix at: ({rowIndex}, {columnIndex})");
-                }
+
+                GetRowUnsafe(in this, rowIndex)[columnIndex] = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref Vector3d GetRowUnsafe(in Matrix4x3d m, int index)
+        private static ref Vector3d GetRowUnsafe(in Matrix4x3d m, int index)
         {
             ref Vector3d address = ref Unsafe.AsRef(in m.Row0);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -94,31 +94,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) < 2)
+                if (((uint)index) > 1)
                 {
-                    return GetElementUnsafe(in this, index);
+                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-                }
+
+                return GetElementUnsafe(in this, index);
             }
 
             set
             {
-                if (((uint)index) < 2)
+                if (((uint)index) > 1)
                 {
-                    GetElementUnsafe(in this, index) = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
-                }
+
+                GetElementUnsafe(in this, index) = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref float GetElementUnsafe(in Vector2 v, int index)
+        private static ref float GetElementUnsafe(in Vector2 v, int index)
         {
             ref float address = ref Unsafe.AsRef(in v.X);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -94,7 +94,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) > 1)
+                if (((uint)index) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
@@ -104,7 +104,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)index) > 1)
+                if (((uint)index) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }

--- a/src/OpenTK.Mathematics/Vector/Vector2b.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2b.cs
@@ -71,41 +71,30 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) < 2)
+                if (((uint)index) > 1)
                 {
-                    return GetElementUnsafe(in this, index);
+                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-                }
+
+                return GetElementUnsafe(in this, index);
             }
 
             set
             {
-                if (((uint)index) < 2)
+                if (((uint)index) > 1)
                 {
-                    SetElementUnsafe(ref this, index, value);
+                    MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
-                }
+
+                GetElementUnsafe(in this, index) = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool GetElementUnsafe(in Vector2b v, int index)
+        private static ref bool GetElementUnsafe(in Vector2b v, int index)
         {
             ref bool address = ref Unsafe.AsRef(in v.X);
-            return Unsafe.Add(ref address, index);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void SetElementUnsafe(ref Vector2b v, int index, bool value)
-        {
-            ref bool address = ref Unsafe.AsRef(in v.X);
-            Unsafe.Add(ref address, index) = value;
+            return ref Unsafe.Add(ref address, index);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2b.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2b.cs
@@ -71,7 +71,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) > 1)
+                if (((uint)index) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
@@ -81,7 +81,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)index) > 1)
+                if (((uint)index) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -127,31 +127,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) < 2)
+                if (((uint)index) > 1)
                 {
-                    return GetElementUnsafe(in this, index);
+                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-                }
+
+                return GetElementUnsafe(in this, index);
             }
 
             set
             {
-                if (((uint)index) < 2)
+                if (((uint)index) > 1)
                 {
-                    GetElementUnsafe(in this, index) = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
-                }
+
+                GetElementUnsafe(in this, index) = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref double GetElementUnsafe(in Vector2d v, int index)
+        private static ref double GetElementUnsafe(in Vector2d v, int index)
         {
             ref double address = ref Unsafe.AsRef(in v.X);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -127,7 +127,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) > 1)
+                if (((uint)index) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
@@ -137,7 +137,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)index) > 1)
+                if (((uint)index) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -78,31 +78,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) < 2)
+                if (((uint)index) > 1)
                 {
-                    return GetElementUnsafe(in this, index);
+                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-                }
+
+                return GetElementUnsafe(in this, index);
             }
 
             set
             {
-                if (((uint)index) < 2)
+                if (((uint)index) > 1)
                 {
-                    GetElementUnsafe(in this, index) = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
-                }
+
+                GetElementUnsafe(in this, index) = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref int GetElementUnsafe(in Vector2i v, int index)
+        private static ref int GetElementUnsafe(in Vector2i v, int index)
         {
             ref int address = ref Unsafe.AsRef(in v.X);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -78,7 +78,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) > 1)
+                if (((uint)index) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
@@ -88,7 +88,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)index) > 1)
+                if (((uint)index) >= 2)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -114,7 +114,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) > 2)
+                if (((uint)index) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
@@ -124,7 +124,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)index) > 2)
+                if (((uint)index) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -114,31 +114,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) < 3)
+                if (((uint)index) > 2)
                 {
-                    return GetElementUnsafe(in this, index);
+                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-                }
+
+                return GetElementUnsafe(in this, index);
             }
 
             set
             {
-                if (((uint)index) < 3)
+                if (((uint)index) > 2)
                 {
-                    GetElementUnsafe(in this, index) = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
-                }
+
+                GetElementUnsafe(in this, index) = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref float GetElementUnsafe(in Vector3 v, int index)
+        private static ref float GetElementUnsafe(in Vector3 v, int index)
         {
             ref float address = ref Unsafe.AsRef(in v.X);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Vector/Vector3b.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3b.cs
@@ -102,7 +102,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) > 2)
+                if (((uint)index) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
@@ -112,7 +112,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)index) > 2)
+                if (((uint)index) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }

--- a/src/OpenTK.Mathematics/Vector/Vector3b.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3b.cs
@@ -102,41 +102,30 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) < 3)
+                if (((uint)index) > 2)
                 {
-                    return GetElementUnsafe(in this, index);
+                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-                }
+
+                return GetElementUnsafe(in this, index);
             }
 
             set
             {
-                if (((uint)index) < 3)
+                if (((uint)index) > 2)
                 {
-                    SetElementUnsafe(ref this, index, value);
+                    MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
-                }
+
+                GetElementUnsafe(in this, index) = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool GetElementUnsafe(in Vector3b v, int index)
+        private static ref bool GetElementUnsafe(in Vector3b v, int index)
         {
             ref bool address = ref Unsafe.AsRef(in v.X);
-            return Unsafe.Add(ref address, index);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void SetElementUnsafe(ref Vector3b v, int index, bool value)
-        {
-            ref bool address = ref Unsafe.AsRef(in v.X);
-            Unsafe.Add(ref address, index) = value;
+            return ref Unsafe.Add(ref address, index);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -112,7 +112,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) > 2)
+                if (((uint)index) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
@@ -122,7 +122,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)index) > 2)
+                if (((uint)index) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -112,31 +112,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) < 3)
+                if (((uint)index) > 2)
                 {
-                    return GetElementUnsafe(in this, index);
+                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-                }
+
+                return GetElementUnsafe(in this, index);
             }
 
             set
             {
-                if (((uint)index) < 3)
+                if (((uint)index) > 2)
                 {
-                    GetElementUnsafe(in this, index) = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
-                }
+
+                GetElementUnsafe(in this, index) = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref double GetElementUnsafe(in Vector3d v, int index)
+        private static ref double GetElementUnsafe(in Vector3d v, int index)
         {
             ref double address = ref Unsafe.AsRef(in v.X);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -98,7 +98,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) > 2)
+                if (((uint)index) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
@@ -108,7 +108,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)index) > 2)
+                if (((uint)index) >= 3)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -98,31 +98,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) < 3)
+                if (((uint)index) > 2)
                 {
-                    return GetElementUnsafe(in this, index);
+                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-                }
+
+                return GetElementUnsafe(in this, index);
             }
 
             set
             {
-                if (((uint)index) < 3)
+                if (((uint)index) > 2)
                 {
-                    GetElementUnsafe(in this, index) = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
-                }
+
+                GetElementUnsafe(in this, index) = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref int GetElementUnsafe(in Vector3i v, int index)
+        private static ref int GetElementUnsafe(in Vector3i v, int index)
         {
             ref int address = ref Unsafe.AsRef(in v.X);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -183,7 +183,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) > 3)
+                if (((uint)index) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
@@ -193,7 +193,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)index) > 3)
+                if (((uint)index) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -183,32 +183,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) < 4)
+                if (((uint)index) > 3)
                 {
-                    return GetElementUnsafe(in this, index);
+                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: " + index);
-                    return default;
-                }
+
+                return GetElementUnsafe(in this, index);
             }
 
             set
             {
-                if (((uint)index) < 4)
+                if (((uint)index) > 3)
                 {
-                    GetElementUnsafe(in this, index) = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: " + index);
-                }
+
+                GetElementUnsafe(in this, index) = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref float GetElementUnsafe(in Vector4 v, int index)
+        private static ref float GetElementUnsafe(in Vector4 v, int index)
         {
             ref float address = ref Unsafe.AsRef(in v.X);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Vector/Vector4b.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4b.cs
@@ -115,7 +115,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) > 3)
+                if (((uint)index) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
@@ -125,7 +125,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)index) > 3)
+                if (((uint)index) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }

--- a/src/OpenTK.Mathematics/Vector/Vector4b.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4b.cs
@@ -115,41 +115,30 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) < 4)
+                if (((uint)index) > 3)
                 {
-                    return GetElementUnsafe(in this, index);
+                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-                }
+
+                return GetElementUnsafe(in this, index);
             }
 
             set
             {
-                if (((uint)index) < 4)
+                if (((uint)index) > 3)
                 {
-                    SetElementUnsafe(ref this, index, value);
+                    MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
-                }
+
+                GetElementUnsafe(in this, index) = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool GetElementUnsafe(in Vector4b v, int index)
+        private static ref bool GetElementUnsafe(in Vector4b v, int index)
         {
             ref bool address = ref Unsafe.AsRef(in v.X);
-            return Unsafe.Add(ref address, index);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void SetElementUnsafe(ref Vector4b v, int index, bool value)
-        {
-            ref bool address = ref Unsafe.AsRef(in v.X);
-            Unsafe.Add(ref address, index) = value;
+            return ref Unsafe.Add(ref address, index);
         }
 
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -203,32 +203,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) < 4)
+                if (((uint)index) > 3)
                 {
-                    return GetElementUnsafe(in this, index);
+                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
-                else
-                {
-                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: " + index);
-                    return default;
-                }
+
+                return GetElementUnsafe(in this, index);
             }
 
             set
             {
-                if (((uint)index) < 4)
+                if (((uint)index) > 3)
                 {
-                    GetElementUnsafe(in this, index) = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
-                }
+
+                GetElementUnsafe(in this, index) = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref double GetElementUnsafe(in Vector4d v, int index)
+        private static ref double GetElementUnsafe(in Vector4d v, int index)
         {
             ref double address = ref Unsafe.AsRef(in v.X);
             return ref Unsafe.Add(ref address, index);

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -203,7 +203,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) > 3)
+                if (((uint)index) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
@@ -213,7 +213,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)index) > 3)
+                if (((uint)index) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -122,7 +122,7 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) > 3)
+                if (((uint)index) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
@@ -132,7 +132,7 @@ namespace OpenTK.Mathematics
 
             set
             {
-                if (((uint)index) > 3)
+                if (((uint)index) >= 4)
                 {
                     MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -122,31 +122,27 @@ namespace OpenTK.Mathematics
         {
             readonly get
             {
-                if (((uint)index) < 4)
+                if (((uint)index) > 3)
                 {
-                    return GetElementUnsafe(in this, index);
+                    MathHelper.ThrowOutOfRangeException("You tried to access this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to access this vector at index: " + index);
-                }
+
+                return GetElementUnsafe(in this, index);
             }
 
             set
             {
-                if (((uint)index) < 4)
+                if (((uint)index) > 3)
                 {
-                    GetElementUnsafe(in this, index) = value;
+                    MathHelper.ThrowOutOfRangeException("You tried to set this vector at index: {0}", index);
                 }
-                else
-                {
-                    throw new IndexOutOfRangeException("You tried to set this vector at index: " + index);
-                }
+
+                GetElementUnsafe(in this, index) = value;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly ref int GetElementUnsafe(in Vector4i v, int index)
+        private static ref int GetElementUnsafe(in Vector4i v, int index)
         {
             ref int address = ref Unsafe.AsRef(in v.X);
             return ref Unsafe.Add(ref address, index);


### PR DESCRIPTION
### Purpose of this PR

Fix #1798

#1808 Added a ThrowHelper but because of the string interpolation on the callsite it still wouldn't inline as that adds lots of bloat.
This moves the interpolation into the throw helper as suggested by @utkumaden. We can do even better by moving the string into the exception. That would possibly require adding many throw helper functions. We could make the exception messages more uniform though.