### PR TITLE
[5.0] Enable json serialization of math types.

### DIFF
--- a/src/OpenTK.Mathematics/MathJsonConverter.cs
+++ b/src/OpenTK.Mathematics/MathJsonConverter.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Numerics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace OpenTK.Mathematics
+{
+    internal enum ComponentType
+    {
+        Float,
+        Double,
+        Int,
+        Bool,
+    }
+
+    public class MathJsonConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)] T, TComp> : JsonConverter<T> where T : struct where TComp : struct
+    {
+        private static readonly FieldInfo[] _fields;
+        private static readonly byte[][] _fieldNames;
+
+        public static bool IsSupported
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return (typeof(T) == typeof(Vector2))
+                    || (typeof(T) == typeof(Vector2d))
+                    || (typeof(T) == typeof(Vector2h))
+                    || (typeof(T) == typeof(Vector2i))
+                    || (typeof(T) == typeof(Vector2b));
+            }
+        }
+
+        static MathJsonConverter()
+        {
+            Debug.Assert(typeof(T).GetFields(BindingFlags.NonPublic | BindingFlags.Instance).Length == 0, "Cannot contain non-public fields.");
+            _fields = typeof(T).GetFields(BindingFlags.Public | BindingFlags.Instance);
+
+            _fieldNames = new byte[_fields.Length][];
+            for (int i = 0; i < _fields.Length; i++)
+            {
+                if (_fields[i].FieldType != typeof(TComp))
+                {
+                    throw new NotSupportedException("Wrong component type!");
+                }
+
+                _fieldNames[i] = Encoding.UTF8.GetBytes(_fields[i].Name);
+            }
+
+            if (IsSupported == false)
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw CreateUnexpectedException(ref reader, "{");
+            }
+            reader.Read();
+
+            T value = default;
+            TypedReference valueRef = __makeref(value);
+            for (int i = 0; i < _fields.Length; i++)
+            {
+                _fields[i].SetValueDirect(valueRef, ReadProperty(ref reader, _fieldNames[i]));
+            }
+
+            reader.Read();
+            if (reader.TokenType != JsonTokenType.EndObject)
+            {
+                throw CreateUnexpectedException(ref reader, "}");
+            }
+
+            return value;
+        }
+
+        // FIXME: Move to extension?
+        private static TComp ReadProperty(ref Utf8JsonReader reader, ReadOnlySpan<byte> utf8Name)
+        {
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw CreateUnexpectedException(ref reader, utf8Name);
+            }
+
+            if (reader.ValueTextEquals(utf8Name) == false)
+            {
+                throw CreateUnexpectedException(ref reader, utf8Name);
+            }
+
+            reader.Read();
+            if (typeof(TComp) == typeof(bool))
+            {
+                if (reader.TokenType != JsonTokenType.True &&
+                    reader.TokenType != JsonTokenType.False)
+                {
+                    throw CreateUnexpectedException(ref reader, "number");
+                }
+                return ReadComponentValue(ref reader);
+            }
+            else
+            {
+                if (reader.TokenType != JsonTokenType.Number)
+                {
+                    throw CreateUnexpectedException(ref reader, "number");
+                }
+                return ReadComponentValue(ref reader);
+            }
+        }
+
+        private static TComp ReadComponentValue(ref Utf8JsonReader reader)
+        {
+            if (typeof(TComp) == typeof(float))
+            {
+                if (reader.TryGetSingle(out float value) == false)
+                {
+                    throw new JsonException();
+                }
+                reader.Read();
+                return (TComp)(object)value;
+            }
+            else if (typeof(TComp) == typeof(double))
+            {
+                if (reader.TryGetDouble(out double value) == false)
+                {
+                    throw new JsonException();
+                }
+                reader.Read();
+                return (TComp)(object)value;
+            }
+            else if (typeof(TComp) == typeof(Half))
+            {
+                if (reader.TryGetSingle(out float value) == false)
+                {
+                    throw new JsonException();
+                }
+                reader.Read();
+                return (TComp)(object)(Half)value;
+            }
+            else if (typeof(TComp) == typeof(int))
+            {
+                if (reader.TryGetInt32(out int value) == false)
+                {
+                    throw new JsonException();
+                }
+                reader.Read();
+                return (TComp)(object)value;
+            }
+            else if (typeof(TComp) == typeof(bool))
+            {
+                bool value = reader.GetBoolean();
+                reader.Read();
+                return (TComp)(object)value;
+            }
+            else
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            for (int i = 0; i < _fields.Length; i++)
+            {
+                WriteComponent(writer, _fieldNames[i], (TComp)_fields[i].GetValue(value));
+            }
+            writer.WriteEndObject();
+        }
+
+        private static void WriteComponent(Utf8JsonWriter writer, ReadOnlySpan<byte> utf8Name, TComp value)
+        {
+            if (typeof(TComp) == typeof(float))
+            {
+                writer.WriteNumber(utf8Name, (float)(object)value);
+            }
+            else if (typeof(TComp) == typeof(double))
+            {
+                writer.WriteNumber(utf8Name, (double)(object)value);
+            }
+            else if (typeof(TComp) == typeof(Half))
+            {
+                writer.WriteNumber(utf8Name, (float)(Half)(object)value);
+            }
+            else if (typeof(TComp) == typeof(int))
+            {
+                writer.WriteNumber(utf8Name, (int)(object)value);
+            }
+            else if (typeof(TComp) == typeof(bool))
+            {
+                writer.WriteBoolean(utf8Name, (bool)(object)value);
+            }
+            else
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        private static FormatException CreateUnexpectedException(ref Utf8JsonReader reader, string expected)
+        {
+            // Replace with public API once https://github.com/dotnet/runtime/issues/28482 is fixed
+            object boxedState = reader.CurrentState;
+            long lineNumber = (long)(typeof(JsonReaderState).GetField("_lineNumber", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(boxedState) ?? -1);
+            long bytePositionInLine = (long)(typeof(JsonReaderState).GetField("_bytePositionInLine", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(boxedState) ?? -1);
+
+            return new FormatException($"Unexpected character encountered, excepted '{expected}' " +
+                                       $"at line {lineNumber} position {bytePositionInLine}");
+        }
+
+        private static FormatException CreateUnexpectedException(ref Utf8JsonReader reader, ReadOnlySpan<byte> expected)
+        {
+            // Replace with public API once https://github.com/dotnet/runtime/issues/28482 is fixed
+            object boxedState = reader.CurrentState;
+            long lineNumber = (long)(typeof(JsonReaderState).GetField("_lineNumber", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(boxedState) ?? -1);
+            long bytePositionInLine = (long)(typeof(JsonReaderState).GetField("_bytePositionInLine", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(boxedState) ?? -1);
+
+            return new FormatException($"Unexpected character encountered, excepted '{Encoding.UTF8.GetString(expected)}' " +
+                                       $"at line {lineNumber} position {bytePositionInLine}");
+        }
+    }
+}

--- a/src/OpenTK.Mathematics/Vector/Vector2.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2.cs
@@ -25,6 +25,7 @@ using System.Diagnostics.Contracts;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -37,6 +38,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector2, float>))]
     public struct Vector2 : IEquatable<Vector2>, IFormattable,
                             IAdditionOperators<Vector2, Vector2, Vector2>,
                             ISubtractionOperators<Vector2, Vector2, Vector2>,

