### PR TITLE
Update OpenTK.redist.glfw to 3.4.0.47.

### DIFF
--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/OpenTK.Windowing.GraphicsLibraryFramework.csproj
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/OpenTK.Windowing.GraphicsLibraryFramework.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
       <ProjectReference Include="..\OpenTK.Core\OpenTK.Core.csproj" />
       <ProjectReference Include="..\OpenTK.Windowing.Common\OpenTK.Windowing.Common.csproj" />
-      <PackageReference Include="OpenTK.redist.glfw" Version="3.4.0.44" />
+      <PackageReference Include="OpenTK.redist.glfw" Version="3.4.0.47" />
     </ItemGroup>
 
     <Import Project="..\..\props\common.props" />

--- a/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
+++ b/src/OpenTK.Windowing.GraphicsLibraryFramework/paket
@@ -5,7 +5,7 @@ description
 dependencies
     framework: netcoreapp3.1
         OpenTK.Core ~> #VERSION#
-        OpenTK.redist.glfw >= 3.4.0.44
+        OpenTK.redist.glfw >= 3.4.0.47
 files
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.dll ==> lib\netcoreapp3.1
     bin\Release\netcoreapp3.1\OpenTK.Windowing.GraphicsLibraryFramework.xml ==> lib\netcoreapp3.1


### PR DESCRIPTION
### Purpose of this PR

Update OpenTK.redist.glfw to 3.4.0.47.
Fixes  #1695

### Testing status

Not tested on old ubuntu or debian versions yet.