### PR TITLE
Fix CL.CreateKernelsInProgram

### DIFF
--- a/src/OpenTK.Compute/OpenCL/CL.cs
+++ b/src/OpenTK.Compute/OpenCL/CL.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using OpenTK.Compute.Native;
 


### PR DESCRIPTION
### Purpose of this PR

* This PR fixes #1849 by changing the `kernels` parameter from `[In] CLKernel[] kernels` to `[Out] CLKernel[] kernels`.
* It affects only the OpenCL wrapper.

### Testing status

* I tested manually by modifying [`tests/OpenToolkit.OpenCL.Tests/Program.cs`](https://github.com/opentk/opentk/blob/6c3ba7dbaef6b2597ef98cd3403e19bafde52782/tests/OpenToolkit.OpenCL.Tests/Program.cs#L48) as described in #1849 . Before the fix, the output of the program included:

```txt
CL.CreateKernelsInProgram result: Success
Kernel handle: 0
CL.GetKernelInfo result: InvalidKernel
```

After the fix, it became:

```txt
CL.CreateKernelsInProgram result: Success
Kernel handle: 2191761710448
CL.GetKernelInfo result: Success
```

### Comments

Please keep in mind that I am no expert in interoperating with C DLLs.
