### PR TITLE
[5.0] Make all bindings trim friendly to greatly decrease size

### DIFF
--- a/src/Generator/Writer.cs
+++ b/src/Generator/Writer.cs
@@ -90,6 +90,7 @@ namespace Generator.Writing
             writer.WriteLine($"// This file is auto generated, do not edit. Generated: {DateTime.Now:yyyy-MM-dd HH:mm:ss \"GMT\"zzz}");
             writer.WriteLine("using System;");
             writer.WriteLine("using System.Runtime.InteropServices;");
+            writer.WriteLine("using System.Runtime.CompilerServices;");
             writer.WriteLine("using OpenTK.Graphics;");
             writer.WriteLine();
             writer.WriteLine($"namespace {GraphicsNamespace}.{strings.Namespace}");
@@ -122,25 +123,29 @@ namespace Generator.Writing
                 out bool _,
                 out string returnType);
 
-            string entryPoint = function.EntryPoint;
+            string funcPointer = $"_{function.EntryPoint}_fnptr";
 
-            writer.WriteLine($"/// <summary><b>[entry point: <c>{entryPoint}</c>]</b></summary>");
-            writer.WriteLine($"public static delegate* unmanaged<{delegateTypes}> _{entryPoint}_fnptr = &{entryPoint}_Lazy;");
+            writer.WriteLine($"/// <summary><b>[entry point: <c>{function.EntryPoint}</c>]</b></summary>");
+            writer.WriteLine($"internal static delegate* unmanaged<{delegateTypes}> {funcPointer};");
 
-            writer.WriteLine($"[UnmanagedCallersOnly]");
-            writer.WriteLine($"private static {returnType} {entryPoint}_Lazy({signature})");
+            writer.WriteLine($"[MethodImpl(MethodImplOptions.NoInlining)]");
+            writer.WriteLine($"internal static {returnType} {function.EntryPoint}_Lazy({signature})");
             using (writer.CsScope())
             {
-                // Dotnet gurantees you can't get torn values when assigning functionpointers, assuming proper allignment which is default.
-                writer.WriteLine($"_{entryPoint}_fnptr = (delegate* unmanaged<{delegateTypes}>){strings.LoaderBindingsContext}.GetProcAddress(\"{function.EntryPoint}\");");
+                writer.WriteLine($"if ({funcPointer} == null)");
+                using (writer.CsScope())
+                {
+                    // Dotnet gurantees you can't get torn values when assigning functionpointers, assuming proper allignment which is default.
+                    writer.WriteLine($"{funcPointer} = (delegate* unmanaged<{delegateTypes}>){strings.LoaderBindingsContext}.GetProcAddress(\"{function.EntryPoint}\");");
+                }
 
                 if (function.ReturnType is not CSVoid)
                 {
-                    writer.WriteLine($"return _{entryPoint}_fnptr({paramNames});");
+                    writer.WriteLine($"return {funcPointer}({paramNames});");
                 }
                 else
                 {
-                    writer.WriteLine($"_{entryPoint}_fnptr({paramNames});");
+                    writer.WriteLine($"{funcPointer}({paramNames});");
                 }
             }
 
@@ -305,16 +310,16 @@ namespace Generator.Writing
                 if (function.ReturnType is CSBool8)
                 {
                     // HACK: We can't cast byte to bool, sigh...
-                    writer.WriteLine($"public static {function.ReturnType.ToCSString()} {name}({signature}) => {apiName}Pointers._{entryPoint}_fnptr({paramNames}) != 0;");
+                    writer.WriteLine($"public static {function.ReturnType.ToCSString()} {name}({signature}) => {apiName}Pointers.{entryPoint}_Lazy({paramNames}) != 0;");
                 }
                 else
                 {
-                    writer.WriteLine($"public static {function.ReturnType.ToCSString()} {name}({signature}) => ({function.ReturnType.ToCSString()}) {apiName}Pointers._{entryPoint}_fnptr({paramNames});");
+                    writer.WriteLine($"public static {function.ReturnType.ToCSString()} {name}({signature}) => ({function.ReturnType.ToCSString()}) {apiName}Pointers.{entryPoint}_Lazy({paramNames});");
                 }
             }
             else
             {
-                writer.WriteLine($"public static {returnType} {name}({signature}) => {apiName}Pointers._{entryPoint}_fnptr({paramNames});");
+                writer.WriteLine($"public static {returnType} {name}({signature}) => {apiName}Pointers.{entryPoint}_Lazy({paramNames});");
             }
 
             writer.WriteLine();

--- a/src/Generator/Writer.cs
+++ b/src/Generator/Writer.cs
@@ -126,7 +126,7 @@ namespace Generator.Writing
             string funcPointer = $"_{function.EntryPoint}_fnptr";
 
             writer.WriteLine($"/// <summary><b>[entry point: <c>{function.EntryPoint}</c>]</b></summary>");
-            writer.WriteLine($"internal static delegate* unmanaged<{delegateTypes}> {funcPointer};");
+            writer.WriteLine($"public static delegate* unmanaged<{delegateTypes}> {funcPointer};");
 
             writer.WriteLine($"[MethodImpl(MethodImplOptions.NoInlining)]");
             writer.WriteLine($"internal static {returnType} {function.EntryPoint}_Lazy({signature})");


### PR DESCRIPTION
Current pattern by the generator is:
```cs
public static delegate* unmanaged<uint, float, void> _glAccum_fnptr = &glAccum_Lazy;
[UnmanagedCallersOnly]
private static void glAccum_Lazy(uint op, float value)
{
    _glAccum_fnptr = (delegate* unmanaged<uint, float, void>)GLLoader.BindingsContext.GetProcAddress("glAccum");
    _glAccum_fnptr(op, value);
}
```
which is not trim compatible: https://github.com/dotnet/runtime/issues/118816

This PR changes it to this pattern:
```cs
public static delegate* unmanaged<uint, float, void> _glAccum_fnptr;
[MethodImpl(MethodImplOptions.NoInlining)]
internal static void glAccum_Lazy(uint op, float value)
{
    if (_glAccum_fnptr == null)
    {
        _glAccum_fnptr = (delegate* unmanaged<uint, float, void>)GLLoader.BindingsContext.GetProcAddress("glAccum");
    }
    _glAccum_fnptr(op, value);
}
```

I marked the methods `NoInlining` so the caller doesnt get bloated with P/Invoke machinery.
We may want to reconsider this if https://github.com/dotnet/runtime/issues/54107 is fixed.

Size improvements as measured in my app:
| Base             | New Pattern   | +NoInlining | +UTF-8   |
|------------------|---------------| ------------|----------|
|  7,907,840       | 6,926,336     | 6,916,608   | 6,912,512 

UTF-8 strings are not implemented as part of this PR, but they should be used more widely in the future.
Note my project explicitly uses the `OpenTK.Graphics` package for people that download the meta package the savings should be even bigger.