--- a/src/OpenTK.Mathematics/Vector/Vector2b.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2b.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 
@@ -19,6 +20,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector2b, bool>))]
     public struct Vector2b : IEquatable<Vector2b>
     {
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2d.cs
@@ -26,6 +26,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -35,6 +36,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector2d, double>))]
     public struct Vector2d : IEquatable<Vector2d>, IFormattable,
                             IAdditionOperators<Vector2d, Vector2d, Vector2d>,
                             ISubtractionOperators<Vector2d, Vector2d, Vector2d>,

--- a/src/OpenTK.Mathematics/Vector/Vector2h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2h.cs
@@ -27,6 +27,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -36,6 +37,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector2h, Half>))]
     public struct Vector2h : ISerializable, IEquatable<Vector2h>, IFormattable, IEqualityOperators<Vector2h, Vector2h, bool>
     {
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector2i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector2i.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.Contracts;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -24,6 +25,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector2i, int>))]
     public struct Vector2i : IEquatable<Vector2i>, IFormattable,
                             IAdditionOperators<Vector2i, Vector2i, Vector2i>,
                             ISubtractionOperators<Vector2i, Vector2i, Vector2i>,

--- a/src/OpenTK.Mathematics/Vector/Vector3.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3.cs
@@ -25,6 +25,7 @@ using System.Diagnostics.Contracts;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -37,6 +38,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector3, float>))]
     public struct Vector3 : IEquatable<Vector3>, IFormattable,
                             IAdditionOperators<Vector3, Vector3, Vector3>,
                             ISubtractionOperators<Vector3, Vector3, Vector3>,

--- a/src/OpenTK.Mathematics/Vector/Vector3b.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3b.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 
@@ -18,6 +19,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector3b, bool>))]
     public struct Vector3b : IEquatable<Vector3b>
     {
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3d.cs
@@ -26,6 +26,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -35,6 +36,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector3d, double>))]
     public struct Vector3d : IEquatable<Vector3d>, IFormattable,
                             IAdditionOperators<Vector3d, Vector3d, Vector3d>,
                             ISubtractionOperators<Vector3d, Vector3d, Vector3d>,

