### PR TITLE
Make documentation for vector types more uniform.

### DIFF
--- a/src/OpenTK.Mathematics/Data/Half.cs
+++ b/src/OpenTK.Mathematics/Data/Half.cs
@@ -123,6 +123,7 @@ namespace OpenTK.Mathematics
         /// </summary>
         /// <param name="f">32-bit single-precision floating-point number.</param>
         /// <param name="throwOnError">Enable checks that will throw if the conversion result is not meaningful.</param>
+        /// <exception cref="ArithmeticException">Thrown if <paramref name="throwOnError"/> is <see langword="true"/> and the conversion is not meaningful.</exception>
         public Half(float f, bool throwOnError)
             : this(f)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -40,12 +40,12 @@ namespace OpenTK.Mathematics
     public struct Vector2 : IEquatable<Vector2>, IFormattable
     {
         /// <summary>
-        /// The X component of the Vector2.
+        /// The X component of the vector.
         /// </summary>
         public float X;
 
         /// <summary>
-        /// The Y component of the Vector2.
+        /// The Y component of the vector.
         /// </summary>
         public float Y;
 
@@ -62,8 +62,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2"/> struct.
         /// </summary>
-        /// <param name="x">The x coordinate of the net Vector2.</param>
-        /// <param name="y">The y coordinate of the net Vector2.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
         public Vector2(float x, float y)
         {
             X = x;

--- a/src/OpenTK.Mathematics/Vector/Vector2b.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2b.cs
@@ -44,8 +44,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2b"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the <see cref="Vector2b"/>.</param>
-        /// <param name="y">The y component of the <see cref="Vector2b"/>.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
         public Vector2b(bool x, bool y)
         {
             X = x;
@@ -55,7 +55,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2b"/> struct.
         /// </summary>
-        /// <param name="xy">The x, and y component of the <see cref="Vector2b"/>.</param>
+        /// <param name="xy">The x, and y component of the vector.</param>
         public Vector2b(Vector2b xy)
         {
             X = xy.X;

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -37,12 +37,12 @@ namespace OpenTK.Mathematics
     public struct Vector2d : IEquatable<Vector2d>, IFormattable
     {
         /// <summary>
-        /// The X coordinate of this instance.
+        /// The X coordinate of the vector.
         /// </summary>
         public double X;
 
         /// <summary>
-        /// The Y coordinate of this instance.
+        /// The Y coordinate of the vector.
         /// </summary>
         public double Y;
 
@@ -94,8 +94,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2d"/> struct.
         /// </summary>
-        /// <param name="x">The X coordinate.</param>
-        /// <param name="y">The Y coordinate.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
         public Vector2d(double x, double y)
         {
             X = x;

--- a/src/OpenTK.Mathematics/Vector/Vector2h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2h.cs
@@ -32,19 +32,19 @@ using System.Xml.Serialization;
 namespace OpenTK.Mathematics
 {
     /// <summary>
-    /// 2-component Vector of the Half type. Occupies 4 Byte total.
+    /// Represents a 2D vector using two half-precision floating-point numbers. Occupies 4 Byte total.
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     public struct Vector2h : ISerializable, IEquatable<Vector2h>, IFormattable
     {
         /// <summary>
-        /// The X component of the Half2.
+        /// The X component of the vector.
         /// </summary>
         public Half X;
 
         /// <summary>
-        /// The Y component of the Half2.
+        /// The Y component of the vector.
         /// </summary>
         public Half Y;
 
@@ -71,8 +71,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2h"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
         public Vector2h(Half x, Half y)
         {
             X = x;
@@ -82,8 +82,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2h"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
         public Vector2h(float x, float y)
         {
             X = new Half(x);
@@ -93,8 +93,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2h"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
         /// <param name="throwOnError">Enable checks that will throw if the conversion result is not meaningful.</param>
         public Vector2h(float x, float y, bool throwOnError)
         {
@@ -201,7 +201,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns this Half2 instance's contents as Vector2.
+        /// Returns this Vector2h instance's contents as Vector2.
         /// </summary>
         /// <returns>The vector.</returns>
         public readonly Vector2 ToVector2()
@@ -210,7 +210,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns this Half2 instance's contents as Vector2d.
+        /// Returns this Vector2h instance's contents as Vector2d.
         /// </summary>
         /// <returns>The vector.</returns>
         public readonly Vector2d ToVector2d()
@@ -286,7 +286,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// The size in bytes for an instance of the Half2 struct is 4.
+        /// The size in bytes for an instance of the Vector2h struct is 4.
         /// </summary>
         public static readonly int SizeInBytes = Unsafe.SizeOf<Vector2h>();
 
@@ -376,9 +376,9 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns the Half2 as an array of bytes.
+        /// Returns the Vector2h as an array of bytes.
         /// </summary>
-        /// <param name="h">The Half2 to convert.</param>
+        /// <param name="h">The Vector2h to convert.</param>
         /// <returns>The input as byte array.</returns>
         [Pure]
         public static byte[] GetBytes(Vector2h h)
@@ -396,11 +396,11 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Converts an array of bytes into Half2.
+        /// Converts an array of bytes into Vector2h.
         /// </summary>
-        /// <param name="value">A Half2 in it's byte[] representation.</param>
+        /// <param name="value">A Vector2h in it's byte[] representation.</param>
         /// <param name="startIndex">The starting position within value.</param>
-        /// <returns>A new Half2 instance.</returns>
+        /// <returns>A new Vector2h instance.</returns>
         [Pure]
         public static Vector2h FromBytes(byte[] value, int startIndex)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -27,12 +27,12 @@ namespace OpenTK.Mathematics
     public struct Vector2i : IEquatable<Vector2i>, IFormattable
     {
         /// <summary>
-        /// The X component of the Vector2i.
+        /// The X component of the vector.
         /// </summary>
         public int X;
 
         /// <summary>
-        /// The Y component of the Vector2i.
+        /// The Y component of the vector.
         /// </summary>
         public int Y;
 
@@ -49,8 +49,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2i"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the Vector2i.</param>
-        /// <param name="y">The Y component of the Vector2i.</param>
+        /// <param name="x">The X component of the vector.</param>
+        /// <param name="y">The Y component of the vector.</param>
         public Vector2i(int x, int y)
         {
             X = x;

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -40,17 +40,17 @@ namespace OpenTK.Mathematics
     public struct Vector3 : IEquatable<Vector3>, IFormattable
     {
         /// <summary>
-        /// The X component of the Vector3.
+        /// The X component of the vector.
         /// </summary>
         public float X;
 
         /// <summary>
-        /// The Y component of the Vector3.
+        /// The Y component of the vector.
         /// </summary>
         public float Y;
 
         /// <summary>
-        /// The Z component of the Vector3.
+        /// The Z component of the vector.
         /// </summary>
         public float Z;
 
@@ -68,9 +68,9 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the Vector3.</param>
-        /// <param name="y">The y component of the Vector3.</param>
-        /// <param name="z">The z component of the Vector3.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
         public Vector3(float x, float y, float z)
         {
             X = x;
@@ -81,7 +81,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3"/> struct.
         /// </summary>
-        /// <param name="v">The Vector2 to copy components from.</param>
+        /// <remarks>
+        /// <see cref="Z"/> is initialized to zero.
+        /// </remarks>
+        /// <param name="v">The vector to copy the x and y components from.</param>
         public Vector3(Vector2 v)
         {
             X = v.X;
@@ -92,7 +95,19 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3"/> struct.
         /// </summary>
-        /// <param name="v">The Vector3 to copy components from.</param>
+        /// <param name="v">The vector to copy the x and y components from.</param>
+        /// <param name="z">The z component of the vector.</param>
+        public Vector3(Vector2 v, float z)
+        {
+            X = v.X;
+            Y = v.Y;
+            Z = z;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3"/> struct.
+        /// </summary>
+        /// <param name="v">The vector to copy components from.</param>
         public Vector3(Vector3 v)
         {
             X = v.X;
@@ -103,7 +118,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3"/> struct.
         /// </summary>
-        /// <param name="v">The Vector4 to copy components from.</param>
+        /// <param name="v">The vector to copy the x, y, and z components from.</param>
         public Vector3(Vector4 v)
         {
             X = v.X;

--- a/src/OpenTK.Mathematics/Vector/Vector3b.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3b.cs
@@ -11,7 +11,7 @@ using System.Xml.Serialization;
 namespace OpenTK.Mathematics
 {
     /// <summary>
-    /// Represents a 2D boolean vector.
+    /// Represents a 3D boolean vector.
     /// </summary>
     /// <remarks>
     /// As bools in C# are not blittable this type is not necessarily suitable for interoperation with unmanaged code.
@@ -49,9 +49,9 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3b"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the <see cref="Vector3b"/>.</param>
-        /// <param name="y">The y component of the <see cref="Vector3b"/>.</param>
-        /// <param name="z">The z component of the <see cref="Vector3b"/>.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
         public Vector3b(bool x, bool y, bool z)
         {
             X = x;
@@ -62,8 +62,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3b"/> struct.
         /// </summary>
-        /// <param name="xy">The x and y components of the Vector3b.</param>
-        /// <param name="z">The z component of the Vector3b.</param>
+        /// <param name="xy">The x and y components of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
         public Vector3b(Vector2b xy, bool z = default)
         {
             X = xy.X;
@@ -74,7 +74,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3b"/> struct.
         /// </summary>
-        /// <param name="xyz">The x, y, and z components of the <see cref="Vector3b"/>.</param>
+        /// <param name="xyz">The x, y, and z components of the vector.</param>
         public Vector3b(Vector3b xyz)
         {
             X = xyz.X;
@@ -85,7 +85,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3b"/> struct.
         /// </summary>
-        /// <param name="xyz">The x, y, and z components of the <see cref="Vector3b"/>.</param>
+        /// <param name="xyz">The x, y, and z components of the vector.</param>
         public Vector3b(Vector4b xyz)
         {
             X = xyz.X;

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -37,17 +37,17 @@ namespace OpenTK.Mathematics
     public struct Vector3d : IEquatable<Vector3d>, IFormattable
     {
         /// <summary>
-        /// The X component of the Vector3.
+        /// The X component of the vector.
         /// </summary>
         public double X;
 
         /// <summary>
-        /// The Y component of the Vector3.
+        /// The Y component of the vector.
         /// </summary>
         public double Y;
 
         /// <summary>
-        /// The Z component of the Vector3.
+        /// The Z component of the vector.
         /// </summary>
         public double Z;
 
@@ -65,9 +65,9 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3d"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the Vector3.</param>
-        /// <param name="y">The y component of the Vector3.</param>
-        /// <param name="z">The z component of the Vector3.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
         public Vector3d(double x, double y, double z)
         {
             X = x;
@@ -78,7 +78,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3d"/> struct.
         /// </summary>
-        /// <param name="v">The Vector2d to copy components from.</param>
+        /// <remarks>
+        /// <see cref="Z"/> is initialized to zero.
+        /// </remarks>
+        /// <param name="v">The vector to copy the x and y components from.</param>
         public Vector3d(Vector2d v)
         {
             X = v.X;
@@ -89,7 +92,22 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3d"/> struct.
         /// </summary>
-        /// <param name="v">The Vector3d to copy components from.</param>
+        /// <remarks>
+        /// <see cref="Z"/> is initialized to zero.
+        /// </remarks>
+        /// <param name="v">The vector to copy the x and y components from.</param>
+        /// <param name="z">The z component of the vector.</param>
+        public Vector3d(Vector2d v, double z)
+        {
+            X = v.X;
+            Y = v.Y;
+            Z = z;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3d"/> struct.
+        /// </summary>
+        /// <param name="v">The vector to copy components from.</param>
         public Vector3d(Vector3d v)
         {
             X = v.X;
@@ -100,7 +118,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3d"/> struct.
         /// </summary>
-        /// <param name="v">The Vector4d to copy components from.</param>
+        /// <param name="v">The vector to copy the x, y, and z components from.</param>
         public Vector3d(Vector4d v)
         {
             X = v.X;

--- a/src/OpenTK.Mathematics/Vector/Vector3h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3h.cs
@@ -32,24 +32,24 @@ using System.Xml.Serialization;
 namespace OpenTK.Mathematics
 {
     /// <summary>
-    /// 3-component Vector of the Half type. Occupies 6 Byte total.
+    /// Represents a 3D vector using three half-precision floating-point numbers. Occupies 6 Byte total.
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     public struct Vector3h : ISerializable, IEquatable<Vector3h>, IFormattable
     {
         /// <summary>
-        /// The X component of the Half3.
+        /// The X component of the vector.
         /// </summary>
         public Half X;
 
         /// <summary>
-        /// The Y component of the Half3.
+        /// The Y component of the vector.
         /// </summary>
         public Half Y;
 
         /// <summary>
-        /// The Z component of the Half3.
+        /// The Z component of the vector.
         /// </summary>
         public Half Z;
 
@@ -78,9 +78,9 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3h"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
-        /// <param name="z">The Z component of the vector.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
         public Vector3h(Half x, Half y, Half z)
         {
             X = x;
@@ -90,11 +90,10 @@ namespace OpenTK.Mathematics
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3h"/> struct.
-        /// The new Half3 instance will convert the 3 parameters into 16-bit half-precision floating-point.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
-        /// <param name="z">The Z component of the vector.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
         public Vector3h(float x, float y, float z)
         {
             X = new Half(x);
@@ -104,11 +103,10 @@ namespace OpenTK.Mathematics
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3h"/> struct.
-        /// The new Half3 instance will convert the 3 parameters into 16-bit half-precision floating-point.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
-        /// <param name="z">The Z component of the vector.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
         /// <param name="throwOnError">Enable checks that will throw if the conversion result is not meaningful.</param>
         public Vector3h(float x, float y, float z, bool throwOnError)
         {
@@ -369,7 +367,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns this Half3 instance's contents as Vector3.
+        /// Returns this Vector3h instance's contents as Vector3.
         /// </summary>
         /// <returns>The vector.</returns>
         public readonly Vector3 ToVector3()
@@ -378,7 +376,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns this Half3 instance's contents as Vector3d.
+        /// Returns this Vector3h instance's contents as Vector3d.
         /// </summary>
         /// <returns>The vector.</returns>
         public readonly Vector3d ToVector3d()
@@ -454,7 +452,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// The size in bytes for an instance of the Half3 struct is 6.
+        /// The size in bytes for an instance of the Vector3h struct is 6.
         /// </summary>
         public static readonly int SizeInBytes = Unsafe.SizeOf<Vector3h>();
 
@@ -551,9 +549,9 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns the Half3 as an array of bytes.
+        /// Returns the Vector3h as an array of bytes.
         /// </summary>
-        /// <param name="h">The Half3 to convert.</param>
+        /// <param name="h">The Vector3h to convert.</param>
         /// <returns>The input as byte array.</returns>
         [Pure]
         public static byte[] GetBytes(Vector3h h)
@@ -574,11 +572,11 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Converts an array of bytes into Half3.
+        /// Converts an array of bytes into Vector3h.
         /// </summary>
-        /// <param name="value">A Half3 in it's byte[] representation.</param>
+        /// <param name="value">A Vector3h in it's byte[] representation.</param>
         /// <param name="startIndex">The starting position within value.</param>
-        /// <returns>A new Half3 instance.</returns>
+        /// <returns>A new Vector3h instance.</returns>
         [Pure]
         public static Vector3h FromBytes(byte[] value, int startIndex)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -27,17 +27,17 @@ namespace OpenTK.Mathematics
     public struct Vector3i : IEquatable<Vector3i>, IFormattable
     {
         /// <summary>
-        /// The X component of the Vector3i.
+        /// The X component of the vector.
         /// </summary>
         public int X;
 
         /// <summary>
-        /// The Y component of the Vector3i.
+        /// The Y component of the vector.
         /// </summary>
         public int Y;
 
         /// <summary>
-        /// The Z component of the Vector3i.
+        /// The Z component of the vector.
         /// </summary>
         public int Z;
 
@@ -55,9 +55,9 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3i"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the Vector3.</param>
-        /// <param name="y">The y component of the Vector3.</param>
-        /// <param name="z">The z component of the Vector3.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
         public Vector3i(int x, int y, int z)
         {
             X = x;
@@ -68,7 +68,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3i"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector2i"/> to copy components from.</param>
+        /// <remarks>
+        /// <see cref="Z"/> is initialized to zero.
+        /// </remarks>
+        /// <param name="v">The <see cref="Vector2i"/> to copy the x and y components from.</param>
         public Vector3i(Vector2i v)
         {
             X = v.X;
@@ -79,8 +82,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3i"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector2i"/> to copy components from.</param>
-        /// <param name="z">The z component of the new Vector3.</param>
+        /// <param name="v">The <see cref="Vector2i"/> to copy the x and y components from.</param>
+        /// <param name="z">The z component of the vector.</param>
         public Vector3i(Vector2i v, int z)
         {
             X = v.X;

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -41,22 +41,22 @@ namespace OpenTK.Mathematics
     public struct Vector4 : IEquatable<Vector4>, IFormattable
     {
         /// <summary>
-        /// The X component of the Vector4.
+        /// The X component of the vector.
         /// </summary>
         public float X;
 
         /// <summary>
-        /// The Y component of the Vector4.
+        /// The Y component of the vector.
         /// </summary>
         public float Y;
 
         /// <summary>
-        /// The Z component of the Vector4.
+        /// The Z component of the vector.
         /// </summary>
         public float Z;
 
         /// <summary>
-        /// The W component of the Vector4.
+        /// The W component of the vector.
         /// </summary>
         public float W;
 
@@ -120,10 +120,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the Vector4.</param>
-        /// <param name="y">The y component of the Vector4.</param>
-        /// <param name="z">The z component of the Vector4.</param>
-        /// <param name="w">The w component of the Vector4.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
+        /// <param name="w">The w component of the vector.</param>
         public Vector4(float x, float y, float z, float w)
         {
             X = x;
@@ -135,7 +135,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4"/> struct.
         /// </summary>
-        /// <param name="v">The Vector2 to copy components from.</param>
+        /// <remarks>
+        /// <see cref="Z"/> and <see cref="W"/> are initialized to zero.
+        /// </remarks>
+        /// <param name="v">The vector to copy the x and y components from.</param>
         public Vector4(Vector2 v)
         {
             X = v.X;
@@ -147,10 +150,11 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4"/> struct.
         /// </summary>
-        /// <param name="v">The Vector3 to copy components from.</param>
         /// <remarks>
-        ///  .<seealso cref="Vector4(Vector3, float)"/>
+        /// <see cref="W"/> is initialized to zero.
         /// </remarks>
+        /// <param name="v">The vector to copy the x, y, and z components from.</param>
+        /// <seealso cref="Vector4(Vector3, float)"/>
         public Vector4(Vector3 v)
         {
             X = v.X;
@@ -162,8 +166,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4"/> struct.
         /// </summary>
-        /// <param name="v">The Vector3 to copy components from.</param>
-        /// <param name="w">The w component of the new Vector4.</param>
+        /// <param name="v">The vector to copy the x, y, and z components from.</param>
+        /// <param name="w">The w component of the new vector.</param>
         public Vector4(Vector3 v, float w)
         {
             X = v.X;
@@ -175,7 +179,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4"/> struct.
         /// </summary>
-        /// <param name="v">The Vector4 to copy components from.</param>
+        /// <param name="v">The vector to copy components from.</param>
         public Vector4(Vector4 v)
         {
             X = v.X;

--- a/src/OpenTK.Mathematics/Vector/Vector4b.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4b.cs
@@ -11,7 +11,7 @@ using System.Xml.Serialization;
 namespace OpenTK.Mathematics
 {
     /// <summary>
-    /// Represents a 2D boolean vector.
+    /// Represents a 4D boolean vector.
     /// </summary>
     /// <remarks>
     /// As bools in C# are not blittable this type is not necessarily suitable for interoperation with unmanaged code.
@@ -55,10 +55,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4b"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the <see cref="Vector4b"/>.</param>
-        /// <param name="y">The y component of the <see cref="Vector4b"/>.</param>
-        /// <param name="z">The z component of the <see cref="Vector4b"/>.</param>
-        /// <param name="w">The w component of the <see cref="Vector4b"/>.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
+        /// <param name="w">The w component of the vector.</param>
         public Vector4b(bool x, bool y, bool z, bool w)
         {
             X = x;
@@ -70,9 +70,9 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4b"/> struct.
         /// </summary>
-        /// <param name="xy">The x and y components of the <see cref="Vector4b"/>.</param>
-        /// <param name="z">The z component of the <see cref="Vector4b"/>.</param>
-        /// <param name="w">The w component of the <see cref="Vector4b"/>.</param>
+        /// <param name="xy">The x and y components of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
+        /// <param name="w">The w component of the vector.</param>
         public Vector4b(Vector2b xy, bool z = default, bool w = default)
         {
             X = xy.X;
@@ -84,8 +84,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4b"/> struct.
         /// </summary>
-        /// <param name="xyz">The x, y, and z components of the <see cref="Vector4b"/>.</param>
-        /// <param name="w">The w component of the <see cref="Vector4b"/>.</param>
+        /// <param name="xyz">The x, y, and z components of the vector.</param>
+        /// <param name="w">The w component of the vector.</param>
         public Vector4b(Vector3b xyz, bool w = default)
         {
             X = xyz.X;
@@ -97,7 +97,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4b"/> struct.
         /// </summary>
-        /// <param name="xyzw">The x, y, z, and w components of the <see cref="Vector4b"/>.</param>
+        /// <param name="xyzw">The x, y, z, and w components of the vector.</param>
         public Vector4b(Vector4b xyzw)
         {
             X = xyzw.X;

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -40,22 +40,22 @@ namespace OpenTK.Mathematics
     public struct Vector4d : IEquatable<Vector4d>, IFormattable
     {
         /// <summary>
-        /// The X component of the Vector4d.
+        /// The X component of the vector.
         /// </summary>
         public double X;
 
         /// <summary>
-        /// The Y component of the Vector4d.
+        /// The Y component of the vector.
         /// </summary>
         public double Y;
 
         /// <summary>
-        /// The Z component of the Vector4d.
+        /// The Z component of the vector.
         /// </summary>
         public double Z;
 
         /// <summary>
-        /// The W component of the Vector4d.
+        /// The W component of the vector.
         /// </summary>
         public double W;
 
@@ -119,10 +119,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4d"/> struct.
         /// </summary>
-        /// <param name="x">The x component of the Vector4d.</param>
-        /// <param name="y">The y component of the Vector4d.</param>
-        /// <param name="z">The z component of the Vector4d.</param>
-        /// <param name="w">The w component of the Vector4d.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
+        /// <param name="w">The w component of the vector.</param>
         public Vector4d(double x, double y, double z, double w)
         {
             X = x;
@@ -134,7 +134,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4d"/> struct.
         /// </summary>
-        /// <param name="v">The Vector2d to copy components from.</param>
+        /// <remarks>
+        /// <see cref="Z"/> and <see cref="W"/> are initialized to zero.
+        /// </remarks>
+        /// <param name="v">The vector to copy the x and y components from.</param>
         public Vector4d(Vector2d v)
         {
             X = v.X;
@@ -146,10 +149,11 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4d"/> struct.
         /// </summary>
-        /// <param name="v">The Vector3d to copy components from.</param>
         /// <remarks>
-        /// <seealso cref="Vector4d(Vector3d, double)"/>.
+        /// <see cref="W"/> is initialized to zero.
         /// </remarks>
+        /// <param name="v">The vector to copy the x, y, and z components from.</param>
+        /// <seealso cref="Vector4d(Vector3d, double)"/>.
         public Vector4d(Vector3d v)
         {
             X = v.X;
@@ -161,8 +165,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4d"/> struct.
         /// </summary>
-        /// <param name="v">The Vector3d to copy components from.</param>
-        /// <param name="w">The w component of the new Vector4.</param>
+        /// <param name="v">The vector to copy the x, y, and z components from.</param>
+        /// <param name="w">The w component of the new vector.</param>
         public Vector4d(Vector3d v, double w)
         {
             X = v.X;
@@ -174,7 +178,7 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4d"/> struct.
         /// </summary>
-        /// <param name="v">The Vector4d to copy components from.</param>
+        /// <param name="v">The vector to copy components from.</param>
         public Vector4d(Vector4d v)
         {
             X = v.X;

--- a/src/OpenTK.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4h.cs
@@ -32,29 +32,29 @@ using System.Xml.Serialization;
 namespace OpenTK.Mathematics
 {
     /// <summary>
-    /// 4-component Vector of the Half type. Occupies 8 Byte total.
+    /// Represents a 4D vector using four half-precision floating-point numbers. Occupies 8 Byte total.
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     public struct Vector4h : ISerializable, IEquatable<Vector4h>, IFormattable
     {
         /// <summary>
-        /// The X component of the Half4.
+        /// The X component of the vector.
         /// </summary>
         public Half X;
 
         /// <summary>
-        /// The Y component of the Half4.
+        /// The Y component of the vector.
         /// </summary>
         public Half Y;
 
         /// <summary>
-        /// The Z component of the Half4.
+        /// The Z component of the vector.
         /// </summary>
         public Half Z;
 
         /// <summary>
-        /// The W component of the Half4.
+        /// The W component of the vector.
         /// </summary>
         public Half W;
 
@@ -90,10 +90,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
-        /// <param name="z">The Z component of the vector.</param>
-        /// <param name="w">The W component of the vector.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
+        /// <param name="w">The w component of the vector.</param>
         public Vector4h(Half x, Half y, Half z, Half w)
         {
             X = x;
@@ -105,10 +105,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
-        /// <param name="z">The Z component of the vector.</param>
-        /// <param name="w">The W component of the vector.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
+        /// <param name="w">The w component of the vector.</param>
         public Vector4h(float x, float y, float z, float w)
         {
             X = new Half(x);
@@ -120,10 +120,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4h"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the vector.</param>
-        /// <param name="y">The Y component of the vector.</param>
-        /// <param name="z">The Z component of the vector.</param>
-        /// <param name="w">The W component of the vector.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
+        /// <param name="w">The w component of the vector.</param>
         /// <param name="throwOnError">Enable checks that will throw if the conversion result is not meaningful.</param>
         public Vector4h(float x, float y, float z, float w, bool throwOnError)
         {
@@ -1194,7 +1194,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns this Half4 instance's contents as Vector4.
+        /// Returns this Vector4h instance's contents as Vector4.
         /// </summary>
         /// <returns>The vector.</returns>
         public readonly Vector4 ToVector4()
@@ -1203,7 +1203,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns this Half4 instance's contents as Vector4d.
+        /// Returns this Vector4h instance's contents as Vector4d.
         /// </summary>
         /// <returns>The vector.</returns>
         public readonly Vector4d ToVector4d()
@@ -1212,7 +1212,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Converts OpenTK.Vector4 to OpenTK.Half4.
+        /// Converts OpenTK.Vector4 to OpenTK.Vector4h.
         /// </summary>
         /// <param name="v4f">The Vector4 to convert.</param>
         /// <returns>The resulting Half vector.</returns>
@@ -1223,7 +1223,7 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Converts OpenTK.Vector4d to OpenTK.Half4.
+        /// Converts OpenTK.Vector4d to OpenTK.Vector4h.
         /// </summary>
         /// <param name="v4d">The Vector4d to convert.</param>
         /// <returns>The resulting Half vector.</returns>
@@ -1398,9 +1398,9 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Returns the Half4 as an array of bytes.
+        /// Returns the Vector4h as an array of bytes.
         /// </summary>
-        /// <param name="h">The Half4 to convert.</param>
+        /// <param name="h">The Vector4h to convert.</param>
         /// <returns>The input as byte array.</returns>
         [Pure]
         public static byte[] GetBytes(Vector4h h)
@@ -1424,11 +1424,11 @@ namespace OpenTK.Mathematics
         }
 
         /// <summary>
-        /// Converts an array of bytes into Half4.
+        /// Converts an array of bytes into Vector4h.
         /// </summary>
-        /// <param name="value">A Half4 in it's byte[] representation.</param>
+        /// <param name="value">A Vector4h in it's byte[] representation.</param>
         /// <param name="startIndex">The starting position within value.</param>
-        /// <returns>A new Half4 instance.</returns>
+        /// <returns>A new Vector4h instance.</returns>
         [Pure]
         public static Vector4h FromBytes(byte[] value, int startIndex)
         {

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -27,22 +27,22 @@ namespace OpenTK.Mathematics
     public struct Vector4i : IEquatable<Vector4i>, IFormattable
     {
         /// <summary>
-        /// The X component of the Vector4i.
+        /// The X component of the vector.
         /// </summary>
         public int X;
 
         /// <summary>
-        /// The Y component of the Vector4i.
+        /// The Y component of the vector.
         /// </summary>
         public int Y;
 
         /// <summary>
-        /// The Z component of the Vector4i.
+        /// The Z component of the vector.
         /// </summary>
         public int Z;
 
         /// <summary>
-        /// The W component of the Vector4i.
+        /// The W component of the vector.
         /// </summary>
         public int W;
 
@@ -61,10 +61,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4i"/> struct.
         /// </summary>
-        /// <param name="x">The X component of the Vector4i.</param>
-        /// <param name="y">The Y component of the Vector4i.</param>
-        /// <param name="z">The Z component of the Vector4i.</param>
-        /// <param name="w">The W component of the Vector4i.</param>
+        /// <param name="x">The x component of the vector.</param>
+        /// <param name="y">The y component of the vector.</param>
+        /// <param name="z">The z component of the vector.</param>
+        /// <param name="w">The w component of the vector.</param>
         public Vector4i(int x, int y, int z, int w)
         {
             X = x;
@@ -76,7 +76,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4i"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector2i"/> to copy components from.</param>
+        /// <remarks>
+        /// <see cref="Z"/> and <see cref="W"/> are initialized to zero.
+        /// </remarks>
+        /// <param name="v">The <see cref="Vector2i"/> to copy the x and y components from.</param>
         public Vector4i(Vector2i v)
         {
             X = v.X;
@@ -88,8 +91,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4i"/> struct.
         /// </summary>
-        /// <param name="v1">The <see cref="Vector2i"/> to get the X and Y components for the Vector4.</param>
-        /// <param name="v2">The <see cref="Vector2i"/> to get the Z and W components for the Vector4.</param>
+        /// <param name="v1">The <see cref="Vector2i"/> to get the x and y components for the vector.</param>
+        /// <param name="v2">The <see cref="Vector2i"/> to get the z and w components for the vector.</param>
         public Vector4i(Vector2i v1, Vector2i v2)
         {
             X = v1.X;
@@ -101,7 +104,10 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4i"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector3i"/> to copy components from.</param>
+        /// <remarks>
+        /// <see cref="W"/> is initialized to zero.
+        /// </remarks>
+        /// <param name="v">The <see cref="Vector3i"/> to copy the x, y, and z components from.</param>
         public Vector4i(Vector3i v)
         {
             X = v.X;
@@ -113,8 +119,8 @@ namespace OpenTK.Mathematics
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector4i"/> struct.
         /// </summary>
-        /// <param name="v">The <see cref="Vector3i"/> to copy components from.</param>
-        /// <param name="w">The w component of the new Vector4.</param>
+        /// <param name="v">The <see cref="Vector3i"/> to copy the x, y, and z components from.</param>
+        /// <param name="w">The w component of the vector.</param>
         public Vector4i(Vector3i v, int w)
         {
             X = v.X;


### PR DESCRIPTION
Added Vector3(Vector2, float) and Vector3d(Vector2d,double) constructors.

### Purpose of this PR

Makes documentation more uniform for vector types.
Fixes documentation errors for half-precision floating point vectors.
Fixes #1866

### Testing status