--- a/src/OpenTK.Mathematics/Vector/Vector3h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3h.cs
@@ -27,6 +27,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -36,6 +37,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector3h, Half>))]
     public struct Vector3h : ISerializable, IEquatable<Vector3h>, IFormattable, IEqualityOperators<Vector3h, Vector3h, bool>
     {
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector3i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector3i.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.Contracts;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -24,6 +25,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector3i, int>))]
     public struct Vector3i : IEquatable<Vector3i>, IFormattable,
                             IAdditionOperators<Vector3i, Vector3i, Vector3i>,
                             ISubtractionOperators<Vector3i, Vector3i, Vector3i>,

--- a/src/OpenTK.Mathematics/Vector/Vector4.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4.cs
@@ -26,6 +26,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -38,6 +39,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector4, float>))]
     public struct Vector4 : IEquatable<Vector4>, IFormattable,
                             IAdditionOperators<Vector4, Vector4, Vector4>,
                             ISubtractionOperators<Vector4, Vector4, Vector4>,

--- a/src/OpenTK.Mathematics/Vector/Vector4b.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4b.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 
@@ -18,6 +19,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector4b, bool>))]
     public struct Vector4b : IEquatable<Vector4b>
     {
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4d.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4d.cs
@@ -26,6 +26,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -38,6 +39,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector4d, double>))]
     public struct Vector4d : IEquatable<Vector4d>, IFormattable,
                             IAdditionOperators<Vector4d, Vector4d, Vector4d>,
                             ISubtractionOperators<Vector4d, Vector4d, Vector4d>,

--- a/src/OpenTK.Mathematics/Vector/Vector4h.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4h.cs
@@ -27,6 +27,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -36,6 +37,7 @@ namespace OpenTK.Mathematics
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector4h, Half>))]
     public struct Vector4h : ISerializable, IEquatable<Vector4h>, IFormattable, IEqualityOperators<Vector4h, Vector4h, bool>
     {
         /// <summary>

--- a/src/OpenTK.Mathematics/Vector/Vector4i.cs
+++ b/src/OpenTK.Mathematics/Vector/Vector4i.cs
@@ -13,6 +13,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace OpenTK.Mathematics
@@ -25,6 +26,7 @@ namespace OpenTK.Mathematics
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [JsonConverter(typeof(MathJsonConverter<Vector4i, int>))]
     public struct Vector4i : IEquatable<Vector4i>, IFormattable,
                             IAdditionOperators<Vector4i, Vector4i, Vector4i>,
                             ISubtractionOperators<Vector4i, Vector4i, Vector4i>,

--- a/tests/OpenTK.Benchmarks/JsonBenchmarks.cs
+++ b/tests/OpenTK.Benchmarks/JsonBenchmarks.cs
@@ -1,0 +1,169 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using OpenTK.Mathematics;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace OpenTK.Benchmarks
+{
+    [SimpleJob(RuntimeMoniker.Net80)]
+    public class JsonBenchmarks
+    {
+        private readonly Vector2JsonConverter Vec2Converter = new Vector2JsonConverter();
+        private readonly MathJsonConverter<Vector2, float> MathConverter = new MathJsonConverter<Vector2, float>();
+        private readonly JsonSerializerOptions Options = new JsonSerializerOptions();
+
+        private static readonly string JsonString = """{"X": 10, "Y": 20}""";
+
+        [BenchmarkCategory("Write")]
+        [Benchmark]
+        public string WriteVector2ThroughSerializer()
+        {
+            return JsonSerializer.Serialize(new Vector2(1, 2), Options);
+        }
+
+        [BenchmarkCategory("Write")]
+        [Benchmark]
+        public void WriteVector2Direct()
+        {
+            Utf8JsonWriter writer = new Utf8JsonWriter(Stream.Null);
+            Vec2Converter.Write(writer, new Vector2(1, 2), Options);
+        }
+
+        [BenchmarkCategory("Write")]
+        [Benchmark]
+        public void WriteVector2Generic()
+        {
+            Utf8JsonWriter writer = new Utf8JsonWriter(Stream.Null);
+            MathConverter.Write(writer, new Vector2(1, 2), Options);
+        }
+
+        [BenchmarkCategory("Write")]
+        [Benchmark]
+        public void WriteVector2TextWriter()
+        {
+            Vector2 val = new Vector2(1, 2);
+            StreamWriter writer = new StreamWriter(Stream.Null);
+            writer.Write($"{{\"X\": {val.X}, \"Y\": {val.Y}}}");
+        }
+
+        [BenchmarkCategory("Read")]
+        [Benchmark]
+        public Vector2 ReadVector2ThroughSerializer()
+        {
+            return JsonSerializer.Deserialize<Vector2>(JsonString, Options);
+        }
+
+        [BenchmarkCategory("Read")]
+        [Benchmark]
+        public Vector2 ReadVector2Direct()
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(JsonString);
+            Utf8JsonReader reader = new Utf8JsonReader(utf8);
+            reader.Read();
+            return Vec2Converter.Read(ref reader, typeof(Vector2), Options);
+        }
+
+        [BenchmarkCategory("Read")]
+        [Benchmark]
+        public Vector2 ReadVector2Generic()
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(JsonString);
+            Utf8JsonReader reader = new Utf8JsonReader(utf8);
+            reader.Read();
+            return MathConverter.Read(ref reader, typeof(Vector2), Options);
+        }
+    }
+
+    internal class Vector2JsonConverter : JsonConverter<Vector2>
+    {
+        public override Vector2 Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw CreateUnexpectedException(ref reader, "{");
+            }
+            reader.Read();
+
+            Vector2 value = default;
+            value.X = ReadProperty(ref reader, "X"u8);
+            value.Y = ReadProperty(ref reader, "Y"u8);
+
+            reader.Read();
+            if (reader.TokenType != JsonTokenType.EndObject)
+            {
+                throw CreateUnexpectedException(ref reader, "}");
+            }
+
+            return value;
+        }
+
+        // FIXME: Move to extension?
+        private static float ReadProperty(ref Utf8JsonReader reader, ReadOnlySpan<byte> utf8Name)
+        {
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw CreateUnexpectedException(ref reader, utf8Name);
+            }
+
+            if (reader.ValueTextEquals(utf8Name) == false)
+            {
+                throw CreateUnexpectedException(ref reader, utf8Name);
+            }
+
+            reader.Read();
+            if (reader.TokenType != JsonTokenType.Number)
+            {
+                throw CreateUnexpectedException(ref reader, "number");
+            }
+            return ReadComponentValue(ref reader);
+        }
+
+        private static float ReadComponentValue(ref Utf8JsonReader reader)
+        {
+            if (reader.TryGetSingle(out float value) == false)
+            {
+                throw new JsonException();
+            }
+            reader.Read();
+            return value;
+        }
+
+        public override void Write(Utf8JsonWriter writer, Vector2 value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("X"u8, value.X);
+            writer.WriteNumber("Y"u8, value.Y);
+            writer.WriteEndObject();
+        }
+
+        private static FormatException CreateUnexpectedException(ref Utf8JsonReader reader, string expected)
+        {
+            // Replace with public API once https://github.com/dotnet/runtime/issues/28482 is fixed
+            object boxedState = reader.CurrentState;
+            long lineNumber = (long)(typeof(JsonReaderState).GetField("_lineNumber", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(boxedState) ?? -1);
+            long bytePositionInLine = (long)(typeof(JsonReaderState).GetField("_bytePositionInLine", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(boxedState) ?? -1);
+
+            return new FormatException($"Unexpected character encountered, excepted '{expected}' " +
+                                       $"at line {lineNumber} position {bytePositionInLine}");
+        }
+
+        private static FormatException CreateUnexpectedException(ref Utf8JsonReader reader, ReadOnlySpan<byte> expected)
+        {
+            // Replace with public API once https://github.com/dotnet/runtime/issues/28482 is fixed
+            object boxedState = reader.CurrentState;
+            long lineNumber = (long)(typeof(JsonReaderState).GetField("_lineNumber", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(boxedState) ?? -1);
+            long bytePositionInLine = (long)(typeof(JsonReaderState).GetField("_bytePositionInLine", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(boxedState) ?? -1);
+
+            return new FormatException($"Unexpected character encountered, excepted '{Encoding.UTF8.GetString(expected)}' " +
+                                       $"at line {lineNumber} position {bytePositionInLine}");
+        }
+    }
+}

--- a/tests/OpenTK.Benchmarks/Program.cs
+++ b/tests/OpenTK.Benchmarks/Program.cs
@@ -10,7 +10,8 @@ namespace OpenTK.Benchmarks
         public static void Main()
         {
             //BenchmarkRunner.Run<SlerpBenchmarks>();
-            BenchmarkRunner.Run<MatrixBenchmark>();
+            //BenchmarkRunner.Run<MatrixBenchmark>();
+            BenchmarkRunner.Run<JsonBenchmarks>();
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

This PR aims to allow math types to be serialized using `System.Text.Json.Serialization`.
Unlike #1273 this PR uses a custom json converter to convert only the fields of the structs, thus avoiding the need to mark individual properties with `[JsonIgnore]` attributes.

I opted to for reflection approach for the initial implementation to avoid a ton of different implementations, but if the performance is bad with the generic code we could look at doing something else.

### Testing status

A few conversions have been tested locally, but before merging we should add unit tests for this feature (at the very least a roundtrip test